### PR TITLE
Fix deferral package retrieval

### DIFF
--- a/ciris_engine/services/discord_deferral_sink.py
+++ b/ciris_engine/services/discord_deferral_sink.py
@@ -69,7 +69,9 @@ class DiscordDeferralSink(Service, DeferralSink):
                 f"**Deferral Package:** ```json\n{json.dumps(package, indent=2)}\n```"
             )
         sent = await channel.send(_truncate_discord_message(report))
-        persistence.save_deferral_report_mapping(str(sent.id), task_id, thought_id)
+        persistence.save_deferral_report_mapping(
+            str(sent.id), task_id, thought_id, package
+        )
 
     async def process_possible_correction(self, msg: IncomingMessage, raw_message: Any) -> bool:
         if not self.deferral_channel_id or str(self.deferral_channel_id) != msg.channel_id:
@@ -81,8 +83,8 @@ class DiscordDeferralSink(Service, DeferralSink):
         mapping = persistence.get_deferral_report_context(ref_message_id)
         if not mapping:
             return False
-        task_id, corrected_thought_id = mapping
-        deferral_data = None
+        task_id, corrected_thought_id, stored_package = mapping
+        deferral_data = stored_package
         try:
             replied_content = raw_message.reference.resolved.content if raw_message.reference.resolved else None
         except Exception:

--- a/ciris_engine/services/discord_service.py
+++ b/ciris_engine/services/discord_service.py
@@ -211,7 +211,7 @@ class DiscordService(Service):
                 if message.reference and message.reference.message_id:
                     mapping = persistence.get_deferral_report_context(str(message.reference.message_id))
                     if mapping:
-                        original_task_id, corrected_thought_id = mapping
+                        original_task_id, corrected_thought_id, _ = mapping
                         logger.info(
                             "Retrieved deferral mapping for message %s -> task %s, thought %s",
                             message.reference.message_id,
@@ -397,6 +397,7 @@ class DiscordService(Service):
                                     str(sent_report.id),
                                     source_task_id,
                                     deferred_thought_id,
+                                    package,
                                 )
                             except Exception as send_exc:
                                 logger.error(

--- a/tests/core/test_persistence.py
+++ b/tests/core/test_persistence.py
@@ -274,8 +274,9 @@ def test_deferral_report_mapping(initialized_db):
     persistence.add_task(task)
     persistence.add_thought(thought)
 
-    persistence.save_deferral_report_mapping("msg1", "task1", "th1")
+    package = {"k": "v"}
+    persistence.save_deferral_report_mapping("msg1", "task1", "th1", package)
     result = persistence.get_deferral_report_context("msg1")
-    assert result == ("task1", "th1")
+    assert result == ("task1", "th1", package)
 
     assert persistence.get_deferral_report_context("missing") is None


### PR DESCRIPTION
## Summary
- persist full deferral package alongside deferral report metadata
- include deferral package when saving to the DB
- recover stored package if WA replies to a truncated report
- adjust Discord service handling
- update persistence tests

## Testing
- `pytest -q`