### PR TITLE
Implement DMA retry escalation

### DIFF
--- a/ciris_engine/dma/dma_executor.py
+++ b/ciris_engine/dma/dma_executor.py
@@ -1,5 +1,9 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Callable, Awaitable
+
+from ..core.thought_escalation import escalate_dma_failure
+from ..core.agent_core_schemas import Thought
+from ..core.agent_processing_queue import ProcessingQueueItem
 
 from .pdma import EthicalPDMAEvaluator
 from .csdma import CSDMAEvaluator
@@ -14,6 +18,44 @@ from ..core.dma_results import (
 )
 
 logger = logging.getLogger(__name__)
+
+DMA_RETRY_LIMIT = 3
+
+
+async def run_dma_with_retries(
+    run_fn: Callable[..., Awaitable[Any]],
+    *args: Any,
+    retry_limit: int = DMA_RETRY_LIMIT,
+    **kwargs: Any,
+) -> Any:
+    """Run a DMA function with retry logic."""
+    attempt = 0
+    last_error: Optional[Exception] = None
+    while attempt < retry_limit:
+        try:
+            return await run_fn(*args, **kwargs)
+        except Exception as e:  # noqa: BLE001
+            last_error = e
+            attempt += 1
+            logger.warning(
+                "DMA %s attempt %s failed: %s", run_fn.__name__, attempt, e
+            )
+
+    thought_arg = next(
+        (
+            arg
+            for arg in args
+            if isinstance(arg, (Thought, ProcessingQueueItem))
+        ),
+        None,
+    )
+
+    if thought_arg is not None:
+        return escalate_dma_failure(
+            thought_arg, run_fn.__name__, last_error, retry_limit
+        )
+
+    raise last_error if last_error else RuntimeError("DMA failure")
 
 
 async def run_pdma(

--- a/tests/dma/test_dma_retry.py
+++ b/tests/dma/test_dma_retry.py
@@ -1,0 +1,53 @@
+import uuid
+from datetime import datetime, timezone
+import pytest
+
+from ciris_engine.core.agent_core_schemas import Thought, ThoughtStatus
+from ciris_engine.dma.dma_executor import run_dma_with_retries
+
+
+def make_thought() -> Thought:
+    now = datetime.now(timezone.utc).isoformat()
+    return Thought(
+        thought_id=str(uuid.uuid4()),
+        source_task_id="task1",
+        thought_type="seed",
+        status=ThoughtStatus.PENDING,
+        created_at=now,
+        updated_at=now,
+        round_created=0,
+        content="test",
+        priority=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_dma_with_retries_success_after_retries():
+    thought = make_thought()
+    call_count = {"n": 0}
+
+    async def sometimes_fail(t):
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise Exception("boom")
+        return "ok"
+
+    result = await run_dma_with_retries(sometimes_fail, thought, retry_limit=3)
+    assert result == "ok"
+    assert call_count["n"] == 3
+    assert thought.escalations == []
+
+
+@pytest.mark.asyncio
+async def test_run_dma_with_retries_escalates_after_limit():
+    thought = make_thought()
+
+    async def always_fail(t):
+        raise Exception("fail")
+
+    result = await run_dma_with_retries(always_fail, thought, retry_limit=2)
+    assert result is thought
+    assert thought.status == ThoughtStatus.DEFERRED
+    assert len(thought.escalations) == 1
+    assert thought.escalations[0]["type"] == "dma_failure"
+


### PR DESCRIPTION
## Summary
- add DMA retry wrapper and escalation hook
- defer thought and escalate on repeated DMA failures
- update workflow to use retry logic
- cover retry logic with new tests
- adjust existing workflow coordinator tests for new behavior

## Testing
- `pytest -q`