### PR TITLE
Cleanup comments and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The core of CIRIS Engine is its ability to process "thoughts" (inputs or interna
 *   **Ethical PDMA (Principled Decision-Making Algorithm):** Evaluates the ethical implications of a thought.
 *   **CSDMA (Common Sense DMA):** Assesses the common-sense plausibility and clarity of a thought.
 *   **DSDMA (Domain-Specific DMA):** Applies domain-specific knowledge and heuristics. Different DSDMAs can be created for various specialized tasks or agent roles (e.g., `StudentDSDMA`, `BasicTeacherDSDMA`).
-*   **ActionSelectionPDMA:** Determines the final action an agent should take based on the outputs of the preceding DMAs and the agent's current state.
+*   **ASPDMA (Action‑Selection PDMA):** Determines the final action an agent should take based on the outputs of the preceding DMAs and the agent's current state.
 
 Actions chosen by the PDMA are routed through an `ActionDispatcher`. Memory operations use `DiscordGraphMemory` for persistence.
 
@@ -28,11 +28,13 @@ The system is designed for modularity, allowing developers to create and integra
 
 ## Key Features
 
-*   **Modular DMA Pipeline:** PDMA (ethical), CSDMA (common sense), and DSDMA (domain) run together for each thought. Once all three results are available, the `ActionSelectionPDMA` uses them to choose the next handler action. This flow is coordinated by the `WorkflowCoordinator`.
+*   **Four‑DMA Pipeline:** PDMA (ethical), CSDMA (common sense), DSDMA (domain) and ASPDMA (action selection) run sequentially for each thought. The ASPDMA chooses the next handler action using the outputs of the preceding DMAs. This flow is coordinated by the `WorkflowCoordinator`.
 *   **Agent Profiles:** Customizable YAML configurations (`ciris_profiles/`) that define an agent's behavior, DSDMA selection, permitted actions, and LLM prompting strategies for various DMAs.
 *   **Local Execution:** Designed to run locally, enabling edge-side reasoning.
 *   **LLM Integration:** Leverages Large Language Models (LLMs) via `instructor` for structured output from DMAs. Requires an OpenAI-compatible API.
 *   **Thought Processing & Pondering:** Agents may "ponder" repeatedly. The `WorkflowCoordinator` tracks ponder rounds and automatically defers once a configured limit is hit.
+*   **DMA Retry & Escalation:** Each DMA invocation is retried on transient errors. Repeated failures generate an escalation to the Wise Authority.
+*   **Profile‑Driven Actions:** Allowed handler actions are loaded from the active profile and passed dynamically to the ASPDMA.
 *   **Basic Guardrails:** Includes an ethical guardrail to check action outputs.
 *   **SQLite Persistence:** Uses SQLite for persisting tasks and thoughts.
 *   **Graph Memory:** MEMORIZE actions store user metadata in `DiscordGraphMemory`. REMEMBER and FORGET exist but are often disabled via profiles during testing.
@@ -73,7 +75,7 @@ These actions are processed by matching handlers within the engine. Profiles typ
 ## Core Components (in `ciris_engine/`)
 
 *   `core/`: Contains data schemas (`config_schemas.py`, `agent_core_schemas.py`, `foundational_schemas.py`), configuration management (`config_manager.py`), the `AgentProcessor`, `WorkflowCoordinator`, `ActionDispatcher`, and persistence layer (`persistence.py`).
-*   `dma/`: Implementations of the various DMAs (EthicalPDMA, CSDMA, DSDMA, ActionSelectionPDMA).
+*   `dma/`: Implementations of the various DMAs (EthicalPDMA, CSDMA, DSDMA, ASPDMA).
 *   `utils/`: Utility helpers like `logging_config.py` and an asynchronous `load_profile` function in `profile_loader.py` (remember to `await` it).
 *   `guardrails/`: Ethical guardrail implementation.
 *   `services/`: LLM client abstractions (`llm_client.py`, `llm_service.py`) and service integrations like `discord_service.py`.

--- a/ciris_engine/core/agent_processor.py
+++ b/ciris_engine/core/agent_processor.py
@@ -7,13 +7,13 @@ from datetime import datetime, timezone
 
 from .config_schemas import AppConfig
 from .workflow_coordinator import WorkflowCoordinator
-from .action_dispatcher import ActionDispatcher # Added import
-from .agent_core_schemas import Task, Thought # <-- Remove ThoughtType import
-from .foundational_schemas import TaskStatus, ThoughtStatus, HandlerActionType # Added HandlerActionType
+from .action_dispatcher import ActionDispatcher
+from .agent_core_schemas import Task, Thought
+from .foundational_schemas import TaskStatus, ThoughtStatus, HandlerActionType
 from .agent_processing_queue import ProcessingQueueItem
 from . import persistence
 
-logger = logging.getLogger(__name__) # Define logger at module level
+logger = logging.getLogger(__name__)
 
 WAKEUP_SEQUENCE = [
     (

--- a/ciris_engine/core/workflow_coordinator.py
+++ b/ciris_engine/core/workflow_coordinator.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
     from ciris_engine.utils import GraphQLContextProvider
 
-# MAX_PONDER_ROUNDS = 5 # REMOVED Constant - will use config
 
 class WorkflowCoordinator:
     """
@@ -38,14 +37,14 @@ class WorkflowCoordinator:
                  llm_client: CIRISLLMClient, # This LLM client MUST support async operations
                  ethical_pdma_evaluator: EthicalPDMAEvaluator,
                  csdma_evaluator: CSDMAEvaluator,
-                 action_selection_pdma_evaluator: ActionSelectionPDMAEvaluator, # Corrected type
+                 action_selection_pdma_evaluator: ActionSelectionPDMAEvaluator,
                  ethical_guardrails: EthicalGuardrails,
-                 app_config: AppConfig, # Corrected type hint to AppConfig
-                 # thought_queue_manager: ThoughtQueueManager, # <-- REMOVE THIS
+                 app_config: AppConfig,
+                 # thought_queue_manager: ThoughtQueueManager,
                  dsdma_evaluators: Optional[Dict[str, 'BaseDSDMA']] = None, # Use string literal for forward reference
                  memory_service: Optional['DiscordGraphMemory'] = None,
                  graphql_context_provider: Optional['GraphQLContextProvider'] = None,
-                 # current_round_number: int = 0 # REMOVED from parameters
+                 # current_round_number: int = 0
                 ):
         self.llm_client = llm_client
         self.ethical_pdma_evaluator = ethical_pdma_evaluator
@@ -58,10 +57,10 @@ class WorkflowCoordinator:
             enable_remote_graphql=app_config.enable_remote_graphql,
         )
         self.ethical_guardrails = ethical_guardrails
-        self.app_config = app_config # Store full AppConfig
-        self.workflow_config = app_config.workflow # Store workflow_config part
-        self.max_ponder_rounds = self.workflow_config.max_ponder_rounds # Store specific value
-        # self.thought_queue_manager = thought_queue_manager # <-- REMOVE THIS
+        self.app_config = app_config
+        self.workflow_config = app_config.workflow
+        self.max_ponder_rounds = self.workflow_config.max_ponder_rounds
+        # self.thought_queue_manager = thought_queue_manager
         self.current_round_number = 0 # Initialize internally
 
     def advance_round(self):

--- a/ciris_engine/dma/action_selection_pdma.py
+++ b/ciris_engine/dma/action_selection_pdma.py
@@ -1,13 +1,12 @@
-from typing import Dict, Any, Optional, List, Union  # Ensure Union, List, Dict are imported
+from typing import Dict, Any, Optional, List, Union
 import logging
 
 import instructor
 from openai import AsyncOpenAI
 
-# Corrected imports
-from ciris_engine.core.agent_processing_queue import ProcessingQueueItem # Though 'Thought' model is used internally
+from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
 from ciris_engine.core.agent_core_schemas import (
-    Thought,  # Assuming Thought model is passed in triaged_inputs
+    Thought,
     HandlerActionType,
     CIRISSchemaVersion,
 )
@@ -28,10 +27,9 @@ from ciris_engine.core.action_params import (
     RememberParams,
     ForgetParams,
 )
-from ciris_engine.core.foundational_schemas import HandlerActionType as CoreHandlerActionType # Alias to avoid conflict if any
-from ciris_engine.core.config_schemas import DEFAULT_OPENAI_MODEL_NAME # Corrected import
+from ciris_engine.core.foundational_schemas import HandlerActionType as CoreHandlerActionType
+from ciris_engine.core.config_schemas import DEFAULT_OPENAI_MODEL_NAME
 from instructor.exceptions import InstructorRetryException
-import instructor # Import the main instructor module for Mode
 from ciris_engine.utils import DEFAULT_WA, ENGINE_OVERVIEW_TEMPLATE
 from pydantic import BaseModel, Field, ValidationError
 

--- a/ciris_engine/dma/csdma.py
+++ b/ciris_engine/dma/csdma.py
@@ -1,20 +1,13 @@
-# src/ciris_engine/dma/csdma.py
 from typing import Dict, Any, List, Optional
 import logging
 
 import instructor
-# from instructor import Mode as InstructorMode # REMOVE Mode import -> Removed
 from openai import AsyncOpenAI
-
-# Updated imports based on current project structure
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
 from ciris_engine.core.dma_results import CSDMAResult
-from ciris_engine.core.config_manager import get_config # To access global config
-# Import InstructorRetryException for specific error handling
+from ciris_engine.core.config_manager import get_config
 from instructor.exceptions import InstructorRetryException
-import instructor # For instructor.Mode
 
-# Setup logger for this module
 logger = logging.getLogger(__name__)
 
 class CSDMAEvaluator:

--- a/ciris_engine/dma/pdma.py
+++ b/ciris_engine/dma/pdma.py
@@ -1,15 +1,12 @@
 import logging
-# import os # Not needed directly here if client handles keys
-from typing import Dict, Any, Optional, Union # Added Union
+from typing import Dict, Any, Optional, Union
 
 import instructor
-from openai import AsyncOpenAI # Needed for type hinting raw client
+from openai import AsyncOpenAI
 
-# Adjusted import paths
-from ciris_engine.core.agent_processing_queue import ProcessingQueueItem  # Renamed from ThoughtQueueItem
+from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
 from ciris_engine.core.dma_results import EthicalPDMAResult
-# from ciris_engine.core.config import DEFAULT_OPENAI_MODEL_NAME # Get from config or define
-DEFAULT_OPENAI_MODEL_NAME = "gpt-4o" # Default model from OpenAIConfig
+DEFAULT_OPENAI_MODEL_NAME = "gpt-4o"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- tidy imports and remove leftover comments from DMA modules
- clean up agent processor and workflow coordinator
- document four-DMA pipeline and retry logic

## Testing
- `pytest -q`