### PR TITLE
Refactor WorkflowCoordinator to use DMA executor

### DIFF
--- a/ciris_engine/core/action_tracker.py
+++ b/ciris_engine/core/action_tracker.py
@@ -1,0 +1,15 @@
+from datetime import datetime, timezone
+from typing import Any
+
+from .agent_core_schemas import Thought, HandlerActionType
+
+
+def track_action(thought: Thought, action: HandlerActionType, parameters: Any) -> None:
+    """Record the selected action on the thought history and increment count."""
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "action": action.value,
+        "parameters": parameters.model_dump() if hasattr(parameters, "model_dump") else parameters,
+    }
+    thought.history.append(entry)
+    thought.action_count += 1

--- a/ciris_engine/core/config_schemas.py
+++ b/ciris_engine/core/config_schemas.py
@@ -23,6 +23,8 @@ DEFAULT_OPENAI_TIMEOUT_SECONDS = 60.0
 DEFAULT_OPENAI_MAX_RETRIES = 2
 DEFAULT_ENTROPY_THRESHOLD = 0.40
 DEFAULT_COHERENCE_THRESHOLD = 0.80
+# Default retry limit for DMAs
+DMA_RETRY_LIMIT = 3
 # Default priorities are already in agent_core_schemas.py for Task and Thought.
 # If they need to be *dynamically configurable* by wise authorities,
 # they can be included in WorkflowConfig.

--- a/ciris_engine/core/dma_executor.py
+++ b/ciris_engine/core/dma_executor.py
@@ -1,0 +1,103 @@
+import logging
+from typing import Any, Dict, Optional, Callable, Awaitable
+
+from .thought_escalation import escalate_dma_failure
+from .agent_core_schemas import Thought
+from .agent_processing_queue import ProcessingQueueItem
+from .dma_results import (
+    EthicalPDMAResult,
+    CSDMAResult,
+    DSDMAResult,
+    ActionSelectionPDMAResult,
+)
+from .config_schemas import DMA_RETRY_LIMIT
+
+from ..dma.pdma import EthicalPDMAEvaluator
+from ..dma.csdma import CSDMAEvaluator
+from ..dma.dsdma_base import BaseDSDMA
+from ..dma.action_selection_pdma import ActionSelectionPDMAEvaluator
+
+logger = logging.getLogger(__name__)
+
+
+async def run_dma_with_retries(
+    run_fn: Callable[..., Awaitable[Any]],
+    *args: Any,
+    retry_limit: int = DMA_RETRY_LIMIT,
+    **kwargs: Any,
+) -> Any:
+    """Run a DMA function with simple retry logic."""
+    attempt = 0
+    last_error: Optional[Exception] = None
+    while attempt < retry_limit:
+        try:
+            return await run_fn(*args, **kwargs)
+        except Exception as e:  # noqa: BLE001
+            last_error = e
+            attempt += 1
+            logger.warning(
+                "DMA %s attempt %s failed: %s", run_fn.__name__, attempt, e
+            )
+
+    thought_arg = next(
+        (
+            arg
+            for arg in args
+            if isinstance(arg, (Thought, ProcessingQueueItem))
+        ),
+        None,
+    )
+
+    if thought_arg is not None:
+        return escalate_dma_failure(
+            thought_arg, run_fn.__name__, last_error, retry_limit
+        )
+
+    raise last_error if last_error else RuntimeError("DMA failure")
+
+
+async def run_pdma(
+    evaluator: EthicalPDMAEvaluator,
+    thought: ProcessingQueueItem,
+    *,
+    retry_limit: int = DMA_RETRY_LIMIT,
+) -> EthicalPDMAResult:
+    """Run the Ethical PDMA for the given thought with retries."""
+    return await run_dma_with_retries(evaluator.evaluate, thought, retry_limit=retry_limit)
+
+
+async def run_csdma(
+    evaluator: CSDMAEvaluator,
+    thought: ProcessingQueueItem,
+    *,
+    retry_limit: int = DMA_RETRY_LIMIT,
+) -> CSDMAResult:
+    """Run the CSDMA for the given thought with retries."""
+    return await run_dma_with_retries(
+        evaluator.evaluate_thought, thought, retry_limit=retry_limit
+    )
+
+
+async def run_dsdma(
+    dsdma: BaseDSDMA,
+    thought: ProcessingQueueItem,
+    context: Optional[Dict[str, Any]] = None,
+    *,
+    retry_limit: int = DMA_RETRY_LIMIT,
+) -> DSDMAResult:
+    """Run the domain-specific DMA with retries."""
+    return await run_dma_with_retries(
+        dsdma.evaluate_thought, thought, context or {}, retry_limit=retry_limit
+    )
+
+
+async def run_action_selection_pdma(
+    evaluator: ActionSelectionPDMAEvaluator,
+    triaged_inputs: Dict[str, Any],
+    *,
+    retry_limit: int = DMA_RETRY_LIMIT,
+) -> ActionSelectionPDMAResult:
+    """Select the next handler action using the triaged DMA results."""
+    return await run_dma_with_retries(
+        evaluator.evaluate, triaged_inputs=triaged_inputs, retry_limit=retry_limit
+    )

--- a/ciris_engine/core/workflow_coordinator.py
+++ b/ciris_engine/core/workflow_coordinator.py
@@ -10,11 +10,14 @@ from .agent_processing_queue import ProcessingQueueItem
 from .config_schemas import AppConfig, WorkflowConfig # Import AppConfig and WorkflowConfig
 from . import persistence # Import persistence module
 from ciris_engine.services.llm_client import CIRISLLMClient # Assume this will have an async call_llm
-# Direct imports for DMA evaluators to avoid circular dependencies
-from ciris_engine.dma.pdma import EthicalPDMAEvaluator
-from ciris_engine.dma.csdma import CSDMAEvaluator
-# from ciris_engine.dma.dsdma_base import BaseDSDMA # For type hinting - moved to TYPE_CHECKING
-from ciris_engine.dma.action_selection_pdma import ActionSelectionPDMAEvaluator
+from ciris_engine.core.dma_executor import (
+    run_pdma,
+    run_csdma,
+    run_dsdma,
+    run_action_selection_pdma,
+)
+from ciris_engine.core.config_schemas import DMA_RETRY_LIMIT
+from ciris_engine.core.action_tracker import track_action
 from ciris_engine.guardrails import EthicalGuardrails
 from ciris_engine.utils import DEFAULT_WA
 from ciris_engine.utils import GraphQLContextProvider
@@ -24,6 +27,9 @@ if TYPE_CHECKING:
     from ciris_engine.dma.dsdma_base import BaseDSDMA # Import only for type checking
     from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
     from ciris_engine.utils import GraphQLContextProvider
+    from ciris_engine.dma.pdma import EthicalPDMAEvaluator
+    from ciris_engine.dma.csdma import CSDMAEvaluator
+    from ciris_engine.dma.action_selection_pdma import ActionSelectionPDMAEvaluator
 
 
 class WorkflowCoordinator:
@@ -35,9 +41,9 @@ class WorkflowCoordinator:
 
     def __init__(self,
                  llm_client: CIRISLLMClient, # This LLM client MUST support async operations
-                 ethical_pdma_evaluator: EthicalPDMAEvaluator,
-                 csdma_evaluator: CSDMAEvaluator,
-                 action_selection_pdma_evaluator: ActionSelectionPDMAEvaluator,
+                 ethical_pdma_evaluator: 'EthicalPDMAEvaluator',
+                 csdma_evaluator: 'CSDMAEvaluator',
+                 action_selection_pdma_evaluator: 'ActionSelectionPDMAEvaluator',
                  ethical_guardrails: EthicalGuardrails,
                  app_config: AppConfig,
                  # thought_queue_manager: ThoughtQueueManager,
@@ -131,21 +137,14 @@ class WorkflowCoordinator:
 
         # 1. Ethical PDMA Task
         logging.debug(f"Scheduling Ethical PDMA for thought ID {thought_object.thought_id}") # Use thought_object
-        from ciris_engine.dma.dma_executor import (
-            run_pdma,
-            run_csdma,
-            run_dsdma,
-            run_dma_with_retries,
-        )
-
         initial_dma_tasks.append(
-            run_dma_with_retries(run_pdma, self.ethical_pdma_evaluator, thought_object)
+            run_pdma(self.ethical_pdma_evaluator, thought_object, retry_limit=DMA_RETRY_LIMIT)
         )
 
         # 2. CSDMA Task
         logging.debug(f"Scheduling CSDMA for thought ID {thought_object.thought_id}") # Use thought_object
         initial_dma_tasks.append(
-            run_dma_with_retries(run_csdma, self.csdma_evaluator, thought_object)
+            run_csdma(self.csdma_evaluator, thought_object, retry_limit=DMA_RETRY_LIMIT)
         )
 
         # 3. DSDMA Task (select and run if applicable)
@@ -174,8 +173,11 @@ class WorkflowCoordinator:
                     f"Scheduling DSDMA '{active_dsdma.domain_name}' (Profile: {active_profile_name_for_dsdma}) for thought ID {thought_object.thought_id}"
                 )
                 initial_dma_tasks.append(
-                    run_dma_with_retries(
-                        run_dsdma, active_dsdma, thought_object, current_platform_context
+                    run_dsdma(
+                        active_dsdma,
+                        thought_object,
+                        current_platform_context,
+                        retry_limit=DMA_RETRY_LIMIT,
                     )
                 )
                 selected_dsdma_instance = active_dsdma
@@ -326,11 +328,10 @@ class WorkflowCoordinator:
             "agent_profile": active_profile_for_as # Pass the determined agent profile object
         }
 
-        from ciris_engine.dma.dma_executor import run_action_selection_pdma
-
         action_selection_result: ActionSelectionPDMAResult = await run_action_selection_pdma(
             self.action_selection_pdma_evaluator,
             triaged_inputs_for_action_selection,
+            retry_limit=DMA_RETRY_LIMIT,
         )
         # Log action_parameters carefully, as it can be a Pydantic model
         logging.info(f"Action Selection PDMA chose: {action_selection_result.selected_handler_action.value} with params {str(action_selection_result.action_parameters)}")
@@ -509,6 +510,11 @@ class WorkflowCoordinator:
         
         # For all other actions OR if PONDER re-queue failed and returned the Ponder action
         if final_action_result: # This means it's a terminal action for this processing cycle
+            track_action(
+                thought_object,
+                final_action_result.selected_handler_action,
+                final_action_result.action_parameters,
+            )
             success = persistence.update_thought_status(
                 thought_id=thought_object.thought_id,
                 new_status=ThoughtStatus.COMPLETED, # Or FAILED/DEFERRED if set by dispatcher

--- a/tests/core/test_workflow_coordinator.py
+++ b/tests/core/test_workflow_coordinator.py
@@ -5,6 +5,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from ciris_engine.core.workflow_coordinator import WorkflowCoordinator
+import ciris_engine.core.workflow_coordinator as wc_module
+from ciris_engine.core.thought_escalation import escalate_dma_failure
+from ciris_engine.core.config_schemas import DMA_RETRY_LIMIT
 from ciris_engine.core.agent_core_schemas import (
     Thought,
     ActionSelectionPDMAResult,
@@ -67,6 +70,26 @@ async def memory_service(tmp_path: Path):
     await service.start()
     yield service
 
+
+@pytest.fixture
+def dma_executor_patches(monkeypatch):
+    pdma = AsyncMock()
+    csdma = AsyncMock()
+    dsdma = AsyncMock()
+    asp = AsyncMock()
+    monkeypatch.setattr(wc_module, "run_pdma", pdma)
+    monkeypatch.setattr(wc_module, "run_csdma", csdma)
+    monkeypatch.setattr(wc_module, "run_dsdma", dsdma)
+    monkeypatch.setattr(wc_module, "run_action_selection_pdma", asp)
+    return pdma, csdma, dsdma, asp
+
+
+@pytest.fixture
+def track_action_patch(monkeypatch):
+    tracker = MagicMock()
+    monkeypatch.setattr(wc_module, "track_action", tracker)
+    return tracker
+
 @pytest.fixture
 def mock_dsdma_evaluators_dict():
     # For simplicity, start with an empty dict or a basic mock if needed
@@ -108,7 +131,9 @@ def workflow_coordinator_instance(
 async def test_memory_meta_thought(
     mock_persistence,
     workflow_coordinator_instance: WorkflowCoordinator,
-    memory_service: DiscordGraphMemory
+    memory_service: DiscordGraphMemory,
+    dma_executor_patches,
+    track_action_patch,
 ):
     now = datetime.now(timezone.utc).isoformat()
     thought = Thought(
@@ -127,6 +152,19 @@ async def test_memory_meta_thought(
     mock_persistence.get_thought_by_id.return_value = thought
     mock_persistence.update_thought_status = MagicMock(return_value=True)
 
+    pdma_mock, csdma_mock, dsdma_mock, asp_mock = dma_executor_patches
+    pdma_mock.return_value = EthicalPDMAResult(context="c", alignment_check={}, decision="d", monitoring={})
+    csdma_mock.return_value = CSDMAResult(common_sense_plausibility_score=1.0, flags=[], reasoning="ok")
+    dsdma_mock.return_value = None
+    asp_mock.return_value = ActionSelectionPDMAResult(
+        context_summary_for_action_selection="s",
+        action_alignment_check={},
+        selected_handler_action=HandlerActionType.SPEAK,
+        action_parameters={"content": "hi"},
+        action_selection_rationale="r",
+        monitoring_for_selected_action={"s": "1"},
+    )
+
     mem_mock = AsyncMock()
     memory_service.memorize = mem_mock
 
@@ -134,6 +172,7 @@ async def test_memory_meta_thought(
 
     assert result is not None
     mem_mock.assert_not_awaited()
+    track_action_patch.assert_called_once()
 
 @pytest.fixture
 def sample_thought():
@@ -175,7 +214,9 @@ async def test_process_thought_successful_run(
     mock_ethical_pdma_evaluator: MagicMock,
     mock_csdma_evaluator: MagicMock,
     mock_action_selection_pdma_evaluator: MagicMock,
-    mock_ethical_guardrails: MagicMock
+    mock_ethical_guardrails: MagicMock,
+    dma_executor_patches,
+    track_action_patch,
 ):
     """Test a successful run of process_thought."""
     mock_persistence.get_thought_by_id = MagicMock(return_value=sample_thought)
@@ -183,18 +224,20 @@ async def test_process_thought_successful_run(
 
     # Mock DMA results
     # Ensure mocked results are instances of the actual Pydantic models or spec'd MagicMocks with all required fields
-    mock_ethical_pdma_evaluator.evaluate.return_value = EthicalPDMAResult(
+    pdma_mock, csdma_mock, dsdma_mock, asp_mock = dma_executor_patches
+    pdma_mock.return_value = EthicalPDMAResult(
         context="Mocked ethical context",
         alignment_check={"principle1": "aligned"},
         decision="Ethical decision: Proceed",
-        monitoring={"metrics": "engagement"}
+        monitoring={"metrics": "engagement"},
     )
-    mock_csdma_evaluator.evaluate_thought.return_value = CSDMAResult(
+    csdma_mock.return_value = CSDMAResult(
         common_sense_plausibility_score=0.9,
         flags=[],
-        reasoning="Looks plausible"
+        reasoning="Looks plausible",
     )
-    
+    dsdma_mock.return_value = None
+
     action_selection_result = ActionSelectionPDMAResult(
         context_summary_for_action_selection="summary",
         action_alignment_check={},
@@ -203,17 +246,23 @@ async def test_process_thought_successful_run(
         action_selection_rationale="rationale",
         monitoring_for_selected_action={"status": "Test monitoring status"} # Ensure this field is present
     )
-    mock_action_selection_pdma_evaluator.evaluate.return_value = action_selection_result
+    asp_mock.return_value = action_selection_result
 
     result = await workflow_coordinator_instance.process_thought(sample_processing_queue_item)
 
     assert result is not None
     assert result.selected_handler_action == HandlerActionType.SPEAK
     mock_persistence.get_thought_by_id.assert_called_once_with(sample_processing_queue_item.thought_id)
-    mock_ethical_pdma_evaluator.evaluate.assert_called_once()
-    mock_csdma_evaluator.evaluate_thought.assert_called_once()
-    mock_action_selection_pdma_evaluator.evaluate.assert_called_once()
+    pdma_mock.assert_called_once()
+    csdma_mock.assert_called_once()
+    asp_mock.assert_called_once()
     mock_ethical_guardrails.check_action_output_safety.assert_called_once()
+
+    track_action_patch.assert_called_once_with(
+        sample_thought,
+        HandlerActionType.SPEAK,
+        action_selection_result.action_parameters,
+    )
     
     # Check that thought status is updated to COMPLETED
     update_calls = mock_persistence.update_thought_status.call_args_list
@@ -233,24 +282,28 @@ async def test_process_thought_guardrail_failure(
     mock_ethical_pdma_evaluator: MagicMock,
     mock_csdma_evaluator: MagicMock,
     mock_action_selection_pdma_evaluator: MagicMock,
-    mock_ethical_guardrails: MagicMock
+    mock_ethical_guardrails: MagicMock,
+    dma_executor_patches,
+    track_action_patch,
 ):
     """Test process_thought when ethical guardrail fails."""
     mock_persistence.get_thought_by_id = MagicMock(return_value=sample_thought)
     mock_persistence.update_thought_status = MagicMock(return_value=True)
 
-    mock_ethical_pdma_evaluator.evaluate.return_value = EthicalPDMAResult(
+    pdma_mock, csdma_mock, dsdma_mock, asp_mock = dma_executor_patches
+    pdma_mock.return_value = EthicalPDMAResult(
         context="Mocked ethical context for guardrail test",
         alignment_check={"principle1": "aligned"},
         decision="Ethical decision: Proceed (risky)",
-        monitoring={"metrics": "engagement"}
+        monitoring={"metrics": "engagement"},
     )
-    mock_csdma_evaluator.evaluate_thought.return_value = CSDMAResult(
+    csdma_mock.return_value = CSDMAResult(
         common_sense_plausibility_score=0.9,
         flags=[],
-        reasoning="Looks plausible (risky)"
+        reasoning="Looks plausible (risky)",
     )
-    
+    dsdma_mock.return_value = None
+
     action_selection_result = ActionSelectionPDMAResult(
         context_summary_for_action_selection="summary",
         action_alignment_check={},
@@ -259,7 +312,7 @@ async def test_process_thought_guardrail_failure(
         action_selection_rationale="rationale",
         monitoring_for_selected_action={"status": "Test monitoring status for risky content"} # Ensure this field is present
     )
-    mock_action_selection_pdma_evaluator.evaluate.return_value = action_selection_result
+    asp_mock.return_value = action_selection_result
     mock_ethical_guardrails.check_action_output_safety.return_value = (False, "Guardrail failed", {}) # Guardrail fails
 
     result = await workflow_coordinator_instance.process_thought(sample_processing_queue_item)
@@ -269,6 +322,11 @@ async def test_process_thought_guardrail_failure(
     assert "Guardrail failed" in result.action_parameters.reason # Access the 'reason' attribute directly
     assert sample_thought.escalations
     assert sample_thought.escalations[0]["type"] == "guardrail_violation"
+    track_action_patch.assert_called_once_with(
+        sample_thought,
+        HandlerActionType.DEFER,
+        result.action_parameters,
+    )
 
 
 @pytest.mark.skip(reason="Failing with AttributeError: 'PonderParams' object has no attribute 'get' in SUT")
@@ -381,24 +439,26 @@ async def test_process_thought_dma_exception(
     workflow_coordinator_instance: WorkflowCoordinator,
     sample_processing_queue_item: ProcessingQueueItem,
     sample_thought: Thought,
-    mock_ethical_pdma_evaluator: MagicMock, # This one will raise an exception
-    mock_csdma_evaluator: MagicMock, # Mock other DMAs even if not strictly needed after exception
-    mock_action_selection_pdma_evaluator: MagicMock # Mock Action Selection PDMA
+    mock_ethical_pdma_evaluator: MagicMock,  # This one will raise an exception
+    mock_csdma_evaluator: MagicMock,
+    mock_action_selection_pdma_evaluator: MagicMock,
+    dma_executor_patches,
+    track_action_patch,
 ):
     """Test process_thought when a DMA evaluator raises an exception."""
     mock_persistence.get_thought_by_id = MagicMock(return_value=sample_thought)
     mock_persistence.update_thought_status = MagicMock(return_value=True)
 
     # Simulate Ethical PDMA raising an exception
-    mock_ethical_pdma_evaluator.evaluate.side_effect = Exception("Ethical PDMA Error")
-    
-    # Mock CSDMA to return a valid result (it might run concurrently before exception is handled)
-    mock_csdma_evaluator.evaluate_thought.return_value = CSDMAResult(
+    pdma_mock, csdma_mock, dsdma_mock, asp_mock = dma_executor_patches
+    pdma_mock.return_value = escalate_dma_failure(
+        sample_thought, "pdma", Exception("Ethical PDMA Error"), DMA_RETRY_LIMIT
+    )
+    csdma_mock.return_value = CSDMAResult(
         common_sense_plausibility_score=0.5, flags=[], reasoning="CSDMA ran"
     )
-
-    # ActionSelectionPDMA should not run when DMA fails repeatedly
-    mock_action_selection_pdma_evaluator.evaluate.reset_mock()
+    dsdma_mock.return_value = None
+    asp_mock.reset_mock()
 
 
     result = await workflow_coordinator_instance.process_thought(sample_processing_queue_item)
@@ -406,9 +466,10 @@ async def test_process_thought_dma_exception(
     assert result is not None
     assert result.selected_handler_action == HandlerActionType.DEFER
     assert "DMA failed" in result.action_parameters.reason
-    mock_action_selection_pdma_evaluator.evaluate.assert_not_called()
+    asp_mock.assert_not_called()
     assert sample_thought.escalations
     assert sample_thought.escalations[0]["type"] == "dma_failure"
+    track_action_patch.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -416,7 +477,8 @@ async def test_process_thought_dma_exception(
 async def test_process_thought_object_not_found(
     mock_persistence,
     workflow_coordinator_instance: WorkflowCoordinator,
-    sample_processing_queue_item: ProcessingQueueItem
+    sample_processing_queue_item: ProcessingQueueItem,
+    track_action_patch,
 ):
     """Test process_thought when the Thought object cannot be fetched from persistence."""
     mock_persistence.get_thought_by_id = MagicMock(return_value=None) # Simulate thought not found
@@ -430,6 +492,7 @@ async def test_process_thought_object_not_found(
     assert hasattr(result.action_parameters, 'reason'), "action_parameters object missing 'reason' attribute"
     assert f"Failed to retrieve thought object for ID {sample_processing_queue_item.thought_id}" in result.action_parameters.reason
     mock_persistence.update_thought_status.assert_not_called() # No status update if thought isn't processed
+    track_action_patch.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -444,6 +507,8 @@ async def test_process_thought_with_dsdma_success(
     mock_csdma_evaluator: MagicMock,
     mock_action_selection_pdma_evaluator: MagicMock,
     mock_ethical_guardrails: MagicMock,
+    dma_executor_patches,
+    track_action_patch,
 ):
     """Ensure PDMA, CSDMA, and DSDMA run and feed ActionSelectionPDMA."""
     workflow_coordinator_instance.dsdma_evaluators = mock_dsdma_evaluators_with_item
@@ -452,13 +517,13 @@ async def test_process_thought_with_dsdma_success(
     mock_persistence.get_thought_by_id = MagicMock(return_value=sample_thought)
     mock_persistence.update_thought_status = MagicMock(return_value=True)
 
+    pdma_mock, csdma_mock, dsdma_exec_mock, asp_mock = dma_executor_patches
     ethical_result = EthicalPDMAResult(context="ctx", alignment_check={}, decision="dec", monitoring={})
     cs_result = CSDMAResult(common_sense_plausibility_score=1.0, flags=[], reasoning="ok")
     dsdma_result = DSDMAResult(domain_name="Mock", domain_alignment_score=0.5, recommended_action=None, flags=[], reasoning="ok")
-
-    mock_ethical_pdma_evaluator.evaluate.return_value = ethical_result
-    mock_csdma_evaluator.evaluate_thought.return_value = cs_result
-    dsdma_mock.evaluate_thought.return_value = dsdma_result
+    pdma_mock.return_value = ethical_result
+    csdma_mock.return_value = cs_result
+    dsdma_exec_mock.return_value = dsdma_result
 
     asp_result = ActionSelectionPDMAResult(
         context_summary_for_action_selection="sum",
@@ -468,17 +533,22 @@ async def test_process_thought_with_dsdma_success(
         action_selection_rationale="r",
         monitoring_for_selected_action={"s": "1"},
     )
-    mock_action_selection_pdma_evaluator.evaluate.return_value = asp_result
+    asp_mock.return_value = asp_result
 
     result = await workflow_coordinator_instance.process_thought(sample_processing_queue_item)
 
     assert result.selected_handler_action == HandlerActionType.SPEAK
-    mock_ethical_pdma_evaluator.evaluate.assert_called_once()
-    mock_csdma_evaluator.evaluate_thought.assert_called_once()
-    dsdma_mock.evaluate_thought.assert_called_once()
-    mock_action_selection_pdma_evaluator.evaluate.assert_called_once()
-    triaged = mock_action_selection_pdma_evaluator.evaluate.call_args.kwargs["triaged_inputs"]
+    pdma_mock.assert_called_once()
+    csdma_mock.assert_called_once()
+    dsdma_exec_mock.assert_called_once()
+    asp_mock.assert_called_once()
+    triaged = asp_mock.call_args.args[1]
     assert triaged["dsdma_result"] is dsdma_result
+    track_action_patch.assert_called_once_with(
+        sample_thought,
+        HandlerActionType.SPEAK,
+        asp_result.action_parameters,
+    )
 
 
 @pytest.mark.asyncio
@@ -493,6 +563,8 @@ async def test_process_thought_dsdma_exception(
     mock_csdma_evaluator: MagicMock,
     mock_action_selection_pdma_evaluator: MagicMock,
     mock_ethical_guardrails: MagicMock,
+    dma_executor_patches,
+    track_action_patch,
 ):
     """If DSDMA fails repeatedly, the thought is deferred."""
     workflow_coordinator_instance.dsdma_evaluators = mock_dsdma_evaluators_with_item
@@ -501,12 +573,15 @@ async def test_process_thought_dsdma_exception(
     mock_persistence.get_thought_by_id = MagicMock(return_value=sample_thought)
     mock_persistence.update_thought_status = MagicMock(return_value=True)
 
+    pdma_mock, csdma_mock, dsdma_exec_mock, asp_mock = dma_executor_patches
     ethical_result = EthicalPDMAResult(context="ctx", alignment_check={}, decision="dec", monitoring={})
     cs_result = CSDMAResult(common_sense_plausibility_score=1.0, flags=[], reasoning="ok")
-
-    mock_ethical_pdma_evaluator.evaluate.return_value = ethical_result
-    mock_csdma_evaluator.evaluate_thought.return_value = cs_result
-    dsdma_mock.evaluate_thought.side_effect = Exception("fail")
+    pdma_mock.return_value = ethical_result
+    csdma_mock.return_value = cs_result
+    dsdma_exec_mock.return_value = escalate_dma_failure(
+        sample_thought, "dsdma", Exception("fail"), DMA_RETRY_LIMIT
+    )
+    asp_mock.reset_mock()
 
     asp_result = ActionSelectionPDMAResult(
         context_summary_for_action_selection="sum",
@@ -516,14 +591,13 @@ async def test_process_thought_dsdma_exception(
         action_selection_rationale="r",
         monitoring_for_selected_action={"s": "1"},
     )
-    mock_action_selection_pdma_evaluator.evaluate.reset_mock()
-
     result = await workflow_coordinator_instance.process_thought(sample_processing_queue_item)
 
     assert result.selected_handler_action == HandlerActionType.DEFER
-    mock_action_selection_pdma_evaluator.evaluate.assert_not_called()
+    asp_mock.assert_not_called()
     assert sample_thought.escalations
     assert sample_thought.escalations[0]["type"] == "dma_failure"
+    track_action_patch.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -537,19 +611,27 @@ async def test_process_thought_dma_failure_escalates(
     mock_csdma_evaluator: MagicMock,
     mock_action_selection_pdma_evaluator: MagicMock,
     mock_ethical_guardrails: MagicMock,
+    dma_executor_patches,
+    track_action_patch,
 ):
     """Ensure DMA failures stop ActionSelection and escalate."""
     mock_persistence.get_thought_by_id = MagicMock(return_value=sample_thought)
     mock_persistence.update_thought_status = MagicMock(return_value=True)
 
-    mock_ethical_pdma_evaluator.evaluate.side_effect = Exception("fail")
-    mock_csdma_evaluator.evaluate_thought.return_value = CSDMAResult(
+    pdma_mock, csdma_mock, dsdma_mock, asp_mock = dma_executor_patches
+    pdma_mock.return_value = escalate_dma_failure(
+        sample_thought, "pdma", Exception("fail"), DMA_RETRY_LIMIT
+    )
+    csdma_mock.return_value = CSDMAResult(
         common_sense_plausibility_score=0.9, flags=[], reasoning="ok"
     )
+    dsdma_mock.return_value = None
+    asp_mock.reset_mock()
 
     result = await workflow_coordinator_instance.process_thought(sample_processing_queue_item)
 
     assert result.selected_handler_action == HandlerActionType.DEFER
-    mock_action_selection_pdma_evaluator.evaluate.assert_not_called()
+    asp_mock.assert_not_called()
     assert sample_thought.escalations
     assert sample_thought.escalations[0]["type"] == "dma_failure"
+    track_action_patch.assert_not_called()


### PR DESCRIPTION
## Summary
- centralize DMA retry limit in `config_schemas.DMA_RETRY_LIMIT`
- add `action_tracker.track_action`
- provide new `core.dma_executor` wrapper with retry logic
- refactor `WorkflowCoordinator` to call new executor and track actions
- update coordinator tests for new executor and tracking

## Testing
- `pytest -q`