### PR TITLE
Use default DSDMA profile when unspecified

### DIFF
--- a/ciris_engine/dma/factory.py
+++ b/ciris_engine/dma/factory.py
@@ -1,0 +1,57 @@
+import logging
+from pathlib import Path
+from typing import Dict, Optional, Type
+
+from openai import AsyncOpenAI
+
+from .dsdma_base import BaseDSDMA
+from ..core.config_schemas import SerializableAgentProfile
+from ..utils.profile_loader import load_profile
+
+logger = logging.getLogger(__name__)
+
+# Registry of available DSDMA classes
+DSDMA_CLASS_REGISTRY: Dict[str, Type[BaseDSDMA]] = {
+    "BaseDSDMA": BaseDSDMA,
+}
+
+DEFAULT_PROFILE_PATH = Path("ciris_profiles/default.yaml")
+
+async def create_dsdma_from_profile(
+    profile: Optional[SerializableAgentProfile],
+    aclient: AsyncOpenAI,
+    *,
+    model_name: Optional[str] = None,
+    default_profile_path: Path = DEFAULT_PROFILE_PATH,
+) -> Optional[BaseDSDMA]:
+    """Instantiate a DSDMA based on the given profile.
+
+    If ``profile`` is ``None`` or lacks ``dsdma_identifier``, the default profile
+    from ``default_profile_path`` is loaded and used instead.
+    """
+    if profile is None or not profile.dsdma_identifier:
+        logger.info(
+            "No specific DSDMA profile provided; loading default profile from %s",
+            default_profile_path,
+        )
+        profile = await load_profile(default_profile_path)
+        if profile is None:
+            logger.error("Default profile could not be loaded")
+            return None
+
+    dsdma_cls = DSDMA_CLASS_REGISTRY.get(profile.dsdma_identifier)
+    if not dsdma_cls:
+        logger.error("Unknown DSDMA identifier: %s", profile.dsdma_identifier)
+        return None
+
+    overrides = profile.dsdma_kwargs or {}
+    prompt_template = overrides.get("prompt_template")
+    domain_knowledge = overrides.get("domain_specific_knowledge")
+
+    return dsdma_cls(
+        domain_name=profile.name,
+        aclient=aclient,
+        model_name=model_name,
+        domain_specific_knowledge=domain_knowledge,
+        prompt_template=prompt_template,
+    )

--- a/ciris_engine/utils/profile_loader.py
+++ b/ciris_engine/utils/profile_loader.py
@@ -8,7 +8,10 @@ from ciris_engine.core.config_schemas import SerializableAgentProfile
 
 logger = logging.getLogger(__name__)
 
-async def load_profile(profile_path: Path) -> Optional[SerializableAgentProfile]:
+DEFAULT_PROFILE_PATH = Path("ciris_profiles/default.yaml")
+
+
+async def load_profile(profile_path: Optional[Path]) -> Optional[SerializableAgentProfile]:
     """Asynchronously load an agent profile from a YAML file.
 
     This coroutine should be awaited so file I/O does not block the event loop.
@@ -19,12 +22,20 @@ async def load_profile(profile_path: Path) -> Optional[SerializableAgentProfile]
     Returns:
         A SerializableAgentProfile instance if loading is successful, otherwise None.
     """
+    if profile_path is None:
+        profile_path = DEFAULT_PROFILE_PATH
     if not isinstance(profile_path, Path):
         profile_path = Path(profile_path)
 
     if not profile_path.exists() or not profile_path.is_file():
-        logger.error(f"Profile file not found or is not a file: {profile_path}")
-        return None
+        if profile_path != DEFAULT_PROFILE_PATH:
+            logger.warning(
+                f"Profile file {profile_path} not found. Falling back to default profile {DEFAULT_PROFILE_PATH}"
+            )
+            profile_path = DEFAULT_PROFILE_PATH
+        if not profile_path.exists() or not profile_path.is_file():
+            logger.error(f"Default profile file not found: {profile_path}")
+            return None
 
     try:
         def _load_yaml(path: Path):
@@ -42,6 +53,10 @@ async def load_profile(profile_path: Path) -> Optional[SerializableAgentProfile]
             # Try to infer name from filename if not in YAML content
             profile_data['name'] = profile_path.stem 
             logger.warning(f"Profile 'name' not found in YAML, inferred as '{profile_data['name']}' from filename: {profile_path}")
+
+        # Map legacy "dsdma_overrides" to "dsdma_kwargs" if present
+        if "dsdma_kwargs" not in profile_data and "dsdma_overrides" in profile_data:
+            profile_data["dsdma_kwargs"] = profile_data.pop("dsdma_overrides")
 
         # The profile_data should directly map to SerializableAgentProfile fields
         profile = SerializableAgentProfile(**profile_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import sys
 from pathlib import Path
 import pytest # Import pytest for potential future fixture use
+import os
+
+# Ensure OpenAI client can initialize during tests
+os.environ.setdefault("OPENAI_API_KEY", "test")
 
 # Add the project root directory (parent of 'tests' directory) to sys.path
 # This ensures that the 'ciris_engine' package can be imported by tests.

--- a/tests/utils/test_profile_loader.py
+++ b/tests/utils/test_profile_loader.py
@@ -1,0 +1,21 @@
+import pytest
+import pytest_asyncio
+from unittest.mock import MagicMock
+
+from ciris_engine.utils.profile_loader import load_profile, DEFAULT_PROFILE_PATH
+from ciris_engine.dma.factory import create_dsdma_from_profile
+from ciris_engine.dma.dsdma_base import BaseDSDMA
+from openai import AsyncOpenAI
+
+@pytest.mark.asyncio
+async def test_load_profile_defaults_to_default():
+    profile = await load_profile(None)
+    assert profile is not None
+    assert profile.name.lower() == "default"
+
+@pytest.mark.asyncio
+async def test_create_dsdma_from_default_profile():
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    dsdma = await create_dsdma_from_profile(None, mock_client, model_name="x")
+    assert isinstance(dsdma, BaseDSDMA)
+    assert "CIRIS Explainer" in dsdma.prompt_template


### PR DESCRIPTION
## Summary
- add `create_dsdma_from_profile` factory with default profile fallback
- fallback to `ciris_profiles/default.yaml` in `load_profile`
- ensure tests always have an OpenAI API key
- test default profile loading and DSDMA factory

## Testing
- `pytest -q`