### PR TITLE
Fix memory meta-thought creation and dispatch context

### DIFF
--- a/ciris_engine/core/action_dispatcher.py
+++ b/ciris_engine/core/action_dispatcher.py
@@ -38,6 +38,12 @@ class ActionDispatcher:
         import uuid
         from datetime import datetime, timezone
 
+        user_nick = context.get("author_name")
+        if not user_nick:
+            logger.warning("Skipping memory meta-thought due to missing user name")
+            context[NEED_MEMORY_METATHOUGHT] = False
+            return
+
         meta_thought = Thought(
             thought_id=f"mem_{uuid.uuid4().hex[:8]}",
             source_task_id=context.get("source_task_id", "unknown"),
@@ -48,7 +54,7 @@ class ActionDispatcher:
             round_created=context.get("round", 0),
             content="Auto memory update",
             processing_context={
-                "user_nick": context.get("author_name"),
+                "user_nick": user_nick,
                 "channel": context.get("channel_id"),
                 "metadata": {},
             },

--- a/ciris_engine/core/agent_processor.py
+++ b/ciris_engine/core/agent_processor.py
@@ -142,7 +142,7 @@ class AgentProcessor:
                 priority=0,
                 created_at=now_iso,
                 updated_at=now_iso,
-                context={"meta_goal": "ubuntu"},
+                context={"meta_goal": "ubuntu", "origin_service": "discord"},
             )
             persistence.add_task(job_task)
         return True

--- a/ciris_engine/services/discord_graph_memory.py
+++ b/ciris_engine/services/discord_graph_memory.py
@@ -64,6 +64,10 @@ class DiscordGraphMemory(Service):
         channel_metadata: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """Add or update a user's metadata. Returns True if finalized."""
+        if not user_nick:
+            logger.warning("Memorize called without a user nickname; skipping")
+            return False
+
         if channel:
             if channel not in self.approved_channels:
                 self._pending.setdefault(channel, []).append((user_nick, metadata, channel_metadata))

--- a/ciris_engine/utils/graphql_context_provider.py
+++ b/ciris_engine/utils/graphql_context_provider.py
@@ -8,7 +8,8 @@ logger = logging.getLogger(__name__)
 class GraphQLClient:
     def __init__(self, endpoint: str | None = None):
         self.endpoint = endpoint or os.getenv("GRAPHQL_ENDPOINT", "http://localhost:8000/graphql")
-        self._client = httpx.AsyncClient()
+        # Use a short timeout per repository guidelines
+        self._client = httpx.AsyncClient(timeout=3.0)
 
     async def query(self, query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
         try:


### PR DESCRIPTION
## Summary
- ensure GraphQL client uses a 3s timeout
- avoid creating memory meta-thoughts when user data is missing
- guard DiscordGraphMemory against empty user_nick
- set origin_service for internal monitor job

## Testing
- `pytest -q`