### PR TITLE
Add async profile loader and CLI runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guidelines for CIRISAgent Contributors
+
+- Always run `pytest -q` before committing changes.
+- Prefer asynchronous functions when dealing with I/O or long-running tasks. Use `asyncio.to_thread` for blocking calls.
+- Keep new scripts and services minimal and well-documented.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,8 @@ The CIRIS Engine uses agent profiles (defined in `ciris_engine.core.config_schem
 **Using a Profile:**
 
 1.  **Loading the Profile:**
-    *   The `ciris_engine.utils.profile_loader.load_profile(path_to_yaml_file)` function is used to load profiles.
-    *   Agent entry points (like `run_discord_student.py`, `run_discord_teacher.py`) are responsible for loading the desired profile.
+    *   The `ciris_engine.utils.profile_loader.load_profile(path_to_yaml_file)` coroutine is **asynchronous** and must be awaited when loading profiles.
+    *   Agent entry points (like `run_discord_student.py`, `run_discord_teacher.py`, `run_cli_student.py`) are responsible for loading the desired profile.
     *   These scripts also ensure the loaded profile is registered in the `AppConfig.agent_profiles` dictionary, typically keyed by the profile's lowercase name.
 
 2.  **Instantiating Components:**

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The system is designed for modularity, allowing developers to create and integra
 
 *   `core/`: Contains data schemas (`config_schemas.py`, `agent_core_schemas.py`, `foundational_schemas.py`), configuration management (`config_manager.py`), the `AgentProcessor`, `WorkflowCoordinator`, `ActionDispatcher`, and persistence layer (`persistence.py`).
 *   `dma/`: Implementations of the various DMAs (EthicalPDMA, CSDMA, DSDMAs like `dsdma_student.py`, `dsdma_teacher.py`, ActionSelectionPDMA).
-*   `utils/`: Utility functions, including logging configuration (`logging_config.py`) and profile loading (`profile_loader.py`).
+*   `utils/`: Utility helpers like `logging_config.py` and an asynchronous `load_profile` function in `profile_loader.py` (remember to `await` it).
 *   `guardrails/`: Ethical guardrail implementation.
 *   `services/`: LLM client abstractions (`llm_client.py`, `llm_service.py`) and service integrations like `discord_service.py`.
 *   `ciris_profiles/`: Directory for agent profile YAML files (e.g., `student.yaml`, `teacher.yaml`).
@@ -118,11 +118,23 @@ Ensure environment variables (`OPENAI_API_KEY`, `DISCORD_BOT_TOKEN`) are set.
 python run_discord_teacher.py
 ```
 
+### 3. `run_cli_student.py` — CLI Student Agent
+
+**Purpose:**
+Run the CIRIS agent with the "Student" profile via a simple command-line interface. Useful for local benchmarking without Discord.
+
+**Usage:**
+Ensure the `OPENAI_API_KEY` environment variable is set.
+```bash
+python run_cli_student.py
+```
+
 ---
 ## Other Notable Scripts & Components
 
 *   **`run_services.py`**: Appears to be a script for running services, potentially for testing or a different deployment mode.
 *   **`test_client_init.py`**: A test script, likely for initializing or testing client connections.
+*   **`run_cli_student.py`**: Simple CLI runner for the student profile.
 *   The `tests/` directory contains unit and integration tests runnable with `pytest`.
 
 ---

--- a/ciris_engine/core/config_manager.py
+++ b/ciris_engine/core/config_manager.py
@@ -1,5 +1,6 @@
 import json
 import os
+import asyncio
 from pathlib import Path
 from typing import Optional
 
@@ -100,6 +101,21 @@ def save_config_to_json(config: AppConfig, config_file_path: Optional[Path] = No
     except Exception as e:
         # print(f"Error saving configuration to {actual_path}: {e}") # For debugging
         raise # Re-raise the exception as saving might be critical
+
+
+async def load_config_from_file_async(config_file_path: Optional[Path] = None, create_if_not_exists: bool = False) -> AppConfig:
+    """Asynchronous wrapper around ``load_config_from_file`` using ``asyncio.to_thread``."""
+    return await asyncio.to_thread(load_config_from_file, config_file_path, create_if_not_exists)
+
+
+async def get_config_async() -> AppConfig:
+    """Asynchronously retrieve the current application configuration."""
+    return await asyncio.to_thread(get_config)
+
+
+async def save_config_to_json_async(config: AppConfig, config_file_path: Optional[Path] = None) -> None:
+    """Asynchronous wrapper around ``save_config_to_json``."""
+    await asyncio.to_thread(save_config_to_json, config, config_file_path)
 
 # --- Utility for Database Path Construction ---
 def get_sqlite_db_full_path() -> str:

--- a/ciris_engine/services/cli_service.py
+++ b/ciris_engine/services/cli_service.py
@@ -1,0 +1,85 @@
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from .base import Service
+from ciris_engine.core.action_dispatcher import ActionDispatcher
+from ciris_engine.core.agent_core_schemas import (
+    ActionSelectionPDMAResult,
+    HandlerActionType,
+    SpeakParams,
+    DeferParams,
+    RejectParams,
+)
+from ciris_engine.core.agent_core_schemas import Task
+from ciris_engine.core.foundational_schemas import TaskStatus, ThoughtStatus
+from ciris_engine.core import persistence
+
+logger = logging.getLogger(__name__)
+
+
+class CLIService(Service):
+    """Simple interactive CLI service for local benchmarking."""
+
+    def __init__(self, action_dispatcher: ActionDispatcher):
+        super().__init__()
+        self.action_dispatcher = action_dispatcher
+        self.action_dispatcher.register_service_handler("cli", self._handle_cli_action)
+        self._running = False
+
+    async def start(self):
+        await super().start()
+        self._running = True
+        logger.info("CLIService started. Type 'exit' to quit.")
+        await self._input_loop()
+
+    async def stop(self):
+        self._running = False
+        await super().stop()
+        logger.info("CLIService stopped.")
+
+    async def _input_loop(self):
+        while self._running:
+            user_input = await asyncio.to_thread(input, ">>> ")
+            if user_input.strip().lower() in {"exit", "quit"}:
+                self._running = False
+                break
+            await self._create_task(user_input)
+
+    async def _create_task(self, content: str):
+        now_iso = datetime.now(timezone.utc).isoformat()
+        new_task_id = f"cli_{uuid.uuid4().hex[:8]}"
+        task = Task(
+            task_id=new_task_id,
+            description=content,
+            status=TaskStatus.PENDING,
+            priority=1,
+            created_at=now_iso,
+            updated_at=now_iso,
+            context={"origin_service": "cli", "content": content},
+        )
+        persistence.add_task(task)
+        logger.info(f"CLIService: Added task {new_task_id}")
+
+    async def _handle_cli_action(self, result: ActionSelectionPDMAResult, dispatch_context: Dict[str, Any]):
+        action_type = result.selected_handler_action
+        params = result.action_parameters
+        if action_type == HandlerActionType.SPEAK and isinstance(params, SpeakParams):
+            print(params.content)
+        elif action_type == HandlerActionType.DEFER and isinstance(params, DeferParams):
+            print(f"DEFERRED: {params.reason}")
+        elif action_type == HandlerActionType.REJECT and isinstance(params, RejectParams):
+            print(f"REJECTED: {params.reason}")
+        else:
+            logger.info(f"Unhandled action {action_type} in CLIService")
+
+        thought_id = dispatch_context.get("thought_id")
+        if thought_id:
+            persistence.update_thought_status(
+                thought_id=thought_id,
+                new_status=ThoughtStatus.COMPLETED,
+                final_action_result=result.model_dump(),
+            )
+

--- a/ciris_engine/utils/profile_loader.py
+++ b/ciris_engine/utils/profile_loader.py
@@ -1,5 +1,6 @@
 import yaml
 import logging
+import asyncio
 from pathlib import Path
 from typing import Optional
 
@@ -7,9 +8,10 @@ from ciris_engine.core.config_schemas import SerializableAgentProfile
 
 logger = logging.getLogger(__name__)
 
-def load_profile(profile_path: Path) -> Optional[SerializableAgentProfile]:
-    """
-    Loads an agent profile from a YAML file.
+async def load_profile(profile_path: Path) -> Optional[SerializableAgentProfile]:
+    """Asynchronously load an agent profile from a YAML file.
+
+    This coroutine should be awaited so file I/O does not block the event loop.
 
     Args:
         profile_path: Path to the YAML profile file.
@@ -25,8 +27,11 @@ def load_profile(profile_path: Path) -> Optional[SerializableAgentProfile]:
         return None
 
     try:
-        with open(profile_path, 'r') as f:
-            profile_data = yaml.safe_load(f)
+        def _load_yaml(path: Path):
+            with open(path, "r") as f:
+                return yaml.safe_load(f)
+
+        profile_data = await asyncio.to_thread(_load_yaml, profile_path)
         
         if not profile_data:
             logger.error(f"Profile file is empty or invalid YAML: {profile_path}")

--- a/run_cli_student.py
+++ b/run_cli_student.py
@@ -1,0 +1,130 @@
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+from ciris_engine.core.config_manager import get_config_async, AppConfig
+from ciris_engine.core.action_dispatcher import ActionDispatcher
+from ciris_engine.core.agent_processor import AgentProcessor
+from ciris_engine.core.workflow_coordinator import WorkflowCoordinator
+from ciris_engine.core.config_schemas import SerializableAgentProfile as AgentProfile
+from ciris_engine.utils.profile_loader import load_profile
+
+from ciris_engine.dma.pdma import EthicalPDMAEvaluator
+from ciris_engine.dma.csdma import CSDMAEvaluator
+from ciris_engine.dma.action_selection_pdma import ActionSelectionPDMAEvaluator
+from ciris_engine.guardrails import EthicalGuardrails
+from ciris_engine.dma.dsdma_base import BaseDSDMA
+from ciris_engine.dma.dsdma_student import StudentDSDMA
+from ciris_engine.dma.dsdma_teacher import BasicTeacherDSDMA
+
+from ciris_engine.services.llm_service import LLMService
+from ciris_engine.services.cli_service import CLIService
+from ciris_engine.utils.logging_config import setup_basic_logging
+
+logger = logging.getLogger(__name__)
+
+
+async def main_cli_student():
+    setup_basic_logging(level=logging.INFO)
+    logger.info("Starting CIRIS Engine CLI (Student Profile)...")
+
+    app_config: AppConfig = await get_config_async()
+
+    profile_base_path = app_config.profile_directory
+    profile_file_path = os.path.join(profile_base_path, "student.yaml")
+    agent_profile: Optional[AgentProfile] = await load_profile(Path(profile_file_path))
+    if not agent_profile:
+        raise FileNotFoundError(f"Profile not found: {profile_file_path}")
+
+    if agent_profile.name.lower() not in app_config.agent_profiles:
+        app_config.agent_profiles[agent_profile.name.lower()] = agent_profile
+
+    action_dispatcher = ActionDispatcher()
+
+    from ciris_engine.core import persistence
+    from ciris_engine.core.config_manager import get_sqlite_db_full_path
+
+    db_file_path_str = get_sqlite_db_full_path()
+    db_file = Path(db_file_path_str)
+    if db_file.exists():
+        logger.warning("Deleting existing database for clean CLI run: %s", db_file)
+        db_file.unlink()
+
+    persistence.initialize_database()
+
+    llm_service = LLMService(llm_config=app_config.llm_services)
+    await llm_service.start()
+    llm_client = llm_service.get_client()
+
+    ethical_pdma_evaluator = EthicalPDMAEvaluator(
+        aclient=llm_client.instruct_client,
+        model_name=llm_client.model_name,
+    )
+    csdma_evaluator = CSDMAEvaluator(
+        aclient=llm_client.instruct_client,
+        model_name=llm_client.model_name,
+        prompt_overrides=agent_profile.csdma_overrides,
+    )
+    action_selection_pdma_evaluator = ActionSelectionPDMAEvaluator(
+        aclient=llm_client.instruct_client,
+        model_name=llm_client.model_name,
+        prompt_overrides=agent_profile.action_selection_pdma_overrides,
+    )
+    ethical_guardrails = EthicalGuardrails(
+        aclient=llm_client.instruct_client,
+        model_name=llm_client.model_name,
+        guardrails_config=app_config.guardrails,
+    )
+
+    dsdma_evaluators: Dict[str, BaseDSDMA] = {}
+    DSDMA_CLASS_REGISTRY: Dict[str, type[BaseDSDMA]] = {
+        "StudentDSDMA": StudentDSDMA,
+        "BasicTeacherDSDMA": BasicTeacherDSDMA,
+    }
+    if agent_profile.dsdma_identifier:
+        dsdma_cls = DSDMA_CLASS_REGISTRY.get(agent_profile.dsdma_identifier)
+        if dsdma_cls:
+            dsdma_instance = dsdma_cls(
+                aclient=llm_client.instruct_client,
+                model_name=llm_client.model_name,
+                **(agent_profile.dsdma_kwargs or {}),
+            )
+            dsdma_evaluators[agent_profile.name] = dsdma_instance
+
+    workflow_coordinator = WorkflowCoordinator(
+        llm_client=llm_client,
+        ethical_pdma_evaluator=ethical_pdma_evaluator,
+        csdma_evaluator=csdma_evaluator,
+        action_selection_pdma_evaluator=action_selection_pdma_evaluator,
+        ethical_guardrails=ethical_guardrails,
+        app_config=app_config,
+        dsdma_evaluators=dsdma_evaluators,
+    )
+
+    agent_processor = AgentProcessor(
+        app_config=app_config,
+        workflow_coordinator=workflow_coordinator,
+        action_dispatcher=action_dispatcher,
+    )
+
+    cli_service = CLIService(action_dispatcher=action_dispatcher)
+
+    agent_processor_task = asyncio.create_task(agent_processor.start_processing())
+    await cli_service.start()
+    await agent_processor_task
+
+    await cli_service.stop()
+    await llm_service.stop()
+
+
+if __name__ == "__main__":
+    if not os.getenv("OPENAI_API_KEY"):
+        print("Error: OPENAI_API_KEY environment variable is not set.")
+    else:
+        try:
+            asyncio.run(main_cli_student())
+        except KeyboardInterrupt:
+            logger.info("CLI run interrupted by user.")
+

--- a/run_discord_student.py
+++ b/run_discord_student.py
@@ -5,12 +5,12 @@ from pathlib import Path # Added import
 from typing import Dict, Optional # Added import
 
 # CIRIS Engine Core Components
-from ciris_engine.core.config_manager import get_config, AppConfig
+from ciris_engine.core.config_manager import get_config_async, AppConfig
 from ciris_engine.core.action_dispatcher import ActionDispatcher
 from ciris_engine.core.agent_processor import AgentProcessor
 from ciris_engine.core.workflow_coordinator import WorkflowCoordinator
 from ciris_engine.core.config_schemas import SerializableAgentProfile as AgentProfile # Updated import
-from ciris_engine.utils.profile_loader import load_profile # Updated import
+from ciris_engine.utils.profile_loader import load_profile
 
 # DMAs and Guardrails
 from ciris_engine.dma.pdma import EthicalPDMAEvaluator
@@ -43,7 +43,7 @@ async def main_student():
     try:
         # app_config will be loaded using the default mechanism in get_config()
         # If a specific file path were needed, load_config_from_file could be used here.
-        app_config: AppConfig = get_config()
+        app_config: AppConfig = await get_config_async()
         logger.info("Application configuration loaded successfully.")
     except Exception as e:
         logger.exception(f"Failed to load application configuration: {e}")
@@ -76,7 +76,7 @@ async def main_student():
             else:
                 raise FileNotFoundError(f"Student profile '{profile_file_path}' not found and no default profile configured.")
         else:
-            agent_profile = load_profile(Path(profile_file_path)) # Ensure profile_path is Path object
+            agent_profile = await load_profile(Path(profile_file_path))
             if agent_profile:
                 logger.info(f"Successfully loaded agent profile: {agent_profile.name} from {profile_file_path}")
             else:

--- a/run_discord_teacher.py
+++ b/run_discord_teacher.py
@@ -5,12 +5,12 @@ from pathlib import Path # Added import
 from typing import Dict, Optional # Added Dict and Optional
 
 # CIRIS Engine Core Components
-from ciris_engine.core.config_manager import get_config, AppConfig
+from ciris_engine.core.config_manager import get_config_async, AppConfig
 from ciris_engine.core.action_dispatcher import ActionDispatcher
 from ciris_engine.core.agent_processor import AgentProcessor
 from ciris_engine.core.workflow_coordinator import WorkflowCoordinator
 from ciris_engine.core.config_schemas import SerializableAgentProfile as AgentProfile # Updated import
-from ciris_engine.utils.profile_loader import load_profile # Updated import
+from ciris_engine.utils.profile_loader import load_profile
 
 # DMAs and Guardrails
 from ciris_engine.dma.pdma import EthicalPDMAEvaluator
@@ -43,7 +43,7 @@ async def main_teacher(): # Renamed function
     try:
         # app_config will be loaded using the default mechanism in get_config()
         # If a specific file path were needed, load_config_from_file could be used here.
-        app_config: AppConfig = get_config()
+        app_config: AppConfig = await get_config_async()
         logger.info("Application configuration loaded successfully.")
     except Exception as e:
         logger.exception(f"Failed to load application configuration: {e}")
@@ -76,7 +76,7 @@ async def main_teacher(): # Renamed function
             else:
                 raise FileNotFoundError(f"Teacher profile '{profile_file_path}' not found and no default profile configured.") # Updated error
         else:
-            agent_profile = load_profile(Path(profile_file_path)) # Ensure profile_path is Path object
+            agent_profile = await load_profile(Path(profile_file_path))
             if agent_profile:
                 logger.info(f"Successfully loaded agent profile: {agent_profile.name} from {profile_file_path}")
             else:


### PR DESCRIPTION
## Summary
- add agent instructions in `AGENTS.md`
- implement async `load_profile` helper and config manager wrappers
- create `CLIService` and `run_cli_student.py`
- update Discord runners to await async helpers
- document CLI usage and async loader

## Testing
- `pytest -q`