### PR TITLE
Decouple Discord input handling

### DIFF
--- a/ciris_engine/services/discord_event_queue.py
+++ b/ciris_engine/services/discord_event_queue.py
@@ -1,0 +1,22 @@
+import asyncio
+from typing import Dict, Any
+
+class DiscordEventQueue:
+    """Simple async queue for Discord events."""
+
+    def __init__(self, maxsize: int = 100):
+        self._queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(maxsize=maxsize)
+
+    async def enqueue(self, event: Dict[str, Any]) -> None:
+        await self._queue.put(event)
+
+    def enqueue_nowait(self, event: Dict[str, Any]) -> None:
+        """Enqueue without awaiting; raises QueueFull if full."""
+        self._queue.put_nowait(event)
+
+    async def dequeue(self) -> Dict[str, Any]:
+        return await self._queue.get()
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+

--- a/ciris_engine/services/discord_observer.py
+++ b/ciris_engine/services/discord_observer.py
@@ -1,8 +1,10 @@
 import logging
 import os
+import asyncio
 from typing import Callable, Awaitable, Dict, Any, Optional
 
 from .base import Service
+from .discord_event_queue import DiscordEventQueue
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +19,13 @@ class DiscordObserver(Service):
         self,
         on_observe: Callable[[Dict[str, Any]], Awaitable[None]],
         monitored_channel_id: Optional[str] = None,
+        event_queue: Optional[DiscordEventQueue] = None,
     ):
         super().__init__()
         self.on_observe = on_observe
+        self.event_queue = event_queue
+        self._poll_task: Optional[asyncio.Task] = None
+        self._stop_event = asyncio.Event()
 
         env_id = os.getenv("DISCORD_CHANNEL_ID")
         if monitored_channel_id is None and env_id:
@@ -29,9 +35,30 @@ class DiscordObserver(Service):
 
     async def start(self):
         await super().start()
+        if self.event_queue:
+            self._poll_task = asyncio.create_task(self._poll_events())
 
     async def stop(self):
+        if self._poll_task:
+            self._stop_event.set()
+            await self._poll_task
+            self._poll_task = None
         await super().stop()
+
+    async def _poll_events(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                event = await asyncio.wait_for(self.event_queue.dequeue(), timeout=0.1)
+            except asyncio.TimeoutError:
+                continue
+            except Exception:
+                continue
+
+            await self.handle_event(
+                event.get("user_nick", ""),
+                event.get("channel", ""),
+                event.get("message_content", ""),
+            )
 
     async def handle_event(
         self, user_nick: str, channel: str, message_content: str

--- a/tests/services/test_discord_observer.py
+++ b/tests/services/test_discord_observer.py
@@ -2,6 +2,12 @@ import pytest
 from unittest.mock import AsyncMock
 
 from ciris_engine.services.discord_observer import DiscordObserver
+from ciris_engine.services.discord_event_queue import DiscordEventQueue
+from ciris_engine.services.discord_service import DiscordService
+from ciris_engine.core.action_dispatcher import ActionDispatcher
+from datetime import datetime, timezone
+import logging
+import asyncio
 
 @pytest.mark.asyncio
 async def test_discord_observer_filters_channels():
@@ -28,3 +34,58 @@ async def test_discord_observer_filters_channels():
             ),
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_discord_observer_queue_polling():
+    events = []
+
+    async def collect(payload):
+        events.append(payload)
+
+    q = DiscordEventQueue()
+    observer = DiscordObserver(collect, monitored_channel_id="allowed", event_queue=q)
+    await observer.start()
+    await q.enqueue({"user_nick": "nick", "channel": "allowed", "message_content": "hi"})
+    await asyncio.sleep(0.05)
+    await observer.stop()
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_discord_service_non_blocking_enqueue(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "x")
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", "2")
+
+    q = DiscordEventQueue(maxsize=1)
+    q.enqueue_nowait({"user_nick": "a", "channel": "1", "message_content": "hi"})
+
+    dispatcher = ActionDispatcher()
+    service = DiscordService(dispatcher, event_queue=q)
+
+    class Author:
+        def __init__(self):
+            self.name = "u"
+            self.id = 1
+            self.bot = False
+
+    class Channel:
+        def __init__(self):
+            self.id = 2
+            self.name = "c"
+
+    class Message:
+        def __init__(self):
+            self.id = 3
+            self.author = Author()
+            self.channel = Channel()
+            self.content = "hello"
+            self.created_at = datetime.now(timezone.utc)
+            self.guild = None
+            self.reference = None
+
+    msg = Message()
+    await service.bot.on_message(msg)
+
+    assert any("Event queue full" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `DiscordEventQueue` for incoming Discord events
- use the queue in `DiscordService` instead of creating tasks directly
- allow `DiscordObserver` to poll from a queue asynchronously
- avoid blocking on full queue via `enqueue_nowait`
- test queue polling and full-queue drop behavior

## Testing
- `pytest -q`