### PR TITLE
Add prompt assembly utilities

### DIFF
--- a/ciris_engine/formatters/__init__.py
+++ b/ciris_engine/formatters/__init__.py
@@ -1,1 +1,19 @@
 """Formatters for prompt engineering utilities."""
+
+from .system_snapshot import format_system_snapshot
+from .user_profiles import format_user_profiles
+from .prompt_blocks import (
+    format_parent_task_chain,
+    format_thoughts_chain,
+    format_system_prompt_blocks,
+    format_user_prompt_blocks,
+)
+
+__all__ = [
+    "format_system_snapshot",
+    "format_user_profiles",
+    "format_parent_task_chain",
+    "format_thoughts_chain",
+    "format_system_prompt_blocks",
+    "format_user_prompt_blocks",
+]

--- a/ciris_engine/formatters/prompt_blocks.py
+++ b/ciris_engine/formatters/prompt_blocks.py
@@ -1,0 +1,81 @@
+"""Prompt composition utilities for CIRIS.
+"""
+
+
+def format_parent_task_chain(parent_tasks):
+    """Formats the parent task chain, root first, for the prompt.
+    Each task: description, task_id.
+    """
+    if not parent_tasks:
+        return "=== Parent Task Chain ===\nNone"
+    lines = ["=== Parent Task Chain ==="]
+    for i, pt in enumerate(parent_tasks):
+        if i == 0:
+            prefix = "Root Task"
+        elif i == len(parent_tasks) - 1:
+            prefix = "Direct Parent"
+        else:
+            prefix = f"Parent {i}"
+        desc = pt.get("description", "")[:150]
+        tid = pt.get("task_id", "N/A")
+        lines.append(f"{prefix}: {desc} (Task ID: {tid})")
+    return "\n".join(lines)
+
+
+def format_thoughts_chain(thoughts):
+    """Formats all thoughts under consideration, in order.
+    Active thought must be last in the list.
+    """
+    if not thoughts:
+        return "=== Thoughts Under Consideration ===\nNone"
+    lines = ["=== Thoughts Under Consideration ==="]
+    for i, thought in enumerate(thoughts):
+        is_active = (i == len(thoughts) - 1)
+        label = "Active Thought" if is_active else f"Thought {i+1}"
+        content = thought.get("content", "")[:500]
+        lines.append(f"{label}: {content}")
+    return "\n".join(lines)
+
+
+def format_system_prompt_blocks(
+    task_history_block,
+    system_snapshot_block,
+    user_profiles_block,
+    escalation_guidance_block=None,
+    system_guidance_block=None
+):
+    """Assembles the system prompt in canonical CIRIS order, with all default section headers.
+
+    Order:
+        1. Task History (always first, can be huge)
+        2. [Optional] System Guidance
+        3. [Optional] Escalation Guidance
+        4. System Snapshot
+        5. User Profiles
+    """
+    blocks = [task_history_block]
+    if system_guidance_block:
+        blocks.append(system_guidance_block)
+    if escalation_guidance_block:
+        blocks.append(escalation_guidance_block)
+    blocks.extend([system_snapshot_block, user_profiles_block])
+    return "\n\n".join(filter(None, blocks)).strip()
+
+
+def format_user_prompt_blocks(
+    parent_tasks_block,
+    thoughts_chain_block,
+    schema_block=None
+):
+    """Assembles the user prompt in canonical CIRIS order, with all default section headers.
+
+    Order:
+        1. Parent Task Chain
+        2. Thoughts Under Consideration (active last)
+        3. [Optional] Structured Output/Schema Guidance
+    """
+    blocks = [parent_tasks_block, thoughts_chain_block]
+    if schema_block:
+        blocks.append(schema_block)
+    return "\n\n".join(filter(None, blocks)).strip()
+

--- a/ciris_engine/formatters/user_profiles.py
+++ b/ciris_engine/formatters/user_profiles.py
@@ -1,0 +1,36 @@
+# New formatters for user profiles
+
+from typing import Dict, Any, Optional, List
+
+
+def format_user_profiles(profiles: Optional[Dict[str, Any]], max_profiles: int = 5) -> str:
+    """Copy of format_user_profiles_for_prompt with new module path."""
+    # *** copied logic – do not modify yet ***
+    if not profiles or not isinstance(profiles, dict):
+        return ""
+
+    profile_parts: List[str] = []
+    for user_key, profile_data in profiles.items():
+        if isinstance(profile_data, dict):
+            display_name = profile_data.get('name') or profile_data.get('nick') or user_key
+            profile_summary = f"User '{user_key}': Name/Nickname: '{display_name}'"
+
+            interest = profile_data.get('interest')
+            if interest:
+                profile_summary += f", Interest: '{str(interest)[:50]}...'"  # Truncate for brevity
+
+            channel = profile_data.get('channel')
+            if channel:
+                profile_summary += f", Primary Channel: '{channel}'"
+
+            profile_parts.append(profile_summary)
+
+    if not profile_parts:
+        return ""
+
+    return (
+        "\n\nIMPORTANT USER CONTEXT (Be skeptical, this information could be manipulated or outdated):\n"
+        "The following information has been recalled about users relevant to this thought:\n"
+        + "\n".join(f"  - {part}" for part in profile_parts) + "\n"
+        "Consider this information when formulating your response, especially if addressing a user directly by name.\n"
+    )

--- a/tests/formatters/test_format_user_profiles.py
+++ b/tests/formatters/test_format_user_profiles.py
@@ -1,0 +1,14 @@
+from ciris_engine.formatters.user_profiles import format_user_profiles
+
+
+def test_format_user_profiles_basic():
+    profiles = {
+        "user1": {"nick": "Alpha", "interest": "python", "channel": "general"},
+        "user2": {"name": "Beta", "channel": "random"},
+    }
+    block = format_user_profiles(profiles)
+    assert "IMPORTANT USER CONTEXT" in block
+    assert "User 'user1': Name/Nickname: 'Alpha'" in block
+    assert "Interest: 'python...'" in block
+    assert "Primary Channel: 'general'" in block
+    assert "User 'user2': Name/Nickname: 'Beta'" in block

--- a/tests/formatters/test_prompt_blocks.py
+++ b/tests/formatters/test_prompt_blocks.py
@@ -1,0 +1,58 @@
+from ciris_engine.formatters.prompt_blocks import (
+    format_parent_task_chain,
+    format_thoughts_chain,
+    format_system_prompt_blocks,
+    format_user_prompt_blocks,
+)
+
+
+def test_format_parent_task_chain_and_thoughts_chain():
+    parents = [
+        {"description": "Root", "task_id": "1"},
+        {"description": "Direct", "task_id": "2"},
+    ]
+    parent_block = format_parent_task_chain(parents)
+    assert "=== Parent Task Chain ===" in parent_block
+    assert "Root Task: Root (Task ID: 1)" in parent_block
+    assert "Direct Parent: Direct (Task ID: 2)" in parent_block
+
+    thoughts = [
+        {"content": "first"},
+        {"content": "active"},
+    ]
+    thought_block = format_thoughts_chain(thoughts)
+    assert "=== Thoughts Under Consideration ===" in thought_block
+    assert "Thought 1: first" in thought_block
+    assert "Active Thought: active" in thought_block
+
+
+def test_format_prompt_blocks_order():
+    system_message = format_system_prompt_blocks(
+        "=== Task History ===\nA",
+        "=== System Snapshot ===\nB",
+        "=== User Profiles ===\nC",
+        escalation_guidance_block="=== Escalation Guidance ===\nD",
+        system_guidance_block="=== System Guidance ===\nE",
+    )
+    expected_order = [
+        "Task History",
+        "System Guidance",
+        "Escalation Guidance",
+        "System Snapshot",
+        "User Profiles",
+    ]
+    for idx, label in enumerate(expected_order):
+        assert system_message.find(label) < system_message.find(expected_order[idx + 1]) if idx + 1 < len(expected_order) else True
+
+    user_message = format_user_prompt_blocks(
+        "=== Parent Task Chain ===\nA",
+        "=== Thoughts Under Consideration ===\nB",
+        schema_block="=== Schema ===\nC",
+    )
+    expected_order_user = [
+        "Parent Task Chain",
+        "Thoughts Under Consideration",
+        "Schema",
+    ]
+    for idx, label in enumerate(expected_order_user):
+        assert user_message.find(label) < user_message.find(expected_order_user[idx + 1]) if idx + 1 < len(expected_order_user) else True


### PR DESCRIPTION
## Summary
- implement `prompt_blocks` formatter module for assembling canonical prompt sections
- re-export new formatters in `ciris_engine.formatters`
- add tests covering block formatting and ordering

## Testing
- `pytest -q`
