### PR TITLE
Improve logging for thought status updates

### DIFF
--- a/ciris_engine/core/agent_processor.py
+++ b/ciris_engine/core/agent_processor.py
@@ -281,15 +281,27 @@ class AgentProcessor:
         # Mark thoughts as PROCESSING in DB before sending to coordinator
         update_tasks = []
         for item in batch:
-             update_tasks.append(
-                 asyncio.to_thread( # Run DB update in thread to avoid blocking event loop
-                     persistence.update_thought_status,
-                     item.thought_id,
-                     ThoughtStatus.PROCESSING,
-                     round_processed=self.current_round_number # Mark the round it *started* processing
-                 )
-             )
+            logging.debug(
+                "Marking thought %s as PROCESSING for round %s",
+                item.thought_id,
+                self.current_round_number,
+            )
+            update_tasks.append(
+                asyncio.to_thread(
+                    persistence.update_thought_status,
+                    item.thought_id,
+                    ThoughtStatus.PROCESSING,
+                    round_processed=self.current_round_number,
+                )
+            )
         update_results = await asyncio.gather(*update_tasks, return_exceptions=True)
+
+        for item, result in zip(batch, update_results):
+            logging.debug(
+                "update_thought_status(PROCESSING) result for %s: %s",
+                item.thought_id,
+                result,
+            )
         
         failed_updates = [item.thought_id for i, item in enumerate(batch) if isinstance(update_results[i], Exception) or not update_results[i]]
         if failed_updates:
@@ -302,11 +314,19 @@ class AgentProcessor:
 
 
         # Process the batch using WorkflowCoordinator
-        processing_tasks = [
-            self.workflow_coordinator.process_thought(item) for item in batch
-        ]
+        processing_tasks = []
+        for item in batch:
+            logging.debug("Calling process_thought for %s", item.thought_id)
+            processing_tasks.append(self.workflow_coordinator.process_thought(item))
 
         results = await asyncio.gather(*processing_tasks, return_exceptions=True)
+
+        for item, res in zip(batch, results):
+            logging.debug(
+                "process_thought result for %s: %s",
+                item.thought_id,
+                res,
+            )
 
         # Handle results/exceptions (logging for now)
         for i, result in enumerate(results):

--- a/ciris_engine/core/persistence.py
+++ b/ciris_engine/core/persistence.py
@@ -340,6 +340,14 @@ def update_thought_status(
     ponder_count: Optional[int] = None
 ) -> bool:
     """Updates the status and optionally other fields of a specific thought."""
+    logging.debug(
+        "update_thought_status called for %s -> %s | round_processed=%s | final_action_result=%s | ponder_count=%s",
+        thought_id,
+        new_status.value,
+        round_processed,
+        final_action_result is not None,
+        ponder_count,
+    )
     # Build the SET part dynamically? Or just update all optional fields passed.
     sql = """
         UPDATE thoughts


### PR DESCRIPTION
## Summary
- add detailed debug logging in `persistence.update_thought_status`
- record when thoughts are marked PROCESSING and the results
- log WorkflowCoordinator return values in `_process_batch`

## Testing
- `pytest -q`