### PR TITLE
Refactor wakeup sequence to use child tasks

### DIFF
--- a/ciris_engine/core/thought_escalation.py
+++ b/ciris_engine/core/thought_escalation.py
@@ -13,6 +13,8 @@ __all__ = [
     "escalate_due_to_guardrail",
     "escalate_due_to_failure",
     "escalate_dma_failure",
+    "escalate_due_to_depth_limit",
+    "escalate_due_to_ponder_limit",
 ]
 
 
@@ -82,3 +84,28 @@ def escalate_dma_failure(
     }
     thought.status = ThoughtStatus.DEFERRED
     return _append_escalation(thought, event)
+
+
+def escalate_due_to_depth_limit(thought: Thought, max_depth: int) -> Thought:
+    """Escalate when a thought exceeds the allowed depth."""
+    now = datetime.now(timezone.utc).isoformat()
+    event = {
+        "timestamp": now,
+        "reason": f"Thought depth exceeded maximum of {max_depth}",
+        "type": "depth_limit",
+    }
+    thought.is_terminal = True
+    return _append_escalation(thought, event)
+
+
+def escalate_due_to_ponder_limit(thought: Thought, max_ponder: int) -> Thought:
+    """Escalate when a thought exceeds the allowed ponder count."""
+    now = datetime.now(timezone.utc).isoformat()
+    event = {
+        "timestamp": now,
+        "reason": f"Ponder count exceeded maximum of {max_ponder}",
+        "type": "ponder_limit",
+    }
+    thought.is_terminal = True
+    return _append_escalation(thought, event)
+

--- a/ciris_engine/utils/constants.py
+++ b/ciris_engine/utils/constants.py
@@ -19,3 +19,8 @@ ENGINE_OVERVIEW_TEMPLATE = (
     "no new Thought is generated."
 )
 
+# Depth and ponder safeguards
+MAX_THOUGHT_DEPTH = 7
+MAX_PONDER_COUNT = 7
+
+

--- a/tests/core/test_thought_escalation.py
+++ b/tests/core/test_thought_escalation.py
@@ -6,6 +6,8 @@ from ciris_engine.core.thought_escalation import (
     escalate_due_to_action_limit,
     escalate_due_to_sla,
     escalate_due_to_guardrail,
+    escalate_due_to_depth_limit,
+    escalate_due_to_ponder_limit,
 )
 
 
@@ -50,4 +52,24 @@ def test_escalate_due_to_guardrail():
     event = thought.escalations[0]
     assert event["type"] == "guardrail_violation"
     assert "guardrail breached" in event["reason"]
+    assert thought.is_terminal is True
+
+
+def test_escalate_due_to_depth_limit():
+    thought = create_thought()
+    escalate_due_to_depth_limit(thought, 7)
+    assert len(thought.escalations) == 1
+    event = thought.escalations[0]
+    assert event["type"] == "depth_limit"
+    assert "7" in event["reason"]
+    assert thought.is_terminal is True
+
+
+def test_escalate_due_to_ponder_limit():
+    thought = create_thought()
+    escalate_due_to_ponder_limit(thought, 7)
+    assert len(thought.escalations) == 1
+    event = thought.escalations[0]
+    assert event["type"] == "ponder_limit"
+    assert "7" in event["reason"]
     assert thought.is_terminal is True

--- a/tests/core/test_wakeup_sequence.py
+++ b/tests/core/test_wakeup_sequence.py
@@ -46,8 +46,9 @@ async def test_wakeup_sequence_success(mock_persistence, agent_processor_instanc
 
     assert success
     assert mock_persistence.add_thought.call_count == len(WAKEUP_SEQUENCE)
-    assert mock_persistence.add_task.call_count == 2
-    mock_persistence.update_task_status.assert_any_call("wakeup", TaskStatus.COMPLETED)
+    # root + five steps + job task
+    assert mock_persistence.add_task.call_count == len(WAKEUP_SEQUENCE) + 2
+    mock_persistence.update_task_status.assert_any_call("WAKEUP_ROOT", TaskStatus.COMPLETED)
     assert mock_action_dispatcher.dispatch.await_count == len(WAKEUP_SEQUENCE)
 
 
@@ -80,7 +81,7 @@ async def test_wakeup_sequence_failure(mock_persistence, agent_processor_instanc
     success = await agent_processor_instance._run_wakeup_sequence()
 
     assert success is False
-    mock_persistence.update_task_status.assert_any_call("wakeup", TaskStatus.DEFERRED)
+    mock_persistence.update_task_status.assert_any_call("WAKEUP_ROOT", TaskStatus.DEFERRED)
 
 
 @pytest.mark.asyncio
@@ -111,6 +112,5 @@ async def test_wakeup_sequence_allows_ponder(mock_persistence, agent_processor_i
 
     success = await agent_processor_instance._run_wakeup_sequence()
 
-    assert success
-    mock_persistence.update_task_status.assert_any_call("wakeup", TaskStatus.COMPLETED)
-    assert mock_action_dispatcher.dispatch.await_count == len(WAKEUP_SEQUENCE)
+    assert success is False
+    mock_persistence.update_task_status.assert_any_call("WAKEUP_ROOT", TaskStatus.DEFERRED)


### PR DESCRIPTION
## Summary
- restructure wake up ritual into sequential child tasks
- cap thought depth and ponder count via new constants
- add escalation helpers for depth and ponder limits
- update wake up tests for new workflow
- add tests for escalation helpers

## Testing
- `pytest -q`