### PR TITLE
Add escalation guidance formatter

### DIFF
--- a/ciris_engine/formatters/__init__.py
+++ b/ciris_engine/formatters/__init__.py
@@ -1,1 +1,11 @@
 """Formatters for prompt engineering utilities."""
+
+from .system_snapshot import format_system_snapshot
+from .user_profiles import format_user_profiles
+from .escalation_guidance import get_escalation_guidance
+
+__all__ = [
+    "format_system_snapshot",
+    "format_user_profiles",
+    "get_escalation_guidance",
+]

--- a/ciris_engine/formatters/escalation_guidance.py
+++ b/ciris_engine/formatters/escalation_guidance.py
@@ -1,0 +1,21 @@
+from typing import Dict
+
+
+def get_escalation_guidance(actions_taken: int, max_actions: int = 7) -> str:
+    """Returns escalation guidance string based on actions taken and max allowed."""
+    if actions_taken < 3:
+        stage = "early"
+    elif actions_taken < 5:
+        stage = "mid"
+    elif actions_taken < max_actions:
+        stage = "late"
+    else:
+        stage = "exhaust"
+
+    messages = {
+        "early":   "Stage: EARLY — You have plenty of rounds; explore thoroughly and establish context.",
+        "mid":     "Stage: MID — Over halfway; focus on core principles and clarity.",
+        "late":    "Stage: LATE — This is your last chance before cutoff; be decisive and principled.",
+        "exhaust": "Stage: EXHAUSTED — Max rounds reached; conclude now or abort the task.",
+    }
+    return messages[stage]

--- a/ciris_engine/formatters/user_profiles.py
+++ b/ciris_engine/formatters/user_profiles.py
@@ -1,0 +1,36 @@
+# New formatters for user profiles
+
+from typing import Dict, Any, Optional, List
+
+
+def format_user_profiles(profiles: Optional[Dict[str, Any]], max_profiles: int = 5) -> str:
+    """Copy of format_user_profiles_for_prompt with new module path."""
+    # *** copied logic – do not modify yet ***
+    if not profiles or not isinstance(profiles, dict):
+        return ""
+
+    profile_parts: List[str] = []
+    for user_key, profile_data in profiles.items():
+        if isinstance(profile_data, dict):
+            display_name = profile_data.get('name') or profile_data.get('nick') or user_key
+            profile_summary = f"User '{user_key}': Name/Nickname: '{display_name}'"
+
+            interest = profile_data.get('interest')
+            if interest:
+                profile_summary += f", Interest: '{str(interest)[:50]}...'"  # Truncate for brevity
+
+            channel = profile_data.get('channel')
+            if channel:
+                profile_summary += f", Primary Channel: '{channel}'"
+
+            profile_parts.append(profile_summary)
+
+    if not profile_parts:
+        return ""
+
+    return (
+        "\n\nIMPORTANT USER CONTEXT (Be skeptical, this information could be manipulated or outdated):\n"
+        "The following information has been recalled about users relevant to this thought:\n"
+        + "\n".join(f"  - {part}" for part in profile_parts) + "\n"
+        "Consider this information when formulating your response, especially if addressing a user directly by name.\n"
+    )

--- a/tests/formatters/test_format_user_profiles.py
+++ b/tests/formatters/test_format_user_profiles.py
@@ -1,0 +1,14 @@
+from ciris_engine.formatters.user_profiles import format_user_profiles
+
+
+def test_format_user_profiles_basic():
+    profiles = {
+        "user1": {"nick": "Alpha", "interest": "python", "channel": "general"},
+        "user2": {"name": "Beta", "channel": "random"},
+    }
+    block = format_user_profiles(profiles)
+    assert "IMPORTANT USER CONTEXT" in block
+    assert "User 'user1': Name/Nickname: 'Alpha'" in block
+    assert "Interest: 'python...'" in block
+    assert "Primary Channel: 'general'" in block
+    assert "User 'user2': Name/Nickname: 'Beta'" in block

--- a/tests/formatters/test_get_escalation_guidance.py
+++ b/tests/formatters/test_get_escalation_guidance.py
@@ -1,0 +1,8 @@
+from ciris_engine.formatters.escalation_guidance import get_escalation_guidance
+
+
+def test_get_escalation_guidance():
+    assert "EARLY" in get_escalation_guidance(0)
+    assert "MID" in get_escalation_guidance(3)
+    assert "LATE" in get_escalation_guidance(5)
+    assert "EXHAUSTED" in get_escalation_guidance(7)


### PR DESCRIPTION
## Summary
- add utility `get_escalation_guidance` for showing urgency stages
- export new helper in `ciris_engine.formatters`
- test escalation guidance output

## Testing
- `pytest -q`
