### PR TITLE
Fix Discord teacher entrypoint

### DIFF
--- a/run_discord_teacher.py
+++ b/run_discord_teacher.py
@@ -336,3 +336,7 @@ async def main() -> None:
         await asyncio.gather(runtime._main_loop(), processor.start_processing())
     finally:
         await asyncio.gather(llm_service.stop(), memory_service.stop())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add missing __main__ block to run the Discord teacher agent

## Testing
- `pytest -q`