### PR TITLE
Wire memory actions to Discord runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,5 +4,6 @@
 - Prefer asynchronous functions when dealing with I/O or long-running tasks. Use `asyncio.to_thread` for blocking calls.
 - Keep new scripts and services minimal and well-documented.
 
-- Use `DiscordGraphMemory` for storing user metadata; avoid writing to the graph elsewhere.
+- Use `DiscordGraphMemory` for storing user metadata via MEMORIZE actions. REMEMBER and FORGET handlers exist but are usually disabled while testing.
+- Ponder rounds are capped; exceeding `max_ponder_rounds` will auto-DEFER the thought.
 - Archived scripts and documents are kept in `legacy/`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The core of CIRIS Engine is its ability to process "thoughts" (inputs or interna
 *   **DSDMA (Domain-Specific DMA):** Applies domain-specific knowledge and heuristics. Different DSDMAs can be created for various specialized tasks or agent roles (e.g., `StudentDSDMA`, `BasicTeacherDSDMA`).
 *   **ActionSelectionPDMA:** Determines the final action an agent should take based on the outputs of the preceding DMAs and the agent's current state.
 
+Actions chosen by the PDMA are routed through an `ActionDispatcher`. Memory operations use `DiscordGraphMemory` for persistence.
+
 CIRIS Engine supports different **agent profiles** (e.g., "Student", "Teacher" defined in `ciris_profiles/`) which can customize the behavior, prompting, and available DSDMAs for an agent. This allows for tailored reasoning processes depending on the agent's role or task.
 
 The system is designed for modularity, allowing developers to create and integrate new DMAs and agent profiles.
@@ -30,9 +32,10 @@ The system is designed for modularity, allowing developers to create and integra
 *   **Agent Profiles:** Customizable YAML configurations (`ciris_profiles/`) that define an agent's behavior, DSDMA selection, permitted actions, and LLM prompting strategies for various DMAs.
 *   **Local Execution:** Designed to run locally, enabling edge-side reasoning.
 *   **LLM Integration:** Leverages Large Language Models (LLMs) via `instructor` for structured output from DMAs. Requires an OpenAI-compatible API.
-*   **Thought Processing & Pondering:** Agents can "ponder" on thoughts, re-evaluating them with new questions or context over multiple cycles, managed by the `AgentProcessor` and `WorkflowCoordinator`.
+*   **Thought Processing & Pondering:** Agents may "ponder" repeatedly. The `WorkflowCoordinator` tracks ponder rounds and automatically defers once a configured limit is hit.
 *   **Basic Guardrails:** Includes an ethical guardrail to check action outputs.
 *   **SQLite Persistence:** Uses SQLite for persisting tasks and thoughts.
+*   **Graph Memory:** MEMORIZE actions store user metadata in `DiscordGraphMemory`. REMEMBER and FORGET exist but are often disabled via profiles during testing.
 
 ---
 
@@ -44,7 +47,7 @@ The `HandlerActionType` enum defines nine core operations grouped as:
 * **Control Responses:** `REJECT`, `PONDER`, `DEFER`
 * **Memory Operations:** `MEMORIZE`, `REMEMBER`, `FORGET`
 
-These actions are processed by matching handlers within the engine.
+These actions are processed by matching handlers within the engine. Profiles typically enable `MEMORIZE` and may disable `REMEMBER` and `FORGET` while the feature is tested.
 
 ---
 

--- a/ciris_engine/dma/action_selection_pdma.py
+++ b/ciris_engine/dma/action_selection_pdma.py
@@ -36,7 +36,10 @@ class ActionSelectionPDMAEvaluator:
     DEFAULT_PROMPT = {
         "system_header": (
             "You are the CIRIS Action‑Selection evaluator. "
-            "Given the PDMA, CSDMA and DSDMA results, choose one handler action."
+            "Given PDMA, CSDMA and DSDMA results, choose one handler action. "
+            "Use MEMORIZE to store facts in graph memory when allowed. "
+            "REMEMBER and FORGET exist but may be disabled. "
+            "If ponder rounds exceed the limit the system auto‑defers."
         ),
         "decision_format": ( # This describes the LLM's direct output structure
             "Return JSON with keys: context_summary_for_action_selection, action_alignment_check, "

--- a/ciris_profiles/student.yaml
+++ b/ciris_profiles/student.yaml
@@ -24,6 +24,7 @@ permitted_actions:
   - speak
   - ponder
   - reject
+  - memorize
 csdma_overrides:
   csdma_system_prompt: |
     You are a Common Sense Evaluation agent, specifically evaluating for a Student agent. Your task is to assess a given "thought" for its alignment with general common-sense understanding of the physical world, typical interactions, and resource constraints on Earth, considering the provided context.
@@ -46,11 +47,12 @@ action_selection_pdma_overrides:
   system_header: |
     CRITICAL DIRECTIVE FOR STUDENT AGENT:
     You are the Student agent.
+    Permitted actions: SPEAK, PONDER, REJECT, MEMORIZE.
+    MEMORIZE stores short facts in graph memory. REMEMBER and FORGET exist but are disabled while testing.
     Your 'Speak' action is ONLY for providing direct, statement-based ANSWERS.
     Your 'Ponder' action is for formulating internal questions for your own analysis.
     YOU MUST NOT USE YOUR 'Speak' ACTION TO ASK ANY QUESTIONS.
-    You have no other tools. You must solve problems with the information given or by Pondering.
-    Adherence to this "Speak means Answer, not Question" rule is paramount.
+    Adherence to this "Speak means Answer, not Question" rule is paramount. Exceeding max ponder rounds causes automatic DEFER.
   student_mode_csdma_ambiguity_guidance: | # This guides ActionSelectionPDMA's reaction to CSDMA flags
     As a Student agent, if CSDMA has flagged any issues like ambiguity, lack of clarity, 'Physical_Implausibility_Ignored_Interaction', or specifically 'Potential_Trick_Question_Physics_Ignored', your primary goal is deep critical analysis and understanding.
     Strongly prioritize the 'Ponder' action. If CSDMA flags 'Potential_Trick_Question_Physics_Ignored' or 'Physical_Implausibility_Ignored_Interaction', this is a strong signal to Ponder.

--- a/ciris_profiles/teacher.yaml
+++ b/ciris_profiles/teacher.yaml
@@ -7,8 +7,13 @@ permitted_actions:
   - "ponder"
   - "defer"
   - "reject"
+  - "memorize"
   # - "tool" # Add if tools are relevant for the teacher
 csdma_overrides: {}
 action_selection_pdma_overrides:
-  system_header: "You are a helpful teacher assistant for the CIRIS project. Answer questions carefully and guide users to learn more about CIRIS. Be concise."
+  system_header: |
+    You are a helpful teacher assistant for the CIRIS project.
+    Permitted actions: SPEAK, PONDER, DEFER, REJECT, MEMORIZE.
+    MEMORIZE stores short facts in graph memory. REMEMBER and FORGET exist but are disabled while testing.
+    Keep answers concise.
   # Add other teacher-specific prompt overrides for ActionSelectionPDMA if needed

--- a/run_discord_teacher.py
+++ b/run_discord_teacher.py
@@ -28,6 +28,7 @@ from ciris_engine.services.llm_service import LLMService
 from ciris_engine.services.discord_service import DiscordService, DiscordConfig
 from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
 from ciris_engine.services.discord_observer import DiscordObserver
+from ciris_engine.core.foundational_schemas import HandlerActionType
 
 # Utility for logging
 from ciris_engine.utils.logging_config import setup_basic_logging
@@ -140,6 +141,31 @@ async def main_teacher(): # Renamed function
             )
 
         action_dispatcher.register_service_handler("observer", _obs_handler)
+
+        async def _memory_handler(result, ctx):
+            action = result.selected_handler_action
+            params = result.action_parameters
+            user_nick = ctx.get("author_name", "unknown")
+            channel_id = ctx.get("channel_id")
+
+            if action == HandlerActionType.MEMORIZE:
+                if hasattr(params, "model_dump"):
+                    metadata = params.model_dump(exclude={"channel_metadata"}, exclude_none=True)
+                    channel_metadata = getattr(params, "channel_metadata", None)
+                elif isinstance(params, dict):
+                    metadata = dict(params)
+                    channel_metadata = metadata.pop("channel_metadata", None)
+                else:
+                    metadata = {}
+                    channel_metadata = None
+
+                await memory_service.memorize(user_nick, channel_id, metadata, channel_metadata)
+            elif action == HandlerActionType.REMEMBER:
+                await memory_service.remember(user_nick)
+            elif action == HandlerActionType.FORGET:
+                await memory_service.forget(user_nick)
+
+        action_dispatcher.register_service_handler("memory", _memory_handler)
         llm_client = llm_service.get_client()
 
         # DMAs and Guardrails - using the loaded teacher profile - CHANGED


### PR DESCRIPTION
## Summary
- route MEMORIZE/REMEMBER/FORGET actions to DiscordGraphMemory
- import `HandlerActionType`
- add MEMORIZE to available actions and document memory flow

## Testing
- `pytest -q`
