### PR TITLE
Centralize escalation logic

### DIFF
--- a/ciris_engine/core/action_dispatcher.py
+++ b/ciris_engine/core/action_dispatcher.py
@@ -15,6 +15,7 @@ from .agent_core_schemas import (
 from .action_params import SpeakParams, MemorizeParams
 from .dma_results import ActionSelectionPDMAResult
 from ciris_engine.services.audit_service import AuditService
+from .thought_escalation import escalate_due_to_failure
 
 logger = logging.getLogger(__name__)
 
@@ -273,7 +274,11 @@ class ActionDispatcher:
                     "service": origin_service,
                 })
                 if action_type == HandlerActionType.DEFER:
-                    thought.escalations.append({
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                        "type": "defer",
-                    })
+                    escalate_due_to_failure(
+                        thought,
+                        reason=(
+                            f"Internal deferral triggered. DMA: {origin_service}, "
+                            f"Task: {thought.source_task_id}. "
+                            f"Last action: {thought.history[-1]['action']}"
+                        ),
+                    )

--- a/ciris_engine/core/thought_escalation.py
+++ b/ciris_engine/core/thought_escalation.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timezone
+from typing import Dict
+
+from .agent_core_schemas import Thought
+
+__all__ = [
+    "escalate_due_to_action_limit",
+    "escalate_due_to_sla",
+    "escalate_due_to_guardrail",
+    "escalate_due_to_failure",
+]
+
+
+def _append_escalation(thought: Thought, event: Dict[str, str]) -> Thought:
+    """Append an escalation event to the thought."""
+    thought.escalations.append(event)
+    return thought
+
+
+def escalate_due_to_action_limit(thought: Thought, reason: str) -> Thought:
+    """Escalate when a thought exceeds its action limit."""
+    now = datetime.now(timezone.utc).isoformat()
+    event = {
+        "timestamp": now,
+        "reason": reason,
+        "type": "action_limit",
+    }
+    return _append_escalation(thought, event)
+
+
+def escalate_due_to_sla(thought: Thought, reason: str) -> Thought:
+    """Escalate when a thought breaches its SLA."""
+    now = datetime.now(timezone.utc).isoformat()
+    event = {
+        "timestamp": now,
+        "reason": reason,
+        "type": "sla_breach",
+    }
+    thought.is_terminal = True
+    return _append_escalation(thought, event)
+
+
+def escalate_due_to_guardrail(thought: Thought, reason: str) -> Thought:
+    """Escalate when a guardrail violation occurs."""
+    now = datetime.now(timezone.utc).isoformat()
+    event = {
+        "timestamp": now,
+        "reason": reason,
+        "type": "guardrail_violation",
+    }
+    thought.is_terminal = True
+    return _append_escalation(thought, event)
+
+
+def escalate_due_to_failure(thought: Thought, reason: str) -> Thought:
+    """Escalate due to internal failure or deferral."""
+    now = datetime.now(timezone.utc).isoformat()
+    event = {
+        "timestamp": now,
+        "reason": reason,
+        "type": "internal_failure",
+    }
+    thought.is_terminal = True
+    return _append_escalation(thought, event)

--- a/ciris_engine/core/workflow_coordinator.py
+++ b/ciris_engine/core/workflow_coordinator.py
@@ -18,6 +18,7 @@ from ciris_engine.dma.action_selection_pdma import ActionSelectionPDMAEvaluator
 from ciris_engine.guardrails import EthicalGuardrails
 from ciris_engine.utils import DEFAULT_WA
 from ciris_engine.utils import GraphQLContextProvider
+from .thought_escalation import escalate_due_to_guardrail
 
 if TYPE_CHECKING:
     from ciris_engine.dma.dsdma_base import BaseDSDMA # Import only for type checking
@@ -334,6 +335,15 @@ class WorkflowCoordinator:
                 reason=f"Guardrail failure: {reason}",
                 target_wa_ual=DEFAULT_WA,
                 deferral_package_content=deferral_package_for_guardrail
+            )
+
+            escalate_due_to_guardrail(
+                thought_object,
+                reason=(
+                    f"Guardrail violation detected: {reason}. DMA: ActionSelectionPDMA, "
+                    f"Task: {thought_object.source_task_id}. "
+                    f"Last action: {thought_object.history[-1]['action']}" if thought_object.history else "Last action: None"
+                ),
             )
 
             final_action_result = ActionSelectionPDMAResult( 

--- a/tests/core/test_thought_escalation.py
+++ b/tests/core/test_thought_escalation.py
@@ -1,0 +1,53 @@
+import uuid
+from datetime import datetime, timezone
+
+from ciris_engine.core.agent_core_schemas import Thought, ThoughtStatus
+from ciris_engine.core.thought_escalation import (
+    escalate_due_to_action_limit,
+    escalate_due_to_sla,
+    escalate_due_to_guardrail,
+)
+
+
+def create_thought() -> Thought:
+    now = datetime.now(timezone.utc).isoformat()
+    return Thought(
+        thought_id=str(uuid.uuid4()),
+        source_task_id="task1",
+        thought_type="seed",
+        status=ThoughtStatus.PENDING,
+        created_at=now,
+        updated_at=now,
+        round_created=0,
+        content="test",
+    )
+
+
+def test_escalate_due_to_action_limit():
+    thought = create_thought()
+    escalate_due_to_action_limit(thought, "limit reached")
+    assert len(thought.escalations) == 1
+    event = thought.escalations[0]
+    assert event["type"] == "action_limit"
+    assert "limit reached" in event["reason"]
+    assert thought.is_terminal is False
+
+
+def test_escalate_due_to_sla():
+    thought = create_thought()
+    escalate_due_to_sla(thought, "timeout")
+    assert len(thought.escalations) == 1
+    event = thought.escalations[0]
+    assert event["type"] == "sla_breach"
+    assert "timeout" in event["reason"]
+    assert thought.is_terminal is True
+
+
+def test_escalate_due_to_guardrail():
+    thought = create_thought()
+    escalate_due_to_guardrail(thought, "guardrail breached")
+    assert len(thought.escalations) == 1
+    event = thought.escalations[0]
+    assert event["type"] == "guardrail_violation"
+    assert "guardrail breached" in event["reason"]
+    assert thought.is_terminal is True

--- a/tests/core/test_workflow_coordinator.py
+++ b/tests/core/test_workflow_coordinator.py
@@ -254,6 +254,8 @@ async def test_process_thought_guardrail_failure(
     assert result is not None
     assert result.selected_handler_action == HandlerActionType.DEFER # Should be deferred
     assert "Guardrail failed" in result.action_parameters.reason # Access the 'reason' attribute directly
+    assert sample_thought.escalations
+    assert sample_thought.escalations[0]["type"] == "guardrail_violation"
 
 
 @pytest.mark.skip(reason="Failing with AttributeError: 'PonderParams' object has no attribute 'get' in SUT")


### PR DESCRIPTION
## Summary
- add new `thought_escalation` module with helper functions
- use escalation helpers in `ActionDispatcher` and `WorkflowCoordinator`
- verify escalation logic with new unit tests
- update existing tests for guardrail deferral and dispatcher deferral

## Testing
- `pytest -q`