### PR TITLE
Implement WA correction flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,13 @@ All Discord-facing agents **must** adhere to the following practices:
 | rate_limit_observe     | Yes       | Cap at 10 messages per OBSERVE cycle                         |
 | metadata_schema        | Yes       | Must match schema and stay <1024 bytes                       |
 | graphql_minimal        | Yes       | Only nick/channel; fallback on timeout                       |
-| graceful_shutdown      | Yes       | 10s max shutdown per service                                 |
+| graceful_shutdown      | Yes       | 10s max shutdown per service                    |
+
+### Channel-metadata approval cycle
+
+Channel updates in `DiscordGraphMemory` are deferred until a follow-up thought from the Wise Authority arrives. The MemoryHandler checks for `is_wa_correction` and a valid `corrected_thought_id` to apply the pending write without deferring again.
 
 ### Runtime Architecture
+
 
 `BaseRuntime` centralizes environment validation, audit logging, and the Dream Protocol. IO adapters expose a small interface (`fetch_inputs` and `send_output`) so new platforms can be added easily. Incoming Discord messages are deduplicated: each message ID maps to exactly one Task and one initial Thought. The helper `_create_task_if_new` performs this check before persisting.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,3 @@
+# Channel-metadata approval cycle
+
+Channel updates to the agent's graph memory are deferred on the first attempt. The DMA automatically spawns a new thought for the Wise Authority containing the original payload. When that follow-up thought arrives with `is_wa_correction` set and a `corrected_thought_id` referencing the deferred thought, the MemoryHandler applies the update without another deferral.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The system is designed for modularity, allowing developers to create and integra
 *   **Basic Guardrails:** Includes an ethical guardrail to check action outputs.
 *   **SQLite Persistence:** Uses SQLite for persisting tasks and thoughts.
 *   **Graph Memory:** MEMORIZE actions store user metadata in `DiscordGraphMemory`. REMEMBER and FORGET exist but are often disabled via profiles during testing.
-    * Channel node updates require WA approval: the agent DEFERs until the Wise Authority approves the channel.
+    * Channel node updates require WA approval. The initial write is deferred and a new thought is generated for the Wise Authority. When that follow-up thought includes `is_wa_correction` and references the deferred thought, the update is applied automatically.
     * User nick node updates can be memorized immediately if guardrails are satisfied.
 
 ## Guardrails Summary

--- a/ciris_engine/core/action_dispatcher.py
+++ b/ciris_engine/core/action_dispatcher.py
@@ -112,6 +112,7 @@ class ActionDispatcher:
             HandlerActionType.SPEAK,
             HandlerActionType.ACT,
             HandlerActionType.DEFER,
+            HandlerActionType.DEFER_TO_WA,
             HandlerActionType.REJECT # Corrected: REJECT_THOUGHT was not defined, REJECT is.
         ]:
             handler = self.service_handlers.get(origin_service)
@@ -126,7 +127,7 @@ class ActionDispatcher:
             else:
                 logger.error(f"No handler registered for origin service '{origin_service}' to handle action '{action_type.value}'. Action not executed.")
 
-            if action_type in [HandlerActionType.SPEAK, HandlerActionType.ACT, HandlerActionType.DEFER]:
+            if action_type in [HandlerActionType.SPEAK, HandlerActionType.ACT, HandlerActionType.DEFER, HandlerActionType.DEFER_TO_WA]:
                 original_context[NEED_MEMORY_METATHOUGHT] = True
                 await self._enqueue_memory_metathought(original_context)
 

--- a/ciris_engine/core/foundational_schemas.py
+++ b/ciris_engine/core/foundational_schemas.py
@@ -20,7 +20,8 @@ class HandlerActionType(str, Enum):
     # Control responses
     REJECT = "reject"
     PONDER = "ponder"
-    DEFER = "defer"  # Deferral to Wise Authority (WA)
+    DEFER = "defer"  # Generic deferral action
+    DEFER_TO_WA = "defer_to_wa"  # Explicit deferral requiring WA intervention
 
     # Memory operations
     MEMORIZE = "memorize"
@@ -44,6 +45,13 @@ class ThoughtStatus(str, Enum):
     FAILED = "failed" # Error during processing
     DEFERRED = "deferred" # Outcome was deferral to WA
     REJECTED = "rejected" # Outcome was rejection
+
+
+class MemoryUpdateContext(str, Enum):
+    """Context markers for memory updates."""
+
+    CHANNEL_UPDATE_REQUEST = "channel_update_request"
+    CHANNEL_UPDATE_WA_APPROVED = "channel_update_wa_approved"
 
 class ObservationSourceType(str, Enum):
     DISCORD_MESSAGE = "discord_message"

--- a/ciris_engine/memory/__init__.py
+++ b/ciris_engine/memory/__init__.py
@@ -1,0 +1,2 @@
+from .memory_handler import MemoryHandler, MemoryWrite
+from .utils import classify_target, is_wa_correction

--- a/ciris_engine/memory/memory_handler.py
+++ b/ciris_engine/memory/memory_handler.py
@@ -1,0 +1,66 @@
+import logging
+from typing import Any, Dict, Optional
+from pydantic import BaseModel
+
+from ..services.discord_graph_memory import DiscordGraphMemory
+from ..core.agent_core_schemas import ActionSelectionPDMAResult
+from ..core.agent_core_schemas import Thought
+from ..core.foundational_schemas import HandlerActionType, ThoughtStatus
+from ..core import persistence
+from .utils import classify_target, is_wa_correction
+
+logger = logging.getLogger(__name__)
+
+class MemoryWrite(BaseModel):
+    key_path: str
+    user_nick: str
+    value: Any
+
+    def to_memorize_args(self):
+        parts = self.key_path.split("/", 2)
+        if parts[0] == "channel":
+            channel = parts[1].lstrip("#")
+            key = parts[2] if len(parts) > 2 else "value"
+            return self.user_nick, channel, {key: self.value}, None
+        else:
+            key = parts[2] if len(parts) > 2 else "value"
+            return self.user_nick, None, {key: self.value}, None
+
+
+class MemoryHandler:
+    def __init__(self, memory_service: DiscordGraphMemory):
+        self.memory_service = memory_service
+
+    async def process_memorize(self, thought: Thought, mem_write: MemoryWrite) -> Optional[ActionSelectionPDMAResult]:
+        user_nick, channel, metadata, chan_meta = mem_write.to_memorize_args()
+        target = classify_target(mem_write)
+
+        if target == "CHANNEL":
+            if is_wa_correction(thought):
+                logger.info(
+                    "Applying WA correction for channel update: %s (thought %s)",
+                    mem_write.key_path,
+                    thought.thought_id,
+                )
+                await self.memory_service.memorize(user_nick, channel, metadata, chan_meta, is_correction=True)
+                persistence.update_thought_status(thought.thought_id, ThoughtStatus.COMPLETED)
+                return None
+            else:
+                logger.info(
+                    "Deferring channel update → WA approval required: %s (thought %s)",
+                    mem_write.key_path,
+                    thought.thought_id,
+                )
+                persistence.update_thought_status(thought.thought_id, ThoughtStatus.DEFERRED)
+                return ActionSelectionPDMAResult(
+                    context_summary_for_action_selection="Channel metadata update requires WA approval",
+                    action_alignment_check={"DEFER": "Policy mandates WA sign-off"},
+                    selected_handler_action=HandlerActionType.DEFER_TO_WA,
+                    action_parameters={"reason": "CHANNEL_POLICY_UPDATE"},
+                    action_selection_rationale="WA approval required",
+                    monitoring_for_selected_action="none",
+                )
+        else:
+            await self.memory_service.memorize(user_nick, channel, metadata, chan_meta)
+            persistence.update_thought_status(thought.thought_id, ThoughtStatus.COMPLETED)
+            return None

--- a/ciris_engine/memory/utils.py
+++ b/ciris_engine/memory/utils.py
@@ -1,0 +1,29 @@
+import logging
+from typing import Any
+
+from ..core.agent_core_schemas import Thought
+from ..core.foundational_schemas import ThoughtStatus
+from ..core import persistence
+
+logger = logging.getLogger(__name__)
+
+class MemoryWriteKey:
+    CHANNEL_PREFIX = "channel/"
+
+
+def classify_target(mem_write: "MemoryWrite") -> str:
+    """Return 'CHANNEL' if the key path targets a channel node else 'USER'."""
+    key = mem_write.key_path
+    return "CHANNEL" if key.startswith(MemoryWriteKey.CHANNEL_PREFIX) else "USER"
+
+
+def is_wa_correction(thought: Thought) -> bool:
+    """Return True if the thought represents a WA correction for a deferred write."""
+    ctx = thought.processing_context or {}
+    if not ctx.get("is_wa_correction"):
+        return False
+    corrected_id = ctx.get("corrected_thought_id")
+    if not corrected_id:
+        return False
+    parent = persistence.get_thought_by_id(corrected_id)
+    return parent is not None and parent.status == ThoughtStatus.DEFERRED

--- a/ciris_engine/runtime/base_runtime.py
+++ b/ciris_engine/runtime/base_runtime.py
@@ -118,6 +118,7 @@ class BaseRuntime:
         HandlerActionType.MEMORIZE,
         HandlerActionType.REMEMBER,
         HandlerActionType.DEFER,
+        HandlerActionType.DEFER_TO_WA,
         HandlerActionType.REJECT,
         HandlerActionType.PONDER,
     }

--- a/tests/memory/test_memory_handler.py
+++ b/tests/memory/test_memory_handler.py
@@ -1,0 +1,125 @@
+import pytest
+from pathlib import Path
+from datetime import datetime
+
+from ciris_engine.memory.memory_handler import MemoryHandler, MemoryWrite
+from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
+from ciris_engine.core.agent_core_schemas import Thought, Task
+from ciris_engine.core.foundational_schemas import ThoughtStatus, HandlerActionType
+from ciris_engine.core import persistence
+
+
+@pytest.fixture
+def init_db(tmp_path: Path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(persistence, "get_sqlite_db_full_path", lambda: str(db_file))
+    persistence.initialize_database()
+    return db_file
+
+
+@pytest.fixture
+async def memory_service(tmp_path: Path):
+    service = DiscordGraphMemory(str(tmp_path / "graph.pkl"))
+    await service.start()
+    yield service
+
+
+def _create_task_and_thought(task_id: str, thought_id: str) -> Thought:
+    now = datetime.utcnow().isoformat()
+    task = Task(task_id=task_id, description="t", created_at=now, updated_at=now)
+    persistence.add_task(task)
+    thought = Thought(
+        thought_id=thought_id,
+        source_task_id=task_id,
+        thought_type="memory",
+        status=ThoughtStatus.PENDING,
+        created_at=now,
+        updated_at=now,
+        round_created=0,
+        content="",
+    )
+    persistence.add_thought(thought)
+    return thought
+
+def _create_thought(task_id: str, thought_id: str) -> Thought:
+    now = datetime.utcnow().isoformat()
+    thought = Thought(
+        thought_id=thought_id,
+        source_task_id=task_id,
+        thought_type="memory",
+        status=ThoughtStatus.PENDING,
+        created_at=now,
+        updated_at=now,
+        round_created=0,
+        content="",
+    )
+    persistence.add_thought(thought)
+    return thought
+
+
+@pytest.mark.asyncio
+async def test_user_metadata_writes_directly(init_db, memory_service):
+    thought = _create_task_and_thought("task1", "th1")
+    handler = MemoryHandler(memory_service)
+
+    mem_write = MemoryWrite(key_path="user/@alice/nick", user_nick="alice", value="A")
+    result = await handler.process_memorize(thought, mem_write)
+
+    assert result is None
+    updated = persistence.get_thought_by_id("th1")
+    assert updated.status == ThoughtStatus.COMPLETED
+    data = await memory_service.remember("alice")
+    assert data["nick"] == "A"
+
+
+@pytest.mark.asyncio
+async def test_channel_write_defers(init_db, memory_service):
+    thought = _create_task_and_thought("task2", "th2")
+    handler = MemoryHandler(memory_service)
+    mem_write = MemoryWrite(key_path="channel/#general/topic", user_nick="alice", value="Rules")
+
+    result = await handler.process_memorize(thought, mem_write)
+
+    assert result.selected_handler_action == HandlerActionType.DEFER_TO_WA
+    updated = persistence.get_thought_by_id("th2")
+    assert updated.status == ThoughtStatus.DEFERRED
+    assert "alice" not in memory_service.graph
+
+
+@pytest.mark.asyncio
+async def test_wa_correction_applies(init_db, memory_service):
+    original = _create_task_and_thought("task3", "th3")
+    handler = MemoryHandler(memory_service)
+    initial_write = MemoryWrite(key_path="channel/#general/topic", user_nick="alice", value="Rules")
+    await handler.process_memorize(original, initial_write)
+
+    correction = _create_thought("task3", "th3c")
+    correction.processing_context = {
+        "is_wa_correction": True,
+        "corrected_thought_id": "th3",
+    }
+
+    corrected_write = MemoryWrite(key_path="channel/#general/topic", user_nick="alice", value="Rules updated")
+    result = await handler.process_memorize(correction, corrected_write)
+
+    assert result is None
+    updated = persistence.get_thought_by_id("th3c")
+    assert updated.status == ThoughtStatus.COMPLETED
+    data = await memory_service.remember("alice")
+    assert data.get("topic") == "Rules updated"
+
+
+@pytest.mark.asyncio
+async def test_double_deferral_prevented(init_db, memory_service):
+    thought = _create_task_and_thought("task4", "th4")
+    handler = MemoryHandler(memory_service)
+    mem_write = MemoryWrite(key_path="channel/#general/topic", user_nick="alice", value="Rules")
+
+    correction = _create_thought("task4", "th5")
+    correction.processing_context = {"is_wa_correction": True, "corrected_thought_id": "nonexistent"}
+
+    result = await handler.process_memorize(correction, mem_write)
+
+    assert result.selected_handler_action == HandlerActionType.DEFER_TO_WA
+    updated = persistence.get_thought_by_id("th5")
+    assert updated.status == ThoughtStatus.DEFERRED

--- a/tests/services/test_discord_graph_memory.py
+++ b/tests/services/test_discord_graph_memory.py
@@ -32,16 +32,13 @@ async def test_memory_graph_loads_existing(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_memorize_defer_flow(tmp_path: Path):
+async def test_memorize_channel_write(tmp_path: Path):
     storage = tmp_path / "graph.pkl"
     service = DiscordGraphMemory(str(storage))
     await service.start()
 
     result = await service.memorize("alice", "general", {"kind": "nice"})
-    assert result.status == MemoryOpStatus.DEFERRED
-    assert "alice" not in service.graph
-
-    await service.approve_channel("general")
+    assert result.status == MemoryOpStatus.SAVED
     data = await service.remember("alice")
     assert data["kind"] == "nice"
     assert "alice" in service.graph


### PR DESCRIPTION
## Summary
- move classify_target & is_wa_correction helpers to `memory/utils.py`
- log channel update deferrals and WA corrections with key path and thought id
- expose `MemoryUpdateContext` enum
- update tests for WA correction round trip

## Testing
- `pytest -q`
