### PR TITLE
Improve wakeup sequence logic

### DIFF
--- a/ciris_engine/core/agent_processor.py
+++ b/ciris_engine/core/agent_processor.py
@@ -16,7 +16,11 @@ from . import persistence
 logger = logging.getLogger(__name__) # Define logger at module level
 
 WAKEUP_SEQUENCE = [
-    "Verify Core Identity",
+    (
+        "Verify Core Identity: recall you are CIRISAgent, a helpful offline "
+        "assistant running locally. If this identity is correct, please speak "
+        "a brief affirmative confirmation."
+    ),
     "Validate Integrity",
     "Evaluate Resilience",
     "Acknowledge Incompleteness",
@@ -90,7 +94,10 @@ class AgentProcessor:
                         "event_summary": phase,
                     },
                 )
-            if not result or result.selected_handler_action != HandlerActionType.SPEAK:
+            if not result or result.selected_handler_action not in (
+                HandlerActionType.SPEAK,
+                HandlerActionType.PONDER,
+            ):
                 await self.action_dispatcher.audit_service.log_action(
                     HandlerActionType.DEFER,
                     {

--- a/tests/core/test_wakeup_sequence.py
+++ b/tests/core/test_wakeup_sequence.py
@@ -12,6 +12,7 @@ from ciris_engine.core.agent_processor import AgentProcessor, WAKEUP_SEQUENCE
 from ciris_engine.core.agent_core_schemas import (
     ActionSelectionPDMAResult,
     SpeakParams,
+    PonderParams,
 )
 from ciris_engine.core.foundational_schemas import HandlerActionType, TaskStatus
 
@@ -80,3 +81,36 @@ async def test_wakeup_sequence_failure(mock_persistence, agent_processor_instanc
 
     assert success is False
     mock_persistence.update_task_status.assert_any_call("wakeup", TaskStatus.DEFERRED)
+
+
+@pytest.mark.asyncio
+@patch("ciris_engine.core.agent_processor.persistence")
+async def test_wakeup_sequence_allows_ponder(mock_persistence, agent_processor_instance: AgentProcessor, mock_workflow_coordinator, mock_action_dispatcher):
+    mock_persistence.task_exists.return_value = False
+    mock_persistence.add_task = MagicMock()
+    mock_persistence.update_task_status = MagicMock()
+    mock_persistence.add_thought = MagicMock()
+
+    ponder_result = ActionSelectionPDMAResult(
+        context_summary_for_action_selection="c",
+        action_alignment_check={},
+        selected_handler_action=HandlerActionType.PONDER,
+        action_parameters=PonderParams(key_questions=["?"], focus_areas=None, max_ponder_rounds=None),
+        action_selection_rationale="r",
+        monitoring_for_selected_action={},
+    )
+    speak_result = ActionSelectionPDMAResult(
+        context_summary_for_action_selection="c",
+        action_alignment_check={},
+        selected_handler_action=HandlerActionType.SPEAK,
+        action_parameters=SpeakParams(content="ok"),
+        action_selection_rationale="r",
+        monitoring_for_selected_action={},
+    )
+    mock_workflow_coordinator.process_thought = AsyncMock(side_effect=[ponder_result] + [speak_result] * (len(WAKEUP_SEQUENCE) - 1))
+
+    success = await agent_processor_instance._run_wakeup_sequence()
+
+    assert success
+    mock_persistence.update_task_status.assert_any_call("wakeup", TaskStatus.COMPLETED)
+    assert mock_action_dispatcher.dispatch.await_count == len(WAKEUP_SEQUENCE)


### PR DESCRIPTION
## Summary
- clarify the core identity wakeup step
- allow `PONDER` as a valid wakeup action
- test that ponder actions succeed during wakeup

## Testing
- `pytest -q`