### PR TITLE
Stop engine on follow‑up creation failure

### DIFF
--- a/ciris_engine/core/action_handlers/memorize_handler.py
+++ b/ciris_engine/core/action_handlers/memorize_handler.py
@@ -9,6 +9,7 @@ from ciris_engine.core import persistence
 from ciris_engine.services.discord_graph_memory import MemoryOpStatus # Assuming this is the correct import
 from .base_handler import BaseActionHandler, ActionHandlerDependencies
 from .helpers import create_follow_up_thought
+from ..exceptions import FollowUpCreationError
 
 logger = logging.getLogger(__name__)
 
@@ -115,22 +116,32 @@ class MemorizeHandler(BaseActionHandler):
         else: # Failed or Deferred
             follow_up_text = f"MEMORIZE action for thought {thought_id} resulted in status {final_thought_status.value}. Info: {follow_up_content_key_info}. Review and determine next steps."
 
-        new_follow_up = create_follow_up_thought(
-            parent=thought,
-            content=follow_up_text,
-            priority_offset= 1 if action_performed_successfully else 0 # Higher if success, normal if fail/deferred
-        )
-        
-        processing_ctx_for_follow_up = {"action_performed": HandlerActionType.MEMORIZE.value}
-        if final_thought_status != ThoughtStatus.COMPLETED: # FAILED or DEFERRED
-            processing_ctx_for_follow_up["error_details"] = follow_up_content_key_info
-        
-        action_params_dump = result.action_parameters
-        if isinstance(action_params_dump, BaseModel):
-            action_params_dump = action_params_dump.model_dump(mode="json")
-        processing_ctx_for_follow_up["action_params"] = action_params_dump
-        
-        new_follow_up.processing_context = processing_ctx_for_follow_up
-        
-        persistence.add_thought(new_follow_up)
-        self.logger.info(f"Created follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after MEMORIZE action.")
+        try:
+            new_follow_up = create_follow_up_thought(
+                parent=thought,
+                content=follow_up_text,
+                priority_offset=1 if action_performed_successfully else 0,
+            )
+
+            processing_ctx_for_follow_up = {
+                "action_performed": HandlerActionType.MEMORIZE.value
+            }
+            if final_thought_status != ThoughtStatus.COMPLETED:
+                processing_ctx_for_follow_up["error_details"] = follow_up_content_key_info
+
+            action_params_dump = result.action_parameters
+            if isinstance(action_params_dump, BaseModel):
+                action_params_dump = action_params_dump.model_dump(mode="json")
+            processing_ctx_for_follow_up["action_params"] = action_params_dump
+
+            new_follow_up.processing_context = processing_ctx_for_follow_up
+            persistence.add_thought(new_follow_up)
+            self.logger.info(
+                f"Created follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after MEMORIZE action."
+            )
+        except Exception as e:
+            self.logger.critical(
+                f"Failed to create follow-up thought for {thought_id}: {e}",
+                exc_info=e,
+            )
+            raise FollowUpCreationError from e

--- a/ciris_engine/core/action_handlers/observe_handler.py
+++ b/ciris_engine/core/action_handlers/observe_handler.py
@@ -11,6 +11,7 @@ from ciris_engine.core.foundational_schemas import ThoughtStatus, HandlerActionT
 from ciris_engine.core import persistence
 from .base_handler import BaseActionHandler, ActionHandlerDependencies
 from .helpers import create_follow_up_thought
+from ..exceptions import FollowUpCreationError
 
 logger = logging.getLogger(__name__)
 
@@ -130,22 +131,33 @@ class ObserveHandler(BaseActionHandler):
             else: # Failed
                 follow_up_text = f"OBSERVE action failed for thought {thought_id}. Reason: {follow_up_content_key_info}. Review and determine next steps."
 
-            new_follow_up = create_follow_up_thought(
-                parent=thought,
-                content=follow_up_text,
-                priority_offset= 1 if action_performed_successfully else 0 # Higher if passive success, normal if fail
-            )
-            
-            processing_ctx_for_follow_up = {"action_performed": HandlerActionType.OBSERVE.value}
-            if final_thought_status == ThoughtStatus.FAILED:
-                processing_ctx_for_follow_up["error_details"] = follow_up_content_key_info
-            
-            action_params_dump = result.action_parameters
-            if isinstance(action_params_dump, BaseModel):
-                action_params_dump = action_params_dump.model_dump(mode="json")
-            processing_ctx_for_follow_up["action_params"] = action_params_dump
-            
-            new_follow_up.processing_context = processing_ctx_for_follow_up
-            
-            persistence.add_thought(new_follow_up)
-            self.logger.info(f"Created standard follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after OBSERVE action.")
+            try:
+                new_follow_up = create_follow_up_thought(
+                    parent=thought,
+                    content=follow_up_text,
+                    priority_offset=1 if action_performed_successfully else 0,
+                )
+
+                processing_ctx_for_follow_up = {
+                    "action_performed": HandlerActionType.OBSERVE.value
+                }
+                if final_thought_status == ThoughtStatus.FAILED:
+                    processing_ctx_for_follow_up["error_details"] = follow_up_content_key_info
+
+                action_params_dump = result.action_parameters
+                if isinstance(action_params_dump, BaseModel):
+                    action_params_dump = action_params_dump.model_dump(mode="json")
+                processing_ctx_for_follow_up["action_params"] = action_params_dump
+
+                new_follow_up.processing_context = processing_ctx_for_follow_up
+
+                persistence.add_thought(new_follow_up)
+                self.logger.info(
+                    f"Created standard follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after OBSERVE action."
+                )
+            except Exception as e:
+                self.logger.critical(
+                    f"Failed to create follow-up thought for {thought_id}: {e}",
+                    exc_info=e,
+                )
+                raise FollowUpCreationError from e

--- a/ciris_engine/core/action_handlers/tool_handler.py
+++ b/ciris_engine/core/action_handlers/tool_handler.py
@@ -8,6 +8,7 @@ from ciris_engine.core.foundational_schemas import ThoughtStatus, HandlerActionT
 from ciris_engine.core import persistence
 from .base_handler import BaseActionHandler, ActionHandlerDependencies
 from .helpers import create_follow_up_thought
+from ..exceptions import FollowUpCreationError
 
 logger = logging.getLogger(__name__)
 
@@ -61,22 +62,31 @@ class ToolHandler(BaseActionHandler):
         else:
             follow_up_text = f"TOOL action failed for thought {thought_id}. Reason: {follow_up_content_key_info}. Review and determine next steps."
         
-        new_follow_up = create_follow_up_thought(
-            parent=thought,
-            content=follow_up_text,
-            priority_offset= 1 if action_performed_successfully else 0 # Higher if success, normal if fail
-        )
-        
-        processing_ctx_for_follow_up = {"action_performed": HandlerActionType.TOOL.value}
-        if final_thought_status == ThoughtStatus.FAILED:
-            processing_ctx_for_follow_up["error_details"] = follow_up_content_key_info
-        
-        action_params_dump = result.action_parameters
-        if isinstance(action_params_dump, BaseModel):
-            action_params_dump = action_params_dump.model_dump(mode="json")
-        processing_ctx_for_follow_up["action_params"] = action_params_dump
-        
-        new_follow_up.processing_context = processing_ctx_for_follow_up
-        
-        persistence.add_thought(new_follow_up)
-        self.logger.info(f"Created follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after TOOL action.")
+        try:
+            new_follow_up = create_follow_up_thought(
+                parent=thought,
+                content=follow_up_text,
+                priority_offset=1 if action_performed_successfully else 0,
+            )
+
+            processing_ctx_for_follow_up = {"action_performed": HandlerActionType.TOOL.value}
+            if final_thought_status == ThoughtStatus.FAILED:
+                processing_ctx_for_follow_up["error_details"] = follow_up_content_key_info
+
+            action_params_dump = result.action_parameters
+            if isinstance(action_params_dump, BaseModel):
+                action_params_dump = action_params_dump.model_dump(mode="json")
+            processing_ctx_for_follow_up["action_params"] = action_params_dump
+
+            new_follow_up.processing_context = processing_ctx_for_follow_up
+
+            persistence.add_thought(new_follow_up)
+            self.logger.info(
+                f"Created follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after TOOL action."
+            )
+        except Exception as e:
+            self.logger.critical(
+                f"Failed to create follow-up thought for {thought_id}: {e}",
+                exc_info=e,
+            )
+            raise FollowUpCreationError from e

--- a/ciris_engine/core/exceptions.py
+++ b/ciris_engine/core/exceptions.py
@@ -1,0 +1,3 @@
+class FollowUpCreationError(Exception):
+    """Raised when a handler fails to create or store a follow-up thought."""
+    pass

--- a/tests/core/test_speak_handler.py
+++ b/tests/core/test_speak_handler.py
@@ -6,6 +6,7 @@ from ciris_engine.core.agent_core_schemas import (
 )
 from ciris_engine.core.foundational_schemas import HandlerActionType, ThoughtStatus
 from ciris_engine.core.action_handlers.speak_handler import SpeakHandler
+from ciris_engine.core.exceptions import FollowUpCreationError
 from ciris_engine.core.action_handlers.base_handler import ActionHandlerDependencies
 from ciris_engine.core import persistence
 
@@ -35,3 +36,29 @@ async def test_handle_speak(monkeypatch):
     await handler.handle(result, t, {"channel_id": "c"})
     assert svc.sent == [("c", "hi")]
     assert added and added[0].related_thought_id == t.thought_id
+
+
+@pytest.mark.asyncio
+async def test_speak_follow_up_failure(monkeypatch):
+    t = Thought(thought_id="t2", source_task_id="task", created_at="", updated_at="", round_created=0, content="")
+    svc = DummyDiscord()
+    deps = ActionHandlerDependencies(action_sink=svc)
+    handler = SpeakHandler(deps)
+    monkeypatch.setattr(persistence, "update_thought_status", lambda **k: None)
+
+    def fail_add(_):
+        raise Exception("boom")
+
+    monkeypatch.setattr(persistence, "add_thought", fail_add)
+
+    result = ActionSelectionPDMAResult(
+        context_summary_for_action_selection="c",
+        action_alignment_check={},
+        selected_handler_action=HandlerActionType.SPEAK,
+        action_parameters=SpeakParams(content="hi", target_channel="c"),
+        action_selection_rationale="r",
+        monitoring_for_selected_action="m",
+    )
+
+    with pytest.raises(FollowUpCreationError):
+        await handler.handle(result, t, {"channel_id": "c"})


### PR DESCRIPTION
## Summary
- add `FollowUpCreationError` exception
- make action handlers raise `FollowUpCreationError` when persistence fails
- re-raise critical errors from `ActionDispatcher`
- halt processing loop if a follow-up cannot be created
- add regression test for `SpeakHandler`

## Testing
- `pytest -q`