### PR TITLE
Step 2 schema refactor

### DIFF
--- a/ciris_engine/core/action_dispatcher.py
+++ b/ciris_engine/core/action_dispatcher.py
@@ -261,3 +261,19 @@ class ActionDispatcher:
         # Handle any other unexpected action types
         else:
             logger.error(f"Unhandled action type received by ActionDispatcher: {action_type.value}")
+
+        thought_id = original_context.get("thought_id")
+        if thought_id:
+            thought = persistence.get_thought_by_id(thought_id)
+            if thought:
+                thought.action_count += 1
+                thought.history.append({
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "action": action_type.value,
+                    "service": origin_service,
+                })
+                if action_type == HandlerActionType.DEFER:
+                    thought.escalations.append({
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "type": "defer",
+                    })

--- a/ciris_engine/core/agent_core_schemas.py
+++ b/ciris_engine/core/agent_core_schemas.py
@@ -73,6 +73,10 @@ class Thought(BaseModel):
     related_thought_id: Optional[str] = None # Link to parent thought if spawned (metathoughts)
     final_action_result: Optional[ActionSelectionPDMAResult] = None # Stores the outcome
 
+    action_count: int = 0
+    history: List[Dict[str, Any]] = Field(default_factory=list)
+    escalations: List[Dict[str, Any]] = Field(default_factory=list)
+    is_terminal: bool = False
 # --- Epistemic Faculty Schemas ---
 
 class EntropyResult(BaseModel):
@@ -84,29 +88,3 @@ class CoherenceResult(BaseModel):
 # --- DMA Schemas ---
 
 
-# --- Observation Record ---
-
-class ObservationRecord(BaseModel):
-    schema_version: CIRISSchemaVersion = CIRISSchemaVersion.V1_0_BETA
-    observation_id: str # Unique identifier
-    timestamp: str # ISO8601 timestamp when observation was made/received
-    source_type: ObservationSourceType
-    source_identifier: Optional[str] = None # e.g., Discord message ID, Sensor ID, Agent UAL/DID
-    data_schema_ual: Optional[CIRISKnowledgeAssetUAL] = None # UAL pointing to the schema of the data payload
-    data_payload: Any # The actual observed data (structure depends on source_type/data_schema_ual)
-    confidence: float = Field(..., ge=0.0, le=1.0)
-    metadata: Optional[Dict[str, Any]] = None # Additional context
-
-# --- Audit Log Entry ---
-class AuditLogEntry(BaseModel):
-    schema_version: CIRISSchemaVersion = CIRISSchemaVersion.V1_0_BETA
-    event_id: str # Unique ID for this specific log entry (e.g., UUID)
-    event_timestamp: str # ISO8601 timestamp with high precision
-    event_type: str # e.g., "ActionExecuted", "MessageSent", "DKGQueryPerformed", "Error"
-    originator_id: Union[CIRISAgentUAL, VeilidDID] # ID of the entity generating the event
-    target_id: Optional[Union[CIRISAgentUAL, VeilidDID, CIRISTaskUAL, CIRISKnowledgeAssetUAL]] = None # ID of the target, if any
-    event_summary: str # Concise summary
-    event_payload_schema_ual: Optional[CIRISKnowledgeAssetUAL] = None # Schema for the payload
-    event_payload: Optional[Any] = None # Detailed data, potentially serialized or a reference
-    dkg_assertion_link: Optional[CIRISKnowledgeAssetUAL] = None # Link if event corresponds to a KA assertion
-    # Signature will be added externally during the logging process before batching

--- a/ciris_engine/core/audit_schemas.py
+++ b/ciris_engine/core/audit_schemas.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from typing import Any, Dict, Optional, Union
+
+from .foundational_schemas import (
+    CIRISSchemaVersion,
+    CIRISAgentUAL,
+    CIRISTaskUAL,
+    CIRISKnowledgeAssetUAL,
+    VeilidDID,
+)
+
+
+class AuditLogEntry(BaseModel):
+    schema_version: CIRISSchemaVersion = CIRISSchemaVersion.V1_0_BETA
+    event_id: str
+    event_timestamp: str
+    event_type: str
+    originator_id: Union[CIRISAgentUAL, VeilidDID]
+    target_id: Optional[Union[CIRISAgentUAL, VeilidDID, CIRISTaskUAL, CIRISKnowledgeAssetUAL]] = None
+    event_summary: str
+    event_payload_schema_ual: Optional[CIRISKnowledgeAssetUAL] = None
+    event_payload: Optional[Any] = None
+    dkg_assertion_link: Optional[CIRISKnowledgeAssetUAL] = None

--- a/ciris_engine/core/observation_schemas.py
+++ b/ciris_engine/core/observation_schemas.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, Field
+from typing import Any, Dict, Optional
+
+from .foundational_schemas import (
+    CIRISSchemaVersion,
+    ObservationSourceType,
+    CIRISKnowledgeAssetUAL,
+)
+
+
+class ObservationRecord(BaseModel):
+    schema_version: CIRISSchemaVersion = CIRISSchemaVersion.V1_0_BETA
+    observation_id: str
+    timestamp: str
+    source_type: ObservationSourceType
+    source_identifier: Optional[str] = None
+    data_schema_ual: Optional[CIRISKnowledgeAssetUAL] = None
+    data_payload: Any
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    metadata: Optional[Dict[str, Any]] = None

--- a/ciris_engine/services/audit_service.py
+++ b/ciris_engine/services/audit_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from .base import Service
-from ciris_engine.core.agent_core_schemas import AuditLogEntry
+from ciris_engine.core.audit_schemas import AuditLogEntry
 from ciris_engine.core.foundational_schemas import HandlerActionType
 
 logger = logging.getLogger(__name__)

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -17,10 +17,12 @@ from ciris_engine.core.agent_core_schemas import (
     ObserveParams, SpeakParams, ActParams, PonderParams, RejectParams, DeferParams,
     MemorizeParams, RememberParams, ForgetParams,
     ActionSelectionPDMAResult,
-    Task, Thought, ObservationRecord, AuditLogEntry
+    Task, Thought
 )
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem, ProcessingQueue
 
+from ciris_engine.core.observation_schemas import ObservationRecord
+from ciris_engine.core.audit_schemas import AuditLogEntry
 # --- Tests for foundational_schemas.py ---
 
 def test_enum_values():
@@ -78,6 +80,10 @@ def test_thought_instantiation_and_defaults():
     assert thought.status == ThoughtStatus.PENDING # Default
     assert thought.priority == 0 # Added field, default 0
     assert thought.round_created == 1 # Added field
+    assert thought.action_count == 0
+    assert thought.history == []
+    assert thought.escalations == []
+    assert thought.is_terminal is False
     assert thought.round_processed is None # Added field, default None
     assert thought.depth == 0 # Default
     assert thought.ponder_count == 0 # Default

--- a/tests/services/test_cirisnode_client.py
+++ b/tests/services/test_cirisnode_client.py
@@ -5,7 +5,7 @@ import pytest
 
 from ciris_engine.services.cirisnode_client import CIRISNodeClient
 from ciris_engine.services.audit_service import AuditService
-from ciris_engine.core.agent_core_schemas import AuditLogEntry
+from ciris_engine.core.audit_schemas import AuditLogEntry
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- move `ObservationRecord` to `observation_schemas.py`
- move `AuditLogEntry` to `audit_schemas.py`
- extend `Thought` with tracking fields
- log action dispatches into the `Thought` history
- update imports and tests

## Testing
- `pytest -q`