### PR TITLE
Implement local memory fallback for GraphQL context

### DIFF
--- a/ciris_engine/core/workflow_coordinator.py
+++ b/ciris_engine/core/workflow_coordinator.py
@@ -52,7 +52,7 @@ class WorkflowCoordinator:
         self.dsdma_evaluators = dsdma_evaluators if dsdma_evaluators else {}
         self.action_selection_pdma_evaluator = action_selection_pdma_evaluator
         self.memory_service = memory_service
-        self.graphql_context_provider = graphql_context_provider or GraphQLContextProvider()
+        self.graphql_context_provider = graphql_context_provider or GraphQLContextProvider(memory_service=memory_service)
         self.ethical_guardrails = ethical_guardrails
         self.app_config = app_config # Store full AppConfig
         self.workflow_config = app_config.workflow # Store workflow_config part

--- a/tests/utils/test_graphql_context_provider.py
+++ b/tests/utils/test_graphql_context_provider.py
@@ -1,0 +1,50 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
+from ciris_engine.utils.graphql_context_provider import GraphQLContextProvider, GraphQLClient
+from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
+
+class DummyTask:
+    def __init__(self, author):
+        self.context = {"author_name": author}
+
+class DummyThought:
+    def __init__(self, history=None):
+        self.processing_context = {"history": history or []}
+
+def _mk_client(response):
+    client = GraphQLClient()
+    client.query = AsyncMock(return_value=response)
+    return client
+
+@pytest.mark.asyncio
+async def test_fallback_to_memory(tmp_path):
+    mem = DiscordGraphMemory(str(tmp_path / "graph.pkl"))
+    await mem.start()
+    await mem.memorize("alice", None, {"nick": "AliceNick", "channel": "general"})
+
+    client = _mk_client({})
+    provider = GraphQLContextProvider(graphql_client=client, memory_service=mem)
+    result = await provider.enrich_context(DummyTask("alice"), DummyThought())
+
+    assert result == {"user_profiles": {"alice": {"nick": "AliceNick", "channel": "general"}}}
+
+@pytest.mark.asyncio
+async def test_partial_fallback(tmp_path):
+    mem = DiscordGraphMemory(str(tmp_path / "graph.pkl"))
+    await mem.start()
+    await mem.memorize("bob", None, {"nick": "Bobby", "channel": "random"})
+
+    graphql_response = {"users": [{"name": "alice", "nick": "Alice", "channel": "general"}]}
+    client = _mk_client(graphql_response)
+    history = [{"author_name": "bob"}]
+    provider = GraphQLContextProvider(graphql_client=client, memory_service=mem)
+    result = await provider.enrich_context(DummyTask("alice"), DummyThought(history))
+
+    assert result == {
+        "user_profiles": {
+            "alice": {"nick": "Alice", "channel": "general"},
+            "bob": {"nick": "Bobby", "channel": "random"},
+        }
+    }


### PR DESCRIPTION
## Summary
- allow GraphQLContextProvider to query DiscordGraphMemory on failure
- wire WorkflowCoordinator to pass memory service into GraphQLContextProvider
- test GraphQLContextProvider fallback behaviour

## Testing
- `pytest -q`