### PR TITLE
Add CIRIS explainer DMA and prompt utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 - Always run `pytest -q` before committing changes.
 - Prefer asynchronous functions when dealing with I/O or long-running tasks. Use `asyncio.to_thread` for blocking calls.
 - Keep new scripts and services minimal and well-documented.
+- Use the canonical prompt-formatting utilities in `ciris_engine.formatters`
+  (`prompt_blocks`, `escalation`, etc.) instead of manual string concatenation.
 
 - After the setup script completes, the environment is locked down: only
   packages listed in `requirements.txt` are available and network access is

--- a/ciris_engine/dma/__init__.py
+++ b/ciris_engine/dma/__init__.py
@@ -3,4 +3,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-pass
+from .ciris_explainer_dsdma import CIRISExplainerDSDMA
+
+__all__ = ["CIRISExplainerDSDMA"]

--- a/ciris_engine/dma/ciris_explainer_dsdma.py
+++ b/ciris_engine/dma/ciris_explainer_dsdma.py
@@ -1,0 +1,143 @@
+import logging
+from typing import Dict, Any, List
+
+from .dsdma_base import BaseDSDMA, InstructorRetryException
+from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
+from ciris_engine.core.dma_results import DSDMAResult
+from ciris_engine.utils.task_formatters import format_task_context
+from ciris_engine.formatters.system_snapshot import format_system_snapshot
+from ciris_engine.formatters.user_profiles import format_user_profiles
+from ciris_engine.formatters.prompt_blocks import (
+    format_parent_task_chain,
+    format_thoughts_chain,
+    format_user_prompt_blocks,
+)
+from ciris_engine.formatters.escalation import get_escalation_guidance
+
+logger = logging.getLogger(__name__)
+
+
+class CIRISExplainerDSDMA(BaseDSDMA):
+    """Domain-specific DMA with canonical CIRIS explainer template."""
+
+    DEFAULT_TEMPLATE = """=== Task History ===
+{task_history_block}
+
+=== CIRIS System Guidance ===
+You are a CIRIS Explainer Agent. Your role is to evaluate thoughts explicitly according to the CIRIS Covenant, which includes:
+
+- Coherence: maintaining logical and ethical consistency.
+- Integrity: ensuring reliability and honesty.
+- Adaptive Ethical Reasoning: dynamically applying principles contextually.
+
+Clearly explain and evaluate thoughts strictly through CIRIS reasoning and terminology.
+
+=== Escalation Guidance ===
+{escalation_guidance_block}
+
+=== System Snapshot ===
+{system_snapshot_block}
+
+=== User Profiles ===
+{user_profiles_block}
+"""
+
+    async def evaluate_thought(
+        self, thought_item: ProcessingQueueItem, current_context: Dict[str, Any]
+    ) -> DSDMAResult:
+        # Extract context blocks
+        task_history_block = format_task_context(
+            current_context.get("current_task", {}),
+            current_context.get("recent_actions", []),
+            current_context.get("completed_tasks", []),
+        )
+
+        escalation_block = get_escalation_guidance(
+            current_context.get("actions_taken", 0),
+            current_context.get("max_actions", 7),
+        )
+
+        system_snapshot_block = format_system_snapshot(
+            current_context.get("system_snapshot", {})
+        )
+
+        user_profiles_block = format_user_profiles(
+            current_context.get("user_profiles", {})
+        )
+
+        parent_tasks_block = format_parent_task_chain(
+            current_context.get("parent_tasks", [])
+        )
+
+        thoughts_chain: List[Dict[str, Any]] = current_context.get("thoughts_chain", [])
+        if not thoughts_chain:
+            thoughts_chain = [{"content": str(thought_item.content)}]
+        else:
+            thoughts_chain.append({"content": str(thought_item.content)})
+
+        thoughts_chain_block = format_thoughts_chain(thoughts_chain)
+
+        system_message = self.DEFAULT_TEMPLATE.format(
+            task_history_block=task_history_block,
+            escalation_guidance_block=escalation_block,
+            system_snapshot_block=system_snapshot_block,
+            user_profiles_block=user_profiles_block,
+        )
+
+        user_message = format_user_prompt_blocks(
+            parent_tasks_block,
+            thoughts_chain_block,
+            None,
+        )
+
+        messages = [
+            {"role": "system", "content": system_message},
+            {"role": "user", "content": user_message},
+        ]
+
+        try:
+            llm_eval_data: BaseDSDMA.LLMOutputForDSDMA = await self.aclient.chat.completions.create(
+                model=self.model_name,
+                response_model=BaseDSDMA.LLMOutputForDSDMA,
+                messages=messages,
+                max_tokens=512,
+            )
+
+            result = DSDMAResult(
+                domain_name=self.domain_name,
+                domain_alignment_score=min(max(llm_eval_data.domain_alignment_score, 0.0), 1.0),
+                recommended_action=llm_eval_data.recommended_action,
+                flags=llm_eval_data.flags,
+                reasoning=llm_eval_data.reasoning,
+                domain_specific_output={},
+            )
+            if hasattr(llm_eval_data, "_raw_response"):
+                result.raw_llm_response = str(llm_eval_data._raw_response)
+            return result
+        except InstructorRetryException as e_instr:
+            error_detail = e_instr.errors() if hasattr(e_instr, "errors") else str(e_instr)
+            logger.error(
+                f"CIRISExplainerDSDMA {self.domain_name} InstructorRetryException for thought {thought_item.thought_id}: {error_detail}",
+                exc_info=True,
+            )
+            return DSDMAResult(
+                domain_name=self.domain_name,
+                domain_alignment_score=0.0,
+                recommended_action=None,
+                flags=["Instructor_ValidationError"],
+                reasoning=f"Failed DSDMA evaluation via instructor due to validation error: {error_detail}",
+                raw_llm_response=f"InstructorRetryException: {error_detail}",
+            )
+        except Exception as e:
+            logger.error(
+                f"CIRISExplainerDSDMA {self.domain_name} evaluation failed for thought ID {thought_item.thought_id}: {e}",
+                exc_info=True,
+            )
+            return DSDMAResult(
+                domain_name=self.domain_name,
+                domain_alignment_score=0.0,
+                recommended_action=None,
+                flags=["LLM_Error_Instructor"],
+                reasoning=f"Failed DSDMA evaluation via instructor: {str(e)}",
+                raw_llm_response=f"Exception: {str(e)}",
+            )

--- a/ciris_engine/formatters/__init__.py
+++ b/ciris_engine/formatters/__init__.py
@@ -1,1 +1,21 @@
 """Formatters for prompt engineering utilities."""
+
+from .system_snapshot import format_system_snapshot
+from .user_profiles import format_user_profiles
+from .prompt_blocks import (
+    format_parent_task_chain,
+    format_thoughts_chain,
+    format_system_prompt_blocks,
+    format_user_prompt_blocks,
+)
+from .escalation import get_escalation_guidance
+
+__all__ = [
+    "format_system_snapshot",
+    "format_user_profiles",
+    "format_parent_task_chain",
+    "format_thoughts_chain",
+    "format_system_prompt_blocks",
+    "format_user_prompt_blocks",
+    "get_escalation_guidance",
+]

--- a/ciris_engine/formatters/escalation.py
+++ b/ciris_engine/formatters/escalation.py
@@ -1,0 +1,22 @@
+"""Escalation guidance helper."""
+
+
+def get_escalation_guidance(actions_taken: int, max_actions: int = 7) -> str:
+    """Returns escalation guidance string based on actions taken and max allowed."""
+    if actions_taken < 3:
+        stage = "early"
+    elif actions_taken < 5:
+        stage = "mid"
+    elif actions_taken < max_actions:
+        stage = "late"
+    else:
+        stage = "exhaust"
+
+    messages = {
+        "early": "Stage: EARLY — You have plenty of rounds; explore thoroughly and establish context.",
+        "mid": "Stage: MID — Over halfway; focus on core principles and clarity.",
+        "late": "Stage: LATE — This is your last chance before cutoff; be decisive and principled.",
+        "exhaust": "Stage: EXHAUSTED — Max rounds reached; conclude now or abort the task.",
+    }
+    return messages[stage]
+

--- a/ciris_engine/formatters/prompt_blocks.py
+++ b/ciris_engine/formatters/prompt_blocks.py
@@ -1,0 +1,64 @@
+"""Utilities for assembling canonical prompt blocks."""
+
+from typing import List, Dict, Any, Optional
+
+
+def format_parent_task_chain(parent_tasks: List[Dict[str, Any]]) -> str:
+    """Formats the parent task chain, root first, for the prompt."""
+    if not parent_tasks:
+        return "=== Parent Task Chain ===\nNone"
+    lines = ["=== Parent Task Chain ==="]
+    for i, pt in enumerate(parent_tasks):
+        if i == 0:
+            prefix = "Root Task"
+        elif i == len(parent_tasks) - 1:
+            prefix = "Direct Parent"
+        else:
+            prefix = f"Parent {i}"
+        desc = pt.get("description", "")[:150]
+        tid = pt.get("task_id", "N/A")
+        lines.append(f"{prefix}: {desc} (Task ID: {tid})")
+    return "\n".join(lines)
+
+
+def format_thoughts_chain(thoughts: List[Dict[str, Any]]) -> str:
+    """Formats all thoughts under consideration, active thought last."""
+    if not thoughts:
+        return "=== Thoughts Under Consideration ===\nNone"
+    lines = ["=== Thoughts Under Consideration ==="]
+    for i, thought in enumerate(thoughts):
+        is_active = i == len(thoughts) - 1
+        label = "Active Thought" if is_active else f"Thought {i+1}"
+        content = str(thought.get("content", ""))[:500]
+        lines.append(f"{label}: {content}")
+    return "\n".join(lines)
+
+
+def format_system_prompt_blocks(
+    task_history_block: str,
+    system_snapshot_block: str,
+    user_profiles_block: str,
+    escalation_guidance_block: Optional[str] = None,
+    system_guidance_block: Optional[str] = None,
+) -> str:
+    """Assemble the system prompt in canonical CIRIS order."""
+    blocks = [task_history_block]
+    if system_guidance_block:
+        blocks.append(system_guidance_block)
+    if escalation_guidance_block:
+        blocks.append(escalation_guidance_block)
+    blocks.extend([system_snapshot_block, user_profiles_block])
+    return "\n\n".join(filter(None, blocks)).strip()
+
+
+def format_user_prompt_blocks(
+    parent_tasks_block: str,
+    thoughts_chain_block: str,
+    schema_block: Optional[str] = None,
+) -> str:
+    """Assemble the user prompt in canonical CIRIS order."""
+    blocks = [parent_tasks_block, thoughts_chain_block]
+    if schema_block:
+        blocks.append(schema_block)
+    return "\n\n".join(filter(None, blocks)).strip()
+

--- a/ciris_engine/formatters/user_profiles.py
+++ b/ciris_engine/formatters/user_profiles.py
@@ -1,0 +1,36 @@
+# New formatters for user profiles
+
+from typing import Dict, Any, Optional, List
+
+
+def format_user_profiles(profiles: Optional[Dict[str, Any]], max_profiles: int = 5) -> str:
+    """Copy of format_user_profiles_for_prompt with new module path."""
+    # *** copied logic – do not modify yet ***
+    if not profiles or not isinstance(profiles, dict):
+        return ""
+
+    profile_parts: List[str] = []
+    for user_key, profile_data in profiles.items():
+        if isinstance(profile_data, dict):
+            display_name = profile_data.get('name') or profile_data.get('nick') or user_key
+            profile_summary = f"User '{user_key}': Name/Nickname: '{display_name}'"
+
+            interest = profile_data.get('interest')
+            if interest:
+                profile_summary += f", Interest: '{str(interest)[:50]}...'"  # Truncate for brevity
+
+            channel = profile_data.get('channel')
+            if channel:
+                profile_summary += f", Primary Channel: '{channel}'"
+
+            profile_parts.append(profile_summary)
+
+    if not profile_parts:
+        return ""
+
+    return (
+        "\n\nIMPORTANT USER CONTEXT (Be skeptical, this information could be manipulated or outdated):\n"
+        "The following information has been recalled about users relevant to this thought:\n"
+        + "\n".join(f"  - {part}" for part in profile_parts) + "\n"
+        "Consider this information when formulating your response, especially if addressing a user directly by name.\n"
+    )

--- a/tests/dma/test_ciris_explainer_dsdma.py
+++ b/tests/dma/test_ciris_explainer_dsdma.py
@@ -1,0 +1,86 @@
+import pytest
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from openai import AsyncOpenAI
+from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
+from ciris_engine.core.dma_results import DSDMAResult
+from ciris_engine.core.agent_core_schemas import ThoughtStatus
+from ciris_engine.dma.ciris_explainer_dsdma import CIRISExplainerDSDMA
+from ciris_engine.dma.dsdma_base import BaseDSDMA
+from ciris_engine.core.config_schemas import AppConfig, OpenAIConfig, LLMServicesConfig
+
+
+@pytest.fixture
+def mock_openai_client():
+    client = MagicMock(spec=AsyncOpenAI)
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def sample_thought_item():
+    now_iso = datetime.now(timezone.utc).isoformat()
+    return ProcessingQueueItem(
+        thought_id=str(uuid.uuid4()),
+        source_task_id=str(uuid.uuid4()),
+        thought_type="test_explainer_thought",
+        status=ThoughtStatus.PENDING,
+        created_at=now_iso,
+        updated_at=now_iso,
+        round_created=1,
+        priority=5,
+        content="Explain CIRIS",
+        processing_context={},
+        initial_context={}
+    )
+
+
+@pytest.fixture
+def explainer_dsdma(mock_openai_client, monkeypatch):
+    cfg = AppConfig(llm_services=LLMServicesConfig(openai=OpenAIConfig(instructor_mode="JSON")))
+    monkeypatch.setattr("ciris_engine.dma.dsdma_base.get_config", lambda: cfg)
+    evaluator = CIRISExplainerDSDMA(
+        domain_name="Explainer",
+        aclient=mock_openai_client,
+        model_name="m"
+    )
+    evaluator.aclient.chat.completions.create = AsyncMock(name="patched_create_explainer")
+    return evaluator
+
+
+@pytest.mark.asyncio
+async def test_explainer_prompt_structure(explainer_dsdma, sample_thought_item):
+    result_obj = BaseDSDMA.LLMOutputForDSDMA(
+        domain_alignment_score=1.0,
+        recommended_action=None,
+        flags=[],
+        reasoning="ok",
+    )
+    result_obj._raw_response = MagicMock()
+    explainer_dsdma.aclient.chat.completions.create.return_value = result_obj
+
+    context = {
+        "current_task": {"description": "CT", "task_id": "1"},
+        "recent_actions": [],
+        "completed_tasks": [],
+        "system_snapshot": {},
+        "user_profiles": {},
+        "parent_tasks": [],
+        "thoughts_chain": [],
+        "actions_taken": 1,
+    }
+
+    await explainer_dsdma.evaluate_thought(sample_thought_item, context)
+
+    explainer_dsdma.aclient.chat.completions.create.assert_awaited_once()
+    call_args = explainer_dsdma.aclient.chat.completions.create.call_args.kwargs
+    system_message = call_args["messages"][0]["content"]
+    user_message = call_args["messages"][1]["content"]
+    assert system_message.startswith("=== Task History ===")
+    assert "CIRIS System Guidance" in system_message
+    assert user_message.startswith("=== Parent Task Chain ===")
+    assert "Thoughts Under Consideration" in user_message

--- a/tests/formatters/test_escalation.py
+++ b/tests/formatters/test_escalation.py
@@ -1,0 +1,8 @@
+from ciris_engine.formatters.escalation import get_escalation_guidance
+
+
+def test_get_escalation_guidance():
+    assert "EARLY" in get_escalation_guidance(0)
+    assert "MID" in get_escalation_guidance(3)
+    assert "LATE" in get_escalation_guidance(5)
+    assert "EXHAUSTED" in get_escalation_guidance(7)

--- a/tests/formatters/test_format_user_profiles.py
+++ b/tests/formatters/test_format_user_profiles.py
@@ -1,0 +1,14 @@
+from ciris_engine.formatters.user_profiles import format_user_profiles
+
+
+def test_format_user_profiles_basic():
+    profiles = {
+        "user1": {"nick": "Alpha", "interest": "python", "channel": "general"},
+        "user2": {"name": "Beta", "channel": "random"},
+    }
+    block = format_user_profiles(profiles)
+    assert "IMPORTANT USER CONTEXT" in block
+    assert "User 'user1': Name/Nickname: 'Alpha'" in block
+    assert "Interest: 'python...'" in block
+    assert "Primary Channel: 'general'" in block
+    assert "User 'user2': Name/Nickname: 'Beta'" in block

--- a/tests/formatters/test_prompt_blocks.py
+++ b/tests/formatters/test_prompt_blocks.py
@@ -1,0 +1,37 @@
+from ciris_engine.formatters.prompt_blocks import (
+    format_parent_task_chain,
+    format_thoughts_chain,
+    format_system_prompt_blocks,
+    format_user_prompt_blocks,
+)
+
+
+def test_format_parent_task_chain():
+    chain = [
+        {"description": "root desc", "task_id": "1"},
+        {"description": "child", "task_id": "2"},
+    ]
+    block = format_parent_task_chain(chain)
+    assert block.startswith("=== Parent Task Chain ===")
+    assert "Root Task" in block
+    assert "Direct Parent" in block
+
+
+def test_format_thoughts_chain():
+    thoughts = [{"content": "first"}, {"content": "second"}]
+    block = format_thoughts_chain(thoughts)
+    assert block.startswith("=== Thoughts Under Consideration ===")
+    assert "Thought 1: first" in block
+    assert "Active Thought: second" in block
+
+
+def test_prompt_block_ordering():
+    sys_block = format_system_prompt_blocks(
+        "TASK", "SNAP", "PROFILES", "ESCALATE", "GUIDE"
+    )
+    assert sys_block.split("\n\n")[0] == "TASK"
+    user_block = format_user_prompt_blocks("PARENT", "THOUGHTS", "SCHEMA")
+    parts = user_block.split("\n\n")
+    assert parts[0] == "PARENT"
+    assert parts[1] == "THOUGHTS"
+    assert parts[2] == "SCHEMA"


### PR DESCRIPTION
## Summary
- add canonical prompt utilities (`prompt_blocks`, `escalation`)
- create `CIRISExplainerDSDMA` using new blocks
- expose new utilities and update `AGENTS.md`
- test prompt blocks, escalation guidance, and the new DSDMA class

## Testing
- `pytest -q`