### PR TITLE
Add deferral sink and WA correction path

### DIFF
--- a/ciris_engine/core/action_handlers/base_handler.py
+++ b/ciris_engine/core/action_handlers/base_handler.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 from abc import ABC, abstractmethod
 
 from ciris_engine.core.agent_core_schemas import ActionSelectionPDMAResult, Thought
-from ciris_engine.core.ports import ActionSink
+from ciris_engine.core.ports import ActionSink, DeferralSink
 from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
 from ciris_engine.services.discord_observer import DiscordObserver # For active look
 from ciris_engine.core import persistence
@@ -14,9 +14,10 @@ class ActionHandlerDependencies:
     """Services and context needed by action handlers."""
     def __init__(
         self,
-        action_sink: Optional[ActionSink] = None, 
+        action_sink: Optional[ActionSink] = None,
         memory_service: Optional[DiscordGraphMemory] = None,
-        observer_service: Optional[DiscordObserver] = None, 
+        observer_service: Optional[DiscordObserver] = None,
+        deferral_sink: Optional[DeferralSink] = None,
         # For Discord-specific active look, we might need the DiscordAdapter or its client
         # Let's pass the io_adapter (which could be DiscordAdapter)
         io_adapter: Optional[Any] = None, # General type, can be cast in handler
@@ -24,6 +25,7 @@ class ActionHandlerDependencies:
         self.action_sink = action_sink
         self.memory_service = memory_service
         self.observer_service = observer_service # Still useful for its config like monitored_channel_id
+        self.deferral_sink = deferral_sink
         self.io_adapter = io_adapter
 
 class BaseActionHandler(ABC):

--- a/ciris_engine/core/foundational_schemas.py
+++ b/ciris_engine/core/foundational_schemas.py
@@ -107,3 +107,4 @@ class IncomingMessage:
     author_name: str
     content: str
     channel_id: Optional[str] = None
+    reference_message_id: Optional[str] = None

--- a/ciris_engine/core/ports.py
+++ b/ciris_engine/core/ports.py
@@ -46,3 +46,30 @@ class ActionSink(ABC):
     @abstractmethod
     async def run_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
         raise NotImplementedError
+
+
+class DeferralSink(ABC):
+    """Specialized sink for sending deferral packages and handling WA corrections."""
+
+    @abstractmethod
+    async def start(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def stop(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def send_deferral(
+        self,
+        task_id: str,
+        thought_id: str,
+        reason: str,
+        package: Dict[str, Any],
+    ) -> None:
+        """Send a deferral report to the WA channel."""
+        raise NotImplementedError
+
+    async def process_possible_correction(self, msg: Any, raw_message: Any) -> bool:
+        """Handle WA correction replies if applicable. Return True if handled."""
+        return False

--- a/ciris_engine/services/discord_deferral_sink.py
+++ b/ciris_engine/services/discord_deferral_sink.py
@@ -1,0 +1,133 @@
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from ciris_engine.core.ports import DeferralSink
+from ciris_engine.core import persistence
+from ciris_engine.core.agent_core_schemas import Thought, ThoughtStatus
+from ciris_engine.core.foundational_schemas import IncomingMessage
+from ciris_engine.services.base import Service
+from ciris_engine.runtime.base_runtime import DiscordAdapter
+
+try:
+    from ciris_engine.services.discord_service import _truncate_discord_message
+except Exception:
+    def _truncate_discord_message(message: str, limit: int = 1900) -> str:
+        return message if len(message) <= limit else message[:limit-3] + "..."
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordDeferralSink(Service, DeferralSink):
+    """Send deferral reports via Discord and handle WA correction replies."""
+
+    def __init__(self, adapter: DiscordAdapter, deferral_channel_id: Optional[str]):
+        super().__init__()
+        self.adapter = adapter
+        self.client = adapter.client
+        self.deferral_channel_id = int(deferral_channel_id) if deferral_channel_id else None
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def send_deferral(
+        self,
+        task_id: str,
+        thought_id: str,
+        reason: str,
+        package: Dict[str, Any],
+    ) -> None:
+        if not self.deferral_channel_id:
+            logger.warning("DiscordDeferralSink: deferral channel not configured")
+            return
+        channel = self.client.get_channel(self.deferral_channel_id)
+        if channel is None:
+            channel = await self.client.fetch_channel(self.deferral_channel_id)
+        if channel is None:
+            logger.error("DiscordDeferralSink: cannot access deferral channel %s", self.deferral_channel_id)
+            return
+        if "metadata" in package and "user_nick" in package:
+            report = (
+                f"**Memory Deferral Report**\n"
+                f"**Task ID:** `{task_id}`\n"
+                f"**Deferred Thought ID:** `{thought_id}`\n"
+                f"**User:** {package.get('user_nick')} Channel: {package.get('channel')}\n"
+                f"**Reason:** {reason}\n"
+                f"**Metadata:** ```json\n{json.dumps(package.get('metadata'), indent=2)}\n```"
+            )
+        else:
+            report = (
+                f"**Deferral Report**\n"
+                f"**Task ID:** `{task_id}`\n"
+                f"**Deferred Thought ID:** `{thought_id}`\n"
+                f"**Reason:** {reason}\n"
+                f"**Deferral Package:** ```json\n{json.dumps(package, indent=2)}\n```"
+            )
+        sent = await channel.send(_truncate_discord_message(report))
+        persistence.save_deferral_report_mapping(str(sent.id), task_id, thought_id)
+
+    async def process_possible_correction(self, msg: IncomingMessage, raw_message: Any) -> bool:
+        if not self.deferral_channel_id or str(self.deferral_channel_id) != msg.channel_id:
+            return False
+        ref_id = getattr(raw_message, "reference", None)
+        if not ref_id or not getattr(raw_message.reference, "message_id", None):
+            return False
+        ref_message_id = str(raw_message.reference.message_id)
+        mapping = persistence.get_deferral_report_context(ref_message_id)
+        if not mapping:
+            return False
+        task_id, corrected_thought_id = mapping
+        deferral_data = None
+        try:
+            replied_content = raw_message.reference.resolved.content if raw_message.reference.resolved else None
+        except Exception:
+            replied_content = None
+        if replied_content:
+            m = re.search(r"```json\n(.*)\n```", replied_content, re.DOTALL)
+            if m:
+                try:
+                    deferral_data = json.loads(m.group(1))
+                except Exception:
+                    pass
+        self._create_correction_thought(task_id, corrected_thought_id, raw_message, deferral_data)
+        return True
+
+    def _create_correction_thought(
+        self,
+        original_task_id: str,
+        corrected_thought_id: Optional[str],
+        message: Any,
+        deferral_data: Optional[Dict[str, Any]],
+    ) -> None:
+        now_iso = datetime.now(timezone.utc).isoformat()
+        thought_id = f"th_corr_{original_task_id}_{now_iso[-4:]}"
+        orig_task = persistence.get_task_by_id(original_task_id)
+        priority = orig_task.priority if orig_task else 1
+        persistence.add_thought(
+            Thought(
+                thought_id=thought_id,
+                source_task_id=original_task_id,
+                related_thought_id=corrected_thought_id,
+                thought_type="correction",
+                status=ThoughtStatus.PENDING,
+                created_at=now_iso,
+                updated_at=now_iso,
+                round_created=0,
+                content=f"WA Correction by {message.author.name}: {message.content}",
+                priority=priority,
+                processing_context={
+                    "is_wa_correction": True,
+                    "wa_author_id": str(message.author.id),
+                    "wa_author_name": message.author.name,
+                    "wa_message_id": str(message.id),
+                    "wa_timestamp": message.created_at.isoformat(),
+                    "deferral_package_content": deferral_data,
+                },
+            )
+        )
+        logger.info("DiscordDeferralSink: created correction thought %s", thought_id)

--- a/tests/services/test_discord_correction.py
+++ b/tests/services/test_discord_correction.py
@@ -4,18 +4,14 @@ from datetime import datetime, timezone
 
 import pytest
 
-from ciris_engine.services.discord_service import DiscordService
-from ciris_engine.core.action_dispatcher import ActionDispatcher
+from ciris_engine.services.discord_deferral_sink import DiscordDeferralSink
 from ciris_engine.core.agent_core_schemas import Task
 from ciris_engine.core import persistence
 
 @pytest.mark.asyncio
 async def test_create_correction_thought(monkeypatch):
-    monkeypatch.setenv("DISCORD_BOT_TOKEN", "x")
-    monkeypatch.setenv("DISCORD_CHANNEL_ID", "1")
-
-    dispatcher = ActionDispatcher({})
-    service = DiscordService(dispatcher)
+    adapter = SimpleNamespace(client=SimpleNamespace())
+    service = DiscordDeferralSink(adapter, "1")
 
     added = {}
     monkeypatch.setattr(persistence, "add_thought", lambda t: added.update({"thought": t}))
@@ -28,7 +24,6 @@ async def test_create_correction_thought(monkeypatch):
         created_at=datetime.now(timezone.utc),
     )
 
-    new_th = service._create_correction_thought("task1", "th0", msg, None)
+    service._create_correction_thought("task1", "th0", msg, None)
     assert added["thought"].source_task_id == "task1"
     assert added["thought"].related_thought_id == "th0"
-    assert new_th == added["thought"]

--- a/tests/services/test_discord_graph_memory.py
+++ b/tests/services/test_discord_graph_memory.py
@@ -66,7 +66,7 @@ async def test_observe_does_not_modify_graph(tmp_path: Path):
     dispatch_mock = AsyncMock()
     q = DiscordEventQueue()
     observer = DiscordObserver(dispatch_mock, message_queue=q, monitored_channel_id="general")
-    msg = IncomingMessage(message_id="1", author_id="1", author_name="bob", content="hi", channel_id="general")
+    msg = IncomingMessage(message_id="1", author_id="1", author_name="bob", content="hi", channel_id="general", reference_message_id=None)
     await observer.handle_incoming_message(msg)
 
     dispatch_mock.assert_awaited_once()
@@ -88,7 +88,7 @@ async def test_observe_queries_graph(tmp_path: Path):
         message_queue=q,
         monitored_channel_id="general"
     )
-    msg = IncomingMessage(message_id="2", author_id="2", author_name="carol", content="hello", channel_id="general")
+    msg = IncomingMessage(message_id="2", author_id="2", author_name="carol", content="hello", channel_id="general", reference_message_id=None)
     await observer.handle_incoming_message(msg)
 
     remember_mock.assert_awaited_once_with("carol")

--- a/tests/services/test_discord_observer.py
+++ b/tests/services/test_discord_observer.py
@@ -19,11 +19,11 @@ async def test_discord_observer_filters_channels():
 
     q = DiscordEventQueue()
     observer = DiscordObserver(collect, message_queue=q, monitored_channel_id="allowed")
-    msg1 = IncomingMessage(message_id="1", author_id="1", author_name="nick", content="hello", channel_id="ignored")
+    msg1 = IncomingMessage(message_id="1", author_id="1", author_name="nick", content="hello", channel_id="ignored", reference_message_id=None)
     await observer.handle_incoming_message(msg1)
     assert events == []
 
-    msg2 = IncomingMessage(message_id="2", author_id="1", author_name="nick", content="hi there", channel_id="allowed")
+    msg2 = IncomingMessage(message_id="2", author_id="1", author_name="nick", content="hi there", channel_id="allowed", reference_message_id=None)
     await observer.handle_incoming_message(msg2)
     assert events == [
         {
@@ -53,7 +53,7 @@ async def test_discord_observer_queue_polling():
     q = DiscordEventQueue()
     observer = DiscordObserver(collect, message_queue=q, monitored_channel_id="allowed")
     await observer.start()
-    await q.enqueue(IncomingMessage(message_id="3", author_id="1", author_name="nick", content="hi", channel_id="allowed"))
+    await q.enqueue(IncomingMessage(message_id="3", author_id="1", author_name="nick", content="hi", channel_id="allowed", reference_message_id=None))
     await asyncio.sleep(0.05)
     await observer.stop()
     assert len(events) == 1


### PR DESCRIPTION
## Summary
- create `DeferralSink` interface and implement `DiscordDeferralSink`
- extend action handler dependencies with deferral sink
- update defer handler to send deferrals through the new sink
- expose reference message info in `IncomingMessage`
- let `DiscordObserver` intercept WA correction replies via the sink
- adapt runtime's Discord adapter to attach raw messages
- wire everything in `run_discord_teacher`
- update unit tests for the new behaviour

## Testing
- `pytest -q`