### PR TITLE
Modular DMA pipeline execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The system is designed for modularity, allowing developers to create and integra
 
 ## Key Features
 
-*   **Modular DMA Pipeline:** A structured workflow for processing thoughts through multiple reasoning stages, managed by the `WorkflowCoordinator`.
+*   **Modular DMA Pipeline:** PDMA (ethical), CSDMA (common sense), and DSDMA (domain) run together for each thought. Once all three results are available, the `ActionSelectionPDMA` uses them to choose the next handler action. This flow is coordinated by the `WorkflowCoordinator`.
 *   **Agent Profiles:** Customizable YAML configurations (`ciris_profiles/`) that define an agent's behavior, DSDMA selection, permitted actions, and LLM prompting strategies for various DMAs.
 *   **Local Execution:** Designed to run locally, enabling edge-side reasoning.
 *   **LLM Integration:** Leverages Large Language Models (LLMs) via `instructor` for structured output from DMAs. Requires an OpenAI-compatible API.

--- a/ciris_engine/dma/dma_executor.py
+++ b/ciris_engine/dma/dma_executor.py
@@ -1,0 +1,46 @@
+import logging
+from typing import Any, Dict, Optional
+
+from .pdma import EthicalPDMAEvaluator
+from .csdma import CSDMAEvaluator
+from .dsdma_base import BaseDSDMA
+from .action_selection_pdma import ActionSelectionPDMAEvaluator
+from ..core.agent_processing_queue import ProcessingQueueItem
+from ..core.dma_results import (
+    EthicalPDMAResult,
+    CSDMAResult,
+    DSDMAResult,
+    ActionSelectionPDMAResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def run_pdma(
+    evaluator: EthicalPDMAEvaluator, thought: ProcessingQueueItem
+) -> EthicalPDMAResult:
+    """Run the Ethical PDMA for the given thought."""
+    return await evaluator.evaluate(thought)
+
+
+async def run_csdma(
+    evaluator: CSDMAEvaluator, thought: ProcessingQueueItem
+) -> CSDMAResult:
+    """Run the CSDMA for the given thought."""
+    return await evaluator.evaluate_thought(thought)
+
+
+async def run_dsdma(
+    dsdma: BaseDSDMA,
+    thought: ProcessingQueueItem,
+    context: Optional[Dict[str, Any]] = None,
+) -> DSDMAResult:
+    """Run the domain-specific DMA using profile-driven configuration."""
+    return await dsdma.evaluate_thought(thought, context or {})
+
+
+async def run_action_selection_pdma(
+    evaluator: ActionSelectionPDMAEvaluator, triaged_inputs: Dict[str, Any]
+) -> ActionSelectionPDMAResult:
+    """Select the next handler action using the triaged DMA results."""
+    return await evaluator.evaluate(triaged_inputs=triaged_inputs)


### PR DESCRIPTION
## Summary
- add `dma_executor` module with simple async helpers for each DMA
- run PDMA, CSDMA and DSDMA via helpers before invoking ASPDMA
- document the new pipeline in the README
- extend WorkflowCoordinator tests to cover DSDMA execution

## Testing
- `pytest -q`