### PR TITLE
Improve startup sequence clarity

### DIFF
--- a/run_discord_teacher.py
+++ b/run_discord_teacher.py
@@ -115,6 +115,7 @@ async def main() -> None:
         app_config=app_config,
         workflow_coordinator=workflow_coordinator,
         action_dispatcher=runtime.dispatcher,
+        startup_channel_id=SNORE_CHANNEL_ID,
     )
 
     try:


### PR DESCRIPTION
## Summary
- refine wakeup prompts for clarity
- pass channel ID to AgentProcessor so startup messages reach Discord
- treat ponder requeue correctly to avoid deferring the wakeup task

## Testing
- `pytest -q`