### PR TITLE
Improve startup memory handling

### DIFF
--- a/ciris_engine/dma/action_selection_pdma.py
+++ b/ciris_engine/dma/action_selection_pdma.py
@@ -228,12 +228,21 @@ class ActionSelectionPDMAEvaluator:
         if current_system_header != self.DEFAULT_PROMPT["system_header"]:
             profile_specific_system_header_injection = f"IMPORTANT AGENT PROFILE DIRECTIVE: {current_system_header}\n\n"
 
+        startup_guidance = ""
+        if original_thought.thought_type == "startup_meta":
+            startup_guidance = (
+                "\nCRITICAL STARTUP DIRECTIVE: When handling 'startup_meta' thoughts, "
+                "select SPEAK to confirm status or PONDER only if additional internal checks are required. "
+                "Avoid MEMORIZE, ACT, REJECT, or DEFER during startup."
+            )
+
         # Using original_thought.content which is a string
         main_user_content_prompt = f"""\
 {profile_specific_system_header_injection}Your task is to determine the single most appropriate HANDLER ACTION based on an original thought and evaluations from three prior DMAs (Ethical PDMA, CSDMA, DSDMA).
 You MUST execute the Principled Decision-Making Algorithm (PDMA) to choose this HANDLER ACTION and structure your response as a JSON object matching the provided schema.
 All fields specified in the schema for your response are MANDATORY unless explicitly marked as optional.
 Permitted Handler Actions: {action_options_str}
+{startup_guidance}
 {reject_thought_guidance}
 {final_ponder_advisory}
 PDMA for Action Selection (all fields MANDATORY):


### PR DESCRIPTION
## Summary
- register DiscordGraphMemory with the dispatcher in `run_discord_teacher.py`
- add a memory handler for MEMORIZE, REMEMBER and FORGET actions
- guide `ActionSelectionPDMA` to prefer SPEAK or PONDER during startup

## Testing
- `pytest -q`