### PR TITLE
Update action enums and memory handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ The system is designed for modularity, allowing developers to create and integra
 
 ---
 
+## 3×3×3 Handler Actions
+
+The `HandlerActionType` enum defines nine core operations grouped as:
+
+* **External Actions:** `OBSERVE`, `SPEAK`, `ACT`
+* **Control Responses:** `REJECT`, `PONDER`, `DEFER`
+* **Memory Operations:** `MEMORIZE`, `REMEMBER`, `FORGET`
+
+These actions are processed by matching handlers within the engine.
+
+---
+
 ## Core Components (in `ciris_engine/`)
 
 *   `core/`: Contains data schemas (`config_schemas.py`, `agent_core_schemas.py`, `foundational_schemas.py`), configuration management (`config_manager.py`), the `AgentProcessor`, `WorkflowCoordinator`, `ActionDispatcher`, and persistence layer (`persistence.py`).
@@ -80,6 +92,7 @@ Set the following environment variables (e.g., in a `.env` file loaded by your e
 *   `OPENAI_BASE_URL` (Optional): If using a non-OpenAI endpoint (e.g., Together.ai, local LLM server), set this to the base URL (e.g., `https://api.together.xyz/v1/`).
 *   `OPENAI_MODEL_NAME` (Optional): Specify the LLM model to be used (e.g., `meta-llama/Llama-3-70b-chat-hf`). Defaults to `gpt-4o-mini` if not set (see `ciris_engine/core/config_schemas.py`).
 *   `DISCORD_WA_USER_ID` (Optional): Your Discord User ID for receiving Wise Authority deferrals from Discord agents.
+*   `WA_DISCORD_USER` (Optional): Fallback Discord username for the Wise Authority. Defaults to `somecomputerguy`.
 
 Example:
 ```bash

--- a/ciris_engine/core/action_dispatcher.py
+++ b/ciris_engine/core/action_dispatcher.py
@@ -73,8 +73,8 @@ class ActionDispatcher:
         # These actions typically require interaction with the external platform where the request originated.
         if action_type in [
             HandlerActionType.SPEAK,
-            HandlerActionType.TOOL, # Corrected: USE_TOOL was not defined, TOOL is.
-            HandlerActionType.DEFER, # Corrected: DEFER_TO_WA was not defined, DEFER is.
+            HandlerActionType.ACT,
+            HandlerActionType.DEFER,
             HandlerActionType.REJECT # Corrected: REJECT_THOUGHT was not defined, REJECT is.
         ]:
             handler = self.service_handlers.get(origin_service)
@@ -89,12 +89,12 @@ class ActionDispatcher:
             else:
                 logger.error(f"No handler registered for origin service '{origin_service}' to handle action '{action_type.value}'. Action not executed.")
 
-            if action_type in [HandlerActionType.SPEAK, HandlerActionType.TOOL, HandlerActionType.DEFER]:
+            if action_type in [HandlerActionType.SPEAK, HandlerActionType.ACT, HandlerActionType.DEFER]:
                 await self._enqueue_memory_metathought(original_context)
 
         # 2. Memory Actions (routed to a dedicated 'memory' service/handler, if registered)
         elif action_type in [
-            HandlerActionType.LEARN,
+            HandlerActionType.MEMORIZE,
             HandlerActionType.REMEMBER,
             HandlerActionType.FORGET
         ]:

--- a/ciris_engine/core/agent_core_schemas.py
+++ b/ciris_engine/core/agent_core_schemas.py
@@ -31,9 +31,9 @@ class SpeakParams(BaseModel):
     modality: str = "text" # Could be "audio", "visual" later
     correlation_id: Optional[str] = None # To link response to request
 
-class ToolParams(BaseModel):
-    tool_name: str # Name of the tool/function to call (aligns with LLM tool calling)
-    arguments: Dict[str, Any] # Arguments for the tool
+class ActParams(BaseModel):
+    tool_name: str
+    arguments: Dict[str, Any]
 
 class PonderParams(BaseModel):
     key_questions: List[str]
@@ -49,14 +49,15 @@ class DeferParams(BaseModel):
     target_wa_ual: CIRISKnowledgeAssetUAL # UAL of the designated Wise Authority KA
     deferral_package_content: Dict[str, Any] # Context, dilemma, analysis (to be structured)
 
-class LearnParams(BaseModel):
+class MemorizeParams(BaseModel):
     knowledge_unit_description: str
-    knowledge_data: Union[Dict[str, Any], str] # The actual knowledge (structured or unstructured)
-    knowledge_type: str # e.g., "heuristic", "fact", "skill_model_update"
-    source: str # Where the knowledge came from (e.g., "observation_id", "metathought_id")
+    knowledge_data: Union[Dict[str, Any], str]
+    knowledge_type: str
+    source: str
     confidence: float = Field(..., ge=0.0, le=1.0)
-    publish_to_dkg: bool = False # Whether to attempt creating/updating a KA
-    target_ka_ual: Optional[CIRISKnowledgeAssetUAL] = None # If updating existing KA
+    publish_to_dkg: bool = False
+    target_ka_ual: Optional[CIRISKnowledgeAssetUAL] = None
+    channel_metadata: Optional[Dict[str, Any]] = None
 
 class RememberParams(BaseModel):
     query: str # Natural language or structured query for memory
@@ -79,8 +80,8 @@ class ActionSelectionPDMAResult(BaseModel):
     action_resolution: Optional[str] = None
     selected_handler_action: HandlerActionType
     action_parameters: Union[ # This will hold the specific Pydantic model for the action's params
-        ObserveParams, SpeakParams, ToolParams, PonderParams,
-        RejectParams, DeferParams, LearnParams, RememberParams, ForgetParams, Dict[str, Any] # Allow Dict for initial parsing
+        ObserveParams, SpeakParams, ActParams, PonderParams,
+        RejectParams, DeferParams, MemorizeParams, RememberParams, ForgetParams, Dict[str, Any]
     ]
     action_selection_rationale: str
     monitoring_for_selected_action: Union[Dict[str, Union[str, List[str]]], str] # Allow list of strings for KPIs

--- a/ciris_engine/core/foundational_schemas.py
+++ b/ciris_engine/core/foundational_schemas.py
@@ -1,3 +1,4 @@
+"""Core enums and type aliases for CIRIS Engine."""
 from enum import Enum
 from typing import Union, List, Dict, Any, Optional # Retaining for now, can be pruned
 
@@ -9,18 +10,20 @@ class CIRISSchemaVersion(str, Enum):
     #... future versions
 
 class HandlerActionType(str, Enum):
-    # Actions
+    """The 3×3×3 action model for CIRIS handlers."""
+
+    # External actions
     OBSERVE = "observe"
     SPEAK = "speak"
-    TOOL = "tool" # Replaces 'Act' concept for LLM tool usage
+    ACT = "act"
 
-    # Deferrals
-    PONDER = "ponder"
+    # Control responses
     REJECT = "reject"
-    DEFER = "defer" # Deferral to Wise Authority (WA)
+    PONDER = "ponder"
+    DEFER = "defer"  # Deferral to Wise Authority (WA)
 
-    # Memory Operations
-    LEARN = "learn"
+    # Memory operations
+    MEMORIZE = "memorize"
     REMEMBER = "remember"
     FORGET = "forget"
 

--- a/ciris_engine/core/workflow_coordinator.py
+++ b/ciris_engine/core/workflow_coordinator.py
@@ -16,6 +16,7 @@ from ciris_engine.dma.csdma import CSDMAEvaluator
 # from ciris_engine.dma.dsdma_base import BaseDSDMA # For type hinting - moved to TYPE_CHECKING
 from ciris_engine.dma.action_selection_pdma import ActionSelectionPDMAEvaluator
 from ciris_engine.guardrails import EthicalGuardrails
+from ciris_engine.utils import DEFAULT_WA
 
 if TYPE_CHECKING:
     from ciris_engine.dma.dsdma_base import BaseDSDMA # Import only for type checking
@@ -82,7 +83,7 @@ class WorkflowCoordinator:
             defer_reason = f"Failed to retrieve thought object for ID {thought_item.thought_id}"
             defer_params = DeferParams(
                 reason=defer_reason,
-                target_wa_ual="ual:placeholder/system_error/default",
+                target_wa_ual=DEFAULT_WA,
                 deferral_package_content={"error_details": defer_reason}
             )
             return ActionSelectionPDMAResult(
@@ -350,7 +351,7 @@ class WorkflowCoordinator:
             # For now, using a placeholder. This should be configured.
             guardrail_defer_params = DeferParams(
                 reason=f"Guardrail failure: {reason}",
-                target_wa_ual="ual:placeholder/wise_authority/default", # Placeholder
+                target_wa_ual=DEFAULT_WA,
                 deferral_package_content=deferral_package_for_guardrail
             )
 
@@ -414,7 +415,7 @@ class WorkflowCoordinator:
                 }
                 max_ponder_defer_params = DeferParams(
                     reason=f"Thought reached maximum ponder rounds ({self.max_ponder_rounds}).",
-                    target_wa_ual="ual:placeholder/wise_authority/default", # Placeholder
+                    target_wa_ual=DEFAULT_WA,
                     deferral_package_content=deferral_package_max_ponder
                 )
                 return ActionSelectionPDMAResult(

--- a/ciris_engine/dma/action_selection_pdma.py
+++ b/ciris_engine/dma/action_selection_pdma.py
@@ -14,14 +14,15 @@ from ciris_engine.core.agent_core_schemas import (
     ActionSelectionPDMAResult,
     HandlerActionType,
     # Import all param types for potential parsing later, though not strictly needed for this file's direct logic
-    ObserveParams, SpeakParams, ToolParams, PonderParams,
-    RejectParams, DeferParams, LearnParams, RememberParams, ForgetParams,
+    ObserveParams, SpeakParams, ActParams, PonderParams,
+    RejectParams, DeferParams, MemorizeParams, RememberParams, ForgetParams,
     CIRISSchemaVersion # Import CIRISSchemaVersion
 )
 from ciris_engine.core.foundational_schemas import HandlerActionType as CoreHandlerActionType # Alias to avoid conflict if any
 from ciris_engine.core.config_schemas import DEFAULT_OPENAI_MODEL_NAME # Corrected import
 from instructor.exceptions import InstructorRetryException
 import instructor # Import the main instructor module for Mode
+from ciris_engine.utils import DEFAULT_WA
 from pydantic import BaseModel, Field # Import BaseModel and Field for internal model definition
 
 logger = logging.getLogger(__name__)
@@ -345,7 +346,7 @@ Adhere strictly to the schema for your JSON output.
                             logger.warning(f"LLM chose DEFER with empty parameters for thought {original_thought.thought_id}. Using default DeferParams.")
                             parsed_action_params = DeferParams(
                                 reason="LLM chose to defer without providing specific parameters.",
-                                target_wa_ual="ual:placeholder/wise_authority/llm_defer_default", # Placeholder
+                                target_wa_ual=DEFAULT_WA,
                                 deferral_package_content={"original_thought_content": original_thought.content, "llm_rationale": llm_response_internal.action_selection_rationale}
                             )
                         elif selected_action == HandlerActionType.SPEAK and 'message_content' in raw_params and 'content' not in raw_params:
@@ -445,11 +446,11 @@ class _ActionSelectionLLMResponse(BaseModel):
 ACTION_PARAM_MODELS: Dict[CoreHandlerActionType, type[BaseModel]] = {
     CoreHandlerActionType.OBSERVE: ObserveParams,
     CoreHandlerActionType.SPEAK: SpeakParams,
-    CoreHandlerActionType.TOOL: ToolParams,
+    CoreHandlerActionType.ACT: ActParams,
     CoreHandlerActionType.PONDER: PonderParams,
     CoreHandlerActionType.REJECT: RejectParams,
     CoreHandlerActionType.DEFER: DeferParams,
-    CoreHandlerActionType.LEARN: LearnParams,
+    CoreHandlerActionType.MEMORIZE: MemorizeParams,
     CoreHandlerActionType.REMEMBER: RememberParams,
     CoreHandlerActionType.FORGET: ForgetParams,
 }

--- a/ciris_engine/utils/__init__.py
+++ b/ciris_engine/utils/__init__.py
@@ -1,2 +1,3 @@
-# Utility functions, including logging and profile loading.
-pass
+"""Utility helpers for CIRIS Engine."""
+from .constants import DEFAULT_WA  # noqa:F401
+

--- a/ciris_engine/utils/constants.py
+++ b/ciris_engine/utils/constants.py
@@ -1,0 +1,4 @@
+import os
+
+DEFAULT_WA = os.getenv("WA_DISCORD_USER", "somecomputerguy")
+

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -14,8 +14,8 @@ from ciris_engine.core.foundational_schemas import (
     CIRISAgentUAL, CIRISTaskUAL, CIRISKnowledgeAssetUAL, VeilidDID, VeilidRouteID
 )
 from ciris_engine.core.agent_core_schemas import (
-    ObserveParams, SpeakParams, ToolParams, PonderParams, RejectParams, DeferParams,
-    LearnParams, RememberParams, ForgetParams,
+    ObserveParams, SpeakParams, ActParams, PonderParams, RejectParams, DeferParams,
+    MemorizeParams, RememberParams, ForgetParams,
     ActionSelectionPDMAResult,
     Task, Thought, ObservationRecord, AuditLogEntry
 )
@@ -27,6 +27,8 @@ def test_enum_values():
     """Test that enums can be accessed and have expected string values."""
     assert CIRISSchemaVersion.V1_0_BETA.value == "1.0-beta"
     assert HandlerActionType.SPEAK.value == "speak"
+    assert HandlerActionType.ACT.value == "act"
+    assert HandlerActionType.MEMORIZE.value == "memorize"
     assert TaskStatus.PENDING.value == "pending"
     assert TaskStatus.PAUSED.value == "paused" # Test added status
     assert ThoughtStatus.PROCESSING.value == "processing"
@@ -192,12 +194,12 @@ def test_processing_queue_type_alias():
     assert isinstance(queue[0], ProcessingQueueItem)
 
 # Example of a validation test if a field had specific constraints
-def test_learn_params_confidence_validation():
+def test_memorize_params_confidence_validation():
     with pytest.raises(ValidationError):
-        LearnParams(knowledge_unit_description="test", knowledge_data="data", knowledge_type="fact", source="test", confidence=1.5) # Confidence > 1.0
+        MemorizeParams(knowledge_unit_description="test", knowledge_data="data", knowledge_type="fact", source="test", confidence=1.5) # Confidence > 1.0
     with pytest.raises(ValidationError):
-        LearnParams(knowledge_unit_description="test", knowledge_data="data", knowledge_type="fact", source="test", confidence=-0.5) # Confidence < 0.0
+        MemorizeParams(knowledge_unit_description="test", knowledge_data="data", knowledge_type="fact", source="test", confidence=-0.5) # Confidence < 0.0
     
     # Valid
-    params = LearnParams(knowledge_unit_description="test", knowledge_data="data", knowledge_type="fact", source="test", confidence=0.5)
+    params = MemorizeParams(knowledge_unit_description="test", knowledge_data="data", knowledge_type="fact", source="test", confidence=0.5)
     assert params.confidence == 0.5

--- a/tests/dma/test_action_selection_pdma.py
+++ b/tests/dma/test_action_selection_pdma.py
@@ -259,13 +259,13 @@ class TestActionSelectionPDMAEvaluator:
     ):
         """Test scenario where LLM returns an action for which no ParamModel is defined."""
         # Simulate LLM returning an action type that doesn't have a mapping in ACTION_PARAM_MODELS
-        # For this test, let's assume 'TOOL' is temporarily unmapped.
+        # For this test, let's assume 'ACT' is temporarily unmapped.
         
         expected_llm_response_data = {
             "schema_version": CIRISSchemaVersion.V1_0_BETA,
             "context_summary_for_action_selection": "LLM decided to use a tool.",
             "action_alignment_check": {"tool": "aligned"},
-            "selected_handler_action": CoreHandlerActionType.TOOL, # This action type
+            "selected_handler_action": CoreHandlerActionType.ACT,
             "action_parameters": {"tool_name": "calculator", "arguments": {"query": "2+2"}},
             "action_selection_rationale": "A calculation is needed.",
             "monitoring_for_selected_action": "Check tool output."
@@ -295,8 +295,8 @@ class TestActionSelectionPDMAEvaluator:
         
         original_models = action_selection_pdma_module.ACTION_PARAM_MODELS
         modified_models = original_models.copy()
-        if CoreHandlerActionType.TOOL in modified_models:
-            del modified_models[CoreHandlerActionType.TOOL]
+        if CoreHandlerActionType.ACT in modified_models:
+            del modified_models[CoreHandlerActionType.ACT]
 
         monkeypatch.setattr(action_selection_pdma_module, 'ACTION_PARAM_MODELS', modified_models)
         
@@ -306,10 +306,10 @@ class TestActionSelectionPDMAEvaluator:
         # to action_selection_pdma_module after the test.
 
         assert isinstance(result, ActionSelectionPDMAResult)
-        assert result.selected_handler_action == CoreHandlerActionType.TOOL # Should now select TOOL
+        assert result.selected_handler_action == CoreHandlerActionType.ACT
         
         # Check the content of action_parameters
-        # It could be a ToolParams object (due to Pydantic Union behavior) or a dict.
+        # It could be an ActParams object (due to Pydantic Union behavior) or a dict.
         # The SUT's internal logic correctly decided not to parse with a specific ParamModel.
         action_params_for_comparison = result.action_parameters
         if isinstance(action_params_for_comparison, BaseModel):

--- a/tests/utils/test_constants.py
+++ b/tests/utils/test_constants.py
@@ -1,0 +1,13 @@
+import importlib
+import os
+
+
+def test_default_wa_fallback(monkeypatch):
+    monkeypatch.delenv("WA_DISCORD_USER", raising=False)
+    module = importlib.reload(importlib.import_module("ciris_engine.utils.constants"))
+    assert module.DEFAULT_WA == "somecomputerguy"
+
+    monkeypatch.setenv("WA_DISCORD_USER", "real_wa")
+    module = importlib.reload(importlib.import_module("ciris_engine.utils.constants"))
+    assert module.DEFAULT_WA == "real_wa"
+


### PR DESCRIPTION
## Summary
- rename action enums to MEMORIZE, REMEMBER, FORGET, SPEAK, ACT, OBSERVE, REJECT, PONDER, DEFER
- include DEFAULT_WA fallback and apply to WA lookups
- extend DiscordGraphMemory with deferred channel memorization
- adjust discord service and workflow for new defaults
- document 3×3×3 handler model and environment variable
- update tests for new enums and memory flow

## Testing
- `pytest -q`