### PR TITLE
Ensure follow-up thought lineage

### DIFF
--- a/ciris_engine/core/action_dispatcher.py
+++ b/ciris_engine/core/action_dispatcher.py
@@ -1,6 +1,12 @@
-from .foundational_schemas import HandlerActionType
-from .agent_core_schemas import Thought
+"""Dispatch actions and ensure follow-up Thought creation."""
+
 from typing import Callable, Awaitable, Any
+from datetime import datetime, timezone
+import uuid
+
+from .foundational_schemas import HandlerActionType
+from .agent_core_schemas import Thought, ThoughtStatus
+from . import persistence
 
 from .action_handlers.speak_handler import handle_speak
 from .action_handlers.observe_handler import handle_observe
@@ -18,11 +24,35 @@ handler_map = {
     HandlerActionType.TASK_COMPLETE: handle_task_complete,
 }
 
-ServiceHandlerCallable = Callable[[Any, Any], Awaitable[None]]
+ServiceHandlerCallable = Callable[[Any, Any], Awaitable[Any]]
 
 async def dispatch(action_type: HandlerActionType, thought: Thought, params: dict, services: dict):
+    """Execute handler and persist a follow-up Thought when required."""
     handler = handler_map[action_type]
-    await handler(thought, params, **services)
+    result = await handler(thought, params, **services)
+
+    if action_type == HandlerActionType.TASK_COMPLETE:
+        return None
+
+    if isinstance(result, Thought):
+        persistence.add_thought(result)
+        return result
+
+    # Fallback: create a minimal follow-up if handler didn't return one
+    new_thought = Thought(
+        thought_id=str(uuid.uuid4()),
+        source_task_id=thought.source_task_id,
+        thought_type="follow_up",
+        status=ThoughtStatus.PENDING,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        updated_at=datetime.now(timezone.utc).isoformat(),
+        round_created=thought.round_created,
+        content="",
+        related_thought_id=thought.thought_id,
+        priority=thought.priority,
+    )
+    persistence.add_thought(new_thought)
+    return new_thought
 
 class ActionDispatcher:
     def __init__(self, audit_service=None):

--- a/ciris_engine/core/action_handlers/defer_handler.py
+++ b/ciris_engine/core/action_handlers/defer_handler.py
@@ -1,7 +1,10 @@
-from ..agent_core_schemas import Thought
+"""Service action for DEFER."""
 
-async def handle_defer(thought: Thought, params: dict):
+from ..agent_core_schemas import Thought
+from .helpers import create_follow_up_thought
+
+async def handle_defer(thought: Thought, params: dict) -> Thought:
+    """Mark the thought deferred and return a follow-up Thought."""
     reason = params.get("reason")
     thought.is_terminal = True
-    thought.action_count += 1
-    thought.history.append({"action": "defer", "reason": reason})
+    return create_follow_up_thought(thought, content=str(reason))

--- a/ciris_engine/core/action_handlers/helpers.py
+++ b/ciris_engine/core/action_handlers/helpers.py
@@ -1,0 +1,26 @@
+from datetime import datetime, timezone
+import uuid
+
+from ..agent_core_schemas import Thought, ThoughtStatus
+
+
+def create_follow_up_thought(parent: Thought, content: str = "", thought_type: str = "follow_up") -> Thought:
+    """Return a new Thought linked to ``parent``.
+
+    The original Thought instance is never mutated.
+    ``source_task_id`` is inherited and ``related_thought_id`` references the
+    parent thought's ID to maintain lineage.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    return Thought(
+        thought_id=str(uuid.uuid4()),
+        source_task_id=parent.source_task_id,
+        thought_type=thought_type,
+        status=ThoughtStatus.PENDING,
+        created_at=now,
+        updated_at=now,
+        round_created=parent.round_created,
+        content=content,
+        related_thought_id=parent.thought_id,
+        priority=parent.priority,
+    )

--- a/ciris_engine/core/action_handlers/memorize_handler.py
+++ b/ciris_engine/core/action_handlers/memorize_handler.py
@@ -1,13 +1,18 @@
-from ..agent_core_schemas import Thought
+"""Service action for MEMORIZE."""
+
 from typing import TYPE_CHECKING
+from ..agent_core_schemas import Thought
+from .helpers import create_follow_up_thought
 
 if TYPE_CHECKING:
     from ...services.discord_graph_memory import DiscordGraphMemory
 
-async def handle_memorize(thought: Thought, params: dict, memory_service: "DiscordGraphMemory"):
+async def handle_memorize(
+    thought: Thought, params: dict, memory_service: "DiscordGraphMemory"
+) -> Thought:
+    """Write user metadata and return a follow-up Thought."""
     user_nick = params["user_nick"]
     channel = params.get("channel")
     metadata = params.get("metadata", {})
     await memory_service.memorize(user_nick, channel, metadata)
-    thought.action_count += 1
-    thought.history.append({"action": "memorize", "user_nick": user_nick})
+    return create_follow_up_thought(thought)

--- a/ciris_engine/core/action_handlers/observe_handler.py
+++ b/ciris_engine/core/action_handlers/observe_handler.py
@@ -1,6 +1,9 @@
-from ..agent_core_schemas import Thought
+"""Service action for OBSERVE."""
 
-async def handle_observe(thought: Thought, params: dict, observer_service):
+from ..agent_core_schemas import Thought
+from .helpers import create_follow_up_thought
+
+async def handle_observe(thought: Thought, params: dict, observer_service) -> Thought:
+    """Perform observation and return a follow-up Thought."""
     await observer_service.observe(params)
-    thought.action_count += 1
-    thought.history.append({"action": "observe"})
+    return create_follow_up_thought(thought)

--- a/ciris_engine/core/action_handlers/speak_handler.py
+++ b/ciris_engine/core/action_handlers/speak_handler.py
@@ -1,12 +1,17 @@
-from ..agent_core_schemas import Thought
+"""Service action for SPEAK."""
+
 from typing import TYPE_CHECKING
+from ..agent_core_schemas import Thought
+from .helpers import create_follow_up_thought
 
 if TYPE_CHECKING:
     from ...services.discord_service import DiscordService
 
-async def handle_speak(thought: Thought, params: dict, discord_service: "DiscordService"):
+async def handle_speak(
+    thought: Thought, params: dict, discord_service: "DiscordService"
+) -> Thought:
+    """Send a Discord message and return a follow-up Thought."""
     content = params["content"]
     target_channel = params.get("target_channel")
     await discord_service.send_message(target_channel, content)
-    thought.action_count += 1
-    thought.history.append({"action": "speak", "content": content})
+    return create_follow_up_thought(thought)

--- a/ciris_engine/core/action_handlers/task_complete_handler.py
+++ b/ciris_engine/core/action_handlers/task_complete_handler.py
@@ -1,6 +1,7 @@
+"""Handler for TASK_COMPLETE."""
+
 from ..agent_core_schemas import Thought
 
-async def handle_task_complete(thought: Thought, params: dict):
+async def handle_task_complete(thought: Thought, params: dict) -> None:
+    """Mark the originating thought as terminal."""
     thought.is_terminal = True
-    thought.action_count += 1
-    thought.history.append({"action": "task_complete"})

--- a/ciris_engine/core/action_handlers/tool_handler.py
+++ b/ciris_engine/core/action_handlers/tool_handler.py
@@ -1,8 +1,11 @@
-from ..agent_core_schemas import Thought
+"""Service action for TOOL."""
 
-async def handle_tool(thought: Thought, params: dict, tool_service):
+from ..agent_core_schemas import Thought
+from .helpers import create_follow_up_thought
+
+async def handle_tool(thought: Thought, params: dict, tool_service) -> Thought:
+    """Execute a tool and return a follow-up Thought."""
     tool_name = params["tool_name"]
     arguments = params.get("arguments", {})
     await tool_service.execute_tool(tool_name, arguments)
-    thought.action_count += 1
-    thought.history.append({"action": "tool", "tool_name": tool_name})
+    return create_follow_up_thought(thought)

--- a/tests/core/test_action_dispatcher.py
+++ b/tests/core/test_action_dispatcher.py
@@ -4,13 +4,15 @@ from unittest.mock import AsyncMock, patch
 from ciris_engine.core.action_dispatcher import ActionDispatcher, dispatch, handler_map
 from ciris_engine.core.foundational_schemas import HandlerActionType
 from ciris_engine.core.agent_core_schemas import Thought
+from ciris_engine.core import persistence
 
 @pytest.mark.asyncio
 async def test_dispatch_invokes_correct_handler():
     t = Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content="")
     mock_handler = AsyncMock()
     with patch.dict(handler_map, {HandlerActionType.SPEAK: mock_handler}):
-        await dispatch(HandlerActionType.SPEAK, t, {"content": "hi"}, {})
+        with patch.object(persistence, "add_thought", lambda t: t):
+            await dispatch(HandlerActionType.SPEAK, t, {"content": "hi"}, {})
         mock_handler.assert_awaited_once()
 
 @pytest.mark.asyncio
@@ -18,5 +20,6 @@ async def test_action_dispatcher_wrapper():
     dispatcher = ActionDispatcher()
     mock_handler = AsyncMock()
     with patch.dict(handler_map, {HandlerActionType.SPEAK: mock_handler}):
-        await dispatcher.dispatch(HandlerActionType.SPEAK, Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content=""), {"content": "hi"}, {})
-        mock_handler.assert_awaited_once()
+        with patch.object(persistence, "add_thought", lambda t: t):
+            await dispatcher.dispatch(HandlerActionType.SPEAK, Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content=""), {"content": "hi"}, {})
+            mock_handler.assert_awaited_once()

--- a/tests/core/test_defer_handler.py
+++ b/tests/core/test_defer_handler.py
@@ -5,7 +5,6 @@ from ciris_engine.core.action_handlers.defer_handler import handle_defer
 @pytest.mark.asyncio
 async def test_handle_defer():
     t = Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content="")
-    await handle_defer(t, {"reason": "r"})
+    new_thought = await handle_defer(t, {"reason": "r"})
     assert t.is_terminal
-    assert t.action_count == 1
-    assert t.history[0]["action"] == "defer"
+    assert new_thought.related_thought_id == t.thought_id

--- a/tests/core/test_memorize_handler.py
+++ b/tests/core/test_memorize_handler.py
@@ -12,7 +12,7 @@ async def test_handle_memorize():
     t = Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content="")
     mem = DummyMemory()
     params = {"user_nick": "bob", "channel": "c", "metadata": {"a": 1}}
-    await handle_memorize(t, params, mem)
+    new_thought = await handle_memorize(t, params, mem)
     mem.memorize.assert_awaited_with("bob", "c", {"a": 1})
-    assert t.action_count == 1
-    assert t.history[0]["action"] == "memorize"
+    assert new_thought.source_task_id == t.source_task_id
+    assert new_thought.related_thought_id == t.thought_id

--- a/tests/core/test_observe_handler.py
+++ b/tests/core/test_observe_handler.py
@@ -11,7 +11,7 @@ class DummyObserver:
 async def test_handle_observe():
     t = Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content="")
     obs = DummyObserver()
-    await handle_observe(t, {"x": 1}, obs)
+    new_thought = await handle_observe(t, {"x": 1}, obs)
     obs.observe.assert_awaited_with({"x": 1})
-    assert t.action_count == 1
-    assert t.history[0]["action"] == "observe"
+    assert new_thought.source_task_id == t.source_task_id
+    assert new_thought.related_thought_id == t.thought_id

--- a/tests/core/test_speak_handler.py
+++ b/tests/core/test_speak_handler.py
@@ -12,7 +12,7 @@ class DummyDiscord:
 async def test_handle_speak():
     t = Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content="")
     svc = DummyDiscord()
-    await handle_speak(t, {"content": "hi", "target_channel": "c"}, svc)
+    new_thought = await handle_speak(t, {"content": "hi", "target_channel": "c"}, svc)
     assert svc.sent == [("c", "hi")]
-    assert t.action_count == 1
-    assert t.history[0]["action"] == "speak"
+    assert new_thought.source_task_id == t.source_task_id
+    assert new_thought.related_thought_id == t.thought_id

--- a/tests/core/test_task_complete_handler.py
+++ b/tests/core/test_task_complete_handler.py
@@ -5,7 +5,6 @@ from ciris_engine.core.action_handlers.task_complete_handler import handle_task_
 @pytest.mark.asyncio
 async def test_handle_task_complete():
     t = Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content="")
-    await handle_task_complete(t, {})
+    result = await handle_task_complete(t, {})
     assert t.is_terminal
-    assert t.action_count == 1
-    assert t.history[0]["action"] == "task_complete"
+    assert result is None

--- a/tests/core/test_tool_handler.py
+++ b/tests/core/test_tool_handler.py
@@ -11,7 +11,6 @@ class DummyTool:
 async def test_handle_tool():
     t = Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content="")
     tool = DummyTool()
-    await handle_tool(t, {"tool_name": "x", "arguments": {"a": 1}}, tool)
+    new_thought = await handle_tool(t, {"tool_name": "x", "arguments": {"a": 1}}, tool)
     tool.execute_tool.assert_awaited_with("x", {"a": 1})
-    assert t.action_count == 1
-    assert t.history[0]["action"] == "tool"
+    assert new_thought.related_thought_id == t.thought_id

--- a/tests/runtime/test_base_runtime.py
+++ b/tests/runtime/test_base_runtime.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -44,13 +45,15 @@ async def test_dream_action_filter_blocks(mocker):
 
     svc = DummySvc()
     runtime.dispatcher.register_service_handler("discord", svc)
-    await runtime.dispatcher.dispatch(HandlerActionType.SPEAK, Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content=""), {"content": "x"}, {"discord_service": svc})
+    with patch.object(persistence, "add_thought", lambda t: t):
+        await runtime.dispatcher.dispatch(HandlerActionType.SPEAK, Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content=""), {"content": "x"}, {"discord_service": svc})
     svc.send_message.assert_awaited_once()
 
     svc.send_message.reset_mock()
     runtime.dreaming = True
     runtime.dispatcher.action_filter = runtime._dream_action_filter
-    await runtime.dispatcher.dispatch(HandlerActionType.SPEAK, Thought(thought_id="t2", source_task_id="task", created_at="", updated_at="", round_created=0, content=""), {"content": "x"}, {"discord_service": svc})
+    with patch.object(persistence, "add_thought", lambda t: t):
+        await runtime.dispatcher.dispatch(HandlerActionType.SPEAK, Thought(thought_id="t2", source_task_id="task", created_at="", updated_at="", round_created=0, content=""), {"content": "x"}, {"discord_service": svc})
     svc.send_message.assert_not_awaited()
 
 @pytest.mark.asyncio

--- a/tests/services/test_discord_correction.py
+++ b/tests/services/test_discord_correction.py
@@ -1,0 +1,34 @@
+import os
+from types import SimpleNamespace
+from datetime import datetime, timezone
+
+import pytest
+
+from ciris_engine.services.discord_service import DiscordService
+from ciris_engine.core.action_dispatcher import ActionDispatcher
+from ciris_engine.core.agent_core_schemas import Task
+from ciris_engine.core import persistence
+
+@pytest.mark.asyncio
+async def test_create_correction_thought(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "x")
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", "1")
+
+    dispatcher = ActionDispatcher()
+    service = DiscordService(dispatcher)
+
+    added = {}
+    monkeypatch.setattr(persistence, "add_thought", lambda t: added.update({"thought": t}))
+    monkeypatch.setattr(persistence, "get_task_by_id", lambda tid: Task(task_id=tid, description="d", created_at="", updated_at=""))
+
+    msg = SimpleNamespace(
+        author=SimpleNamespace(id=2, name="wa"),
+        id=3,
+        content="fix",
+        created_at=datetime.now(timezone.utc),
+    )
+
+    new_th = service._create_correction_thought("task1", "th0", msg, None)
+    assert added["thought"].source_task_id == "task1"
+    assert added["thought"].related_thought_id == "th0"
+    assert new_th == added["thought"]


### PR DESCRIPTION
## Summary
- add `create_follow_up_thought` helper for lineage
- ensure action handlers return new Thoughts instead of mutating
- persist follow-up thoughts via `ActionDispatcher`
- extract WA correction helper in Discord service
- adjust tests for new behaviour and add correction test

## Testing
- `pytest -q`