### PR TITLE
Add system snapshot formatter

### DIFF
--- a/ciris_engine/formatters/__init__.py
+++ b/ciris_engine/formatters/__init__.py
@@ -1,0 +1,1 @@
+"""Formatters for prompt engineering utilities."""

--- a/ciris_engine/formatters/system_snapshot.py
+++ b/ciris_engine/formatters/system_snapshot.py
@@ -1,0 +1,34 @@
+from typing import Dict
+
+
+def format_system_snapshot(system_snapshot: Dict) -> str:
+    """Summarize core system counters for LLM prompt context.
+
+    Parameters
+    ----------
+    system_snapshot : dict
+        Mapping of counters such as ``pending_tasks`` and ``active_thoughts``.
+
+    Returns
+    -------
+    str
+        Compact block ready to append after task context.
+    """
+
+    lines = ["=== System Snapshot ==="]
+
+    # Display order / whitelist
+    fields = [
+        ("pending_tasks", "Pending Tasks"),
+        ("active_thoughts", "Active Thoughts"),
+        ("completed_tasks", "Completed Tasks"),
+        ("recent_errors", "Recent Errors"),
+        # ↳ add more tuples as needed
+    ]
+
+    for key, label in fields:
+        if key in system_snapshot:
+            val = system_snapshot[key]
+            lines.append(f"{label}: {val}")
+
+    return "\n".join(lines)

--- a/ciris_engine/utils/task_formatters.py
+++ b/ciris_engine/utils/task_formatters.py
@@ -1,0 +1,61 @@
+"""Prompt engineering utilities for summarizing task context."""
+
+from typing import List, Dict, Optional
+
+
+def format_task_context(current_task: Dict[str, str],
+                         recent_actions: List[Dict[str, str]],
+                         completed_tasks: Optional[List[Dict[str, str]]] = None,
+                         max_actions: int = 5) -> str:
+    """Return a formatted summary block for LLM prompts.
+
+    Parameters
+    ----------
+    current_task : Dict[str, str]
+        Mapping containing ``description``, ``task_id`` and optional ``status``
+        and ``priority``.
+    recent_actions : List[Dict[str, str]]
+        Sequence of recent actions with ``description``, ``outcome`` and
+        ``updated_at`` fields.
+    completed_tasks : List[Dict[str, str]], optional
+        Optional list of completed tasks for additional context. Only the first
+        item is included.
+    max_actions : int, default 5
+        Maximum number of actions to include.
+
+    Returns
+    -------
+    str
+        A human-readable block describing the task context.
+    """
+
+    if not isinstance(current_task, dict):
+        raise TypeError("current_task must be a dict")
+
+    out_lines: List[str] = ["=== Current Task ==="]
+    cur_desc = str(current_task.get("description", ""))[:200]
+    task_id = current_task.get("task_id", "N/A")
+    status = current_task.get("status", "N/A")
+    priority = current_task.get("priority", "N/A")
+    out_lines.append(f"{cur_desc} (Task ID: {task_id}, Status: {status}, Priority: {priority})")
+
+    if recent_actions:
+        out_lines.append("\n=== Recent Actions ===")
+        for idx, act in enumerate(recent_actions[:max_actions], 1):
+            if not isinstance(act, dict):
+                continue
+            desc = str(act.get("description", ""))[:120]
+            outcome = str(act.get("outcome", ""))[:100]
+            upd = act.get("updated_at", "N/A")
+            out_lines.append(f"{idx}. {desc} | Outcome: {outcome} (updated: {upd})")
+
+    if completed_tasks:
+        last = completed_tasks[0]
+        if isinstance(last, dict):
+            desc = str(last.get("description", ""))[:120]
+            outcome = str(last.get("outcome", ""))[:100]
+            upd = last.get("updated_at", "N/A")
+            out_lines.append(f"\n=== Last Completed Task ===\n{desc} | Outcome: {outcome} (completed: {upd})")
+
+    return "\n".join(out_lines)
+

--- a/tests/formatters/test_format_system_snapshot.py
+++ b/tests/formatters/test_format_system_snapshot.py
@@ -1,0 +1,14 @@
+from ciris_engine.formatters.system_snapshot import format_system_snapshot
+
+
+def test_format_system_snapshot():
+    snapshot = {
+        "pending_tasks": 4,
+        "active_thoughts": 1,
+        "completed_tasks": 22,
+        "recent_errors": 0,
+    }
+    block = format_system_snapshot(snapshot)
+    assert "=== System Snapshot ===" in block
+    assert "Pending Tasks: 4" in block
+    assert "Active Thoughts: 1" in block

--- a/tests/utils/test_task_formatters.py
+++ b/tests/utils/test_task_formatters.py
@@ -1,0 +1,47 @@
+import pytest
+from ciris_engine.utils.task_formatters import format_task_context
+
+
+def test_format_task_context_basic():
+    current_task = {
+        "description": "Handle customer issue",
+        "task_id": "42",
+        "status": "in_progress",
+        "priority": "high",
+    }
+    recent_actions = [
+        {
+            "description": "Contacted customer",
+            "outcome": "Awaiting reply",
+            "updated_at": "2024-06-01 12:00",
+        },
+        {
+            "description": "Escalated to tier 2",
+            "outcome": "Pending",
+            "updated_at": "2024-06-01 12:05",
+        },
+    ]
+    completed_tasks = [
+        {
+            "description": "Resolved previous ticket",
+            "outcome": "Issue fixed",
+            "updated_at": "2024-06-01 11:00",
+        }
+    ]
+
+    block = format_task_context(current_task, recent_actions, completed_tasks)
+    assert "=== Current Task ===" in block
+    assert "Handle customer issue" in block
+    assert "1. Contacted customer" in block
+    assert "Awaiting reply" in block
+    assert "=== Last Completed Task ===" in block
+    assert "Issue fixed" in block
+
+
+def test_format_task_context_no_actions():
+    block = format_task_context({"description": "d", "task_id": "1"}, [], [])
+    assert "=== Current Task ===" in block
+    assert "Recent Actions" not in block
+    assert "Last Completed Task" not in block
+
+


### PR DESCRIPTION
## Summary
- add `format_system_snapshot` formatter for prompt utilities
- create unit test covering snapshot formatting

## Testing
- `pytest -q`