### PR TITLE
Integrate CIRISLocalGraph

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -4,7 +4,7 @@ Channel updates to the agent's graph memory are deferred on the first attempt. T
 
 ## Manual persistence verification
 
-Until automated tests cover persistence, you can verify `DiscordGraphMemory` manually:
+Until automated tests cover persistence, you can verify `CIRISLocalGraph` manually:
 
 1. Run a MEMORIZE action.
 2. Wait a moment for the background persist thread to finish.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The core of CIRIS Engine is its ability to process "thoughts" (inputs or interna
 *   **DSDMA (Domain-Specific DMA):** Applies domain-specific knowledge and heuristics. Different DSDMAs can be created for various specialized tasks or agent roles (e.g., `StudentDSDMA`, `BasicTeacherDSDMA`).
 *   **ASPDMA (Action‑Selection PDMA):** Determines the final action an agent should take based on the outputs of the preceding DMAs and the agent's current state.
 
-Actions chosen by the PDMA are routed through an `ActionDispatcher`. Memory operations use `DiscordGraphMemory` for persistence.
+Actions chosen by the PDMA are routed through an `ActionDispatcher`. Memory operations use `CIRISLocalGraph` for persistence.
 
 CIRIS Engine supports different **agent profiles** (e.g., "Student", "Teacher" defined in `ciris_profiles/`) which can customize the behavior, prompting, and available DSDMAs for an agent. This allows for tailored reasoning processes depending on the agent's role or task.
 
@@ -37,7 +37,7 @@ The system is designed for modularity, allowing developers to create and integra
 *   **Profile‑Driven Actions:** Allowed handler actions are loaded from the active profile and passed dynamically to the ASPDMA.
 *   **Basic Guardrails:** Includes an ethical guardrail to check action outputs.
 *   **SQLite Persistence:** Uses SQLite for persisting tasks and thoughts.
-*   **Graph Memory:** MEMORIZE actions store user metadata in `DiscordGraphMemory`. REMEMBER and FORGET exist but are often disabled via profiles during testing.
+*   **Graph Memory:** MEMORIZE actions store user metadata in `CIRISLocalGraph`. REMEMBER and FORGET exist but are often disabled via profiles during testing.
     * Channel node updates require WA approval. The initial write is deferred and a new thought is generated for the Wise Authority. When that follow-up thought includes `is_wa_correction` and references the deferred thought, the update is applied automatically.
     * User nick node updates can be memorized immediately if guardrails are satisfied.
 

--- a/ciris_engine/core/action_handlers/base_handler.py
+++ b/ciris_engine/core/action_handlers/base_handler.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 
 from ciris_engine.core.agent_core_schemas import ActionSelectionPDMAResult, Thought
 from ciris_engine.core.ports import ActionSink, DeferralSink
-from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
+from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph
 from ciris_engine.services.discord_observer import DiscordObserver # For active look
 from ciris_engine.core import persistence
 
@@ -15,7 +15,7 @@ class ActionHandlerDependencies:
     def __init__(
         self,
         action_sink: Optional[ActionSink] = None,
-        memory_service: Optional[DiscordGraphMemory] = None,
+        memory_service: Optional[CIRISLocalGraph] = None,
         observer_service: Optional[DiscordObserver] = None,
         deferral_sink: Optional[DeferralSink] = None,
         # For Discord-specific active look, we might need the DiscordAdapter or its client

--- a/ciris_engine/core/graph_schemas.py
+++ b/ciris_engine/core/graph_schemas.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+from enum import Enum
+from typing import Dict, Any, Optional
+from pydantic import BaseModel, Field
+from .foundational_schemas import CIRISSchemaVersion, CIRISAgentUAL
+
+class GraphScope(str, Enum):
+    LOCAL = "task specific"
+    IDENTITY = "identity"
+    ENVIRONMENT = "environment"
+
+class NodeType(str, Enum):
+    AGENT = "agent"
+    USER = "user"
+    CHANNEL = "channel"
+    TASK = "task"
+    KNOWLEDGE_ASSET = "knowledge_asset"
+    EXTERNAL_ENTITY = "external_entity"
+
+class EdgeLabel(str, Enum):
+    PARTICIPATES_IN = "participates_in"
+    ASSOCIATED_WITH = "associated_with"
+    PRODUCES = "produces"
+    DERIVED_FROM = "derived_from"
+
+class GraphNode(BaseModel):
+    schema_version: CIRISSchemaVersion = CIRISSchemaVersion.V1_0_BETA
+    id: str
+    ual: Optional[str] = None
+    type: NodeType
+    scope: GraphScope
+    attrs: Dict[str, Any] = Field(default_factory=dict)
+
+class GraphEdge(BaseModel):
+    schema_version: CIRISSchemaVersion = CIRISSchemaVersion.V1_0_BETA
+    source: str
+    target: str
+    label: EdgeLabel
+    scope: GraphScope
+    attrs: Dict[str, Any] = Field(default_factory=dict)
+
+class GraphUpdateEvent(BaseModel):
+    node: Optional[GraphNode] = None
+    edge: Optional[GraphEdge] = None
+    actor: CIRISAgentUAL
+    rationale: Optional[str] = None

--- a/ciris_engine/core/workflow_coordinator.py
+++ b/ciris_engine/core/workflow_coordinator.py
@@ -27,8 +27,8 @@ from ciris_engine.utils.deferral_package_builder import build_deferral_package
 from .thought_escalation import escalate_due_to_guardrail
 
 if TYPE_CHECKING:
-    from ciris_engine.dma.dsdma_base import BaseDSDMA # Import only for type checking
-    from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
+    from ciris_engine.dma.dsdma_base import BaseDSDMA
+    from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph
     from ciris_engine.utils import GraphQLContextProvider
     from ciris_engine.dma.pdma import EthicalPDMAEvaluator
     from ciris_engine.dma.csdma import CSDMAEvaluator
@@ -50,8 +50,8 @@ class WorkflowCoordinator:
                  ethical_guardrails: EthicalGuardrails,
                  app_config: AppConfig,
                  # thought_queue_manager: ThoughtQueueManager,
-                 dsdma_evaluators: Optional[Dict[str, 'BaseDSDMA']] = None, # Use string literal for forward reference
-                 memory_service: Optional['DiscordGraphMemory'] = None,
+                 dsdma_evaluators: Optional[Dict[str, 'BaseDSDMA']] = None,
+                 memory_service: Optional['CIRISLocalGraph'] = None,
                  graphql_context_provider: Optional['GraphQLContextProvider'] = None,
                  # current_round_number: int = 0
                 ):

--- a/ciris_engine/memory/__init__.py
+++ b/ciris_engine/memory/__init__.py
@@ -1,5 +1,6 @@
 from .memory_handler import MemoryHandler, MemoryWrite
 from .utils import classify_target, is_wa_correction
+from .ciris_local_graph import CIRISLocalGraph, MemoryOpStatus, MemoryOpResult
 import logging
 
 logger = logging.getLogger(__name__)

--- a/ciris_engine/memory/ciris_local_graph.py
+++ b/ciris_engine/memory/ciris_local_graph.py
@@ -1,0 +1,125 @@
+import logging
+import asyncio
+import pickle
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+import networkx as nx
+
+from pydantic import BaseModel
+from ..core.graph_schemas import GraphNode, GraphEdge, GraphScope, GraphUpdateEvent, NodeType
+from ..core.foundational_schemas import CaseInsensitiveEnum, CIRISAgentUAL
+from .utils import sanitize_dict
+from ..services.base import Service
+
+logger = logging.getLogger(__name__)
+
+class MemoryOpStatus(CaseInsensitiveEnum):
+    SAVED = "saved"
+    DEFERRED = "deferred"
+    FAILED = "failed"
+
+class MemoryOpResult(BaseModel):
+    status: MemoryOpStatus
+    data: Optional[Dict[str, Any]] = None
+    reason: Optional[str] = None
+
+class CIRISLocalGraph(Service):
+    def __init__(self, storage_path: Optional[str] = None):
+        super().__init__()
+        self.storage_path = Path(storage_path or "memory_graph.pkl")
+        self._graphs = {
+            GraphScope.LOCAL: nx.DiGraph(),
+            GraphScope.IDENTITY: nx.DiGraph(),
+            GraphScope.ENVIRONMENT: nx.DiGraph(),
+        }
+        if self.storage_path.exists():
+            self._load()
+
+    @property
+    def graph(self):
+        return self._graphs[GraphScope.LOCAL]
+
+    def _load(self):
+        try:
+            with self.storage_path.open("rb") as f:
+                data = pickle.load(f)
+            for scope in GraphScope:
+                g = data.get(scope.value)
+                if isinstance(g, nx.DiGraph):
+                    self._graphs[scope] = g
+                else:
+                    self._graphs[scope] = nx.DiGraph()
+                    logger.warning("Init empty graph for scope %s", scope.value)
+        except Exception as exc:
+            logger.warning("Failed to load memory graphs: %s", exc)
+
+    def _persist(self):
+        try:
+            to_dump = {scope.value: g for scope, g in self._graphs.items()}
+            with self.storage_path.open("wb") as f:
+                pickle.dump(to_dump, f)
+        except Exception as exc:
+            logger.error("Failed to persist memory graphs: %s", exc)
+
+    async def start(self):
+        await super().start()
+        if self.storage_path.exists():
+            self._load()
+
+    async def stop(self):
+        await asyncio.to_thread(self._persist)
+        await super().stop()
+
+    # Compatibility layer with previous DiscordGraphMemory API
+    async def memorize(
+        self,
+        user_nick: str,
+        channel: Optional[str],
+        metadata: Dict[str, Any],
+        channel_metadata: Optional[Dict[str, Any]] = None,
+        *,
+        is_correction: bool = False,
+    ) -> MemoryOpResult:
+        node = GraphNode(
+            id=user_nick,
+            type=NodeType.USER,
+            scope=GraphScope.LOCAL,
+            attrs={**metadata, "channel": channel} if channel else metadata,
+        )
+        event = GraphUpdateEvent(node=node, actor="local")
+        return await self.apply_update(event)
+
+    async def remember(self, user_nick: str) -> Dict[str, Any]:
+        data = await self.remember_node(user_nick, GraphScope.LOCAL)
+        return data or {}
+
+    async def forget(self, user_nick: str):
+        await self.forget_node(user_nick, GraphScope.LOCAL)
+
+    async def apply_update(self, event: GraphUpdateEvent) -> MemoryOpResult:
+        scope = event.node.scope if event.node else event.edge.scope  # type: ignore
+        g = self._graphs.get(scope)
+        if event.node:
+            g.add_node(event.node.id, **sanitize_dict(event.node.attrs))
+            await asyncio.to_thread(self._persist)
+            return MemoryOpResult(status=MemoryOpStatus.SAVED)
+        if event.edge:
+            g.add_edge(event.edge.source, event.edge.target, label=event.edge.label.value)
+            await asyncio.to_thread(self._persist)
+            return MemoryOpResult(status=MemoryOpStatus.SAVED)
+        return MemoryOpResult(status=MemoryOpStatus.FAILED, reason="empty event")
+
+    async def remember_node(self, node_id: str, scope: GraphScope = GraphScope.LOCAL) -> Optional[Dict[str, Any]]:
+        g = self._graphs.get(scope)
+        if g and node_id in g:
+            return dict(g.nodes[node_id])
+        return None
+
+    async def forget_node(self, node_id: str, scope: GraphScope = GraphScope.LOCAL) -> MemoryOpResult:
+        g = self._graphs.get(scope)
+        if g and node_id in g:
+            g.remove_node(node_id)
+            await asyncio.to_thread(self._persist)
+            return MemoryOpResult(status=MemoryOpStatus.SAVED)
+        return MemoryOpResult(status=MemoryOpStatus.FAILED, reason="not found")

--- a/ciris_engine/memory/memory_handler.py
+++ b/ciris_engine/memory/memory_handler.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, Optional
 from pydantic import BaseModel
 
-from ..services.discord_graph_memory import DiscordGraphMemory
+from .ciris_local_graph import CIRISLocalGraph
 from ..core.agent_core_schemas import ActionSelectionPDMAResult
 from ..core.agent_core_schemas import Thought
 from ..core.foundational_schemas import HandlerActionType, ThoughtStatus
@@ -28,7 +28,7 @@ class MemoryWrite(BaseModel):
 
 
 class MemoryHandler:
-    def __init__(self, memory_service: DiscordGraphMemory):
+    def __init__(self, memory_service: CIRISLocalGraph):
         self.memory_service = memory_service
 
     async def process_memorize(self, thought: Thought, mem_write: MemoryWrite) -> Optional[ActionSelectionPDMAResult]:

--- a/ciris_engine/memory/utils.py
+++ b/ciris_engine/memory/utils.py
@@ -1,5 +1,13 @@
 import logging
-from typing import Any
+from typing import Any, Dict
+try:
+    import bleach
+    def _clean(text: str) -> str:
+        return bleach.clean(text)
+except Exception:  # noqa: BLE001
+    import html
+    def _clean(text: str) -> str:
+        return html.escape(text)
 
 from ..core.agent_core_schemas import Thought
 from ..core.foundational_schemas import ThoughtStatus
@@ -9,6 +17,17 @@ logger = logging.getLogger(__name__)
 
 class MemoryWriteKey:
     CHANNEL_PREFIX = "channel/"
+
+
+def sanitize_dict(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Sanitize a dictionary's string values using bleach."""
+    sanitized: Dict[str, Any] = {}
+    for k, v in data.items():
+        if isinstance(v, str):
+            sanitized[k] = _clean(v)
+        else:
+            sanitized[k] = v
+    return sanitized
 
 
 def classify_target(mem_write: "MemoryWrite") -> str:

--- a/ciris_engine/services/discord_deferral_sink.py
+++ b/ciris_engine/services/discord_deferral_sink.py
@@ -69,7 +69,9 @@ class DiscordDeferralSink(Service, DeferralSink):
                 f"**Deferral Package:** ```json\n{json.dumps(package, indent=2)}\n```"
             )
         sent = await channel.send(_truncate_discord_message(report))
-        persistence.save_deferral_report_mapping(str(sent.id), task_id, thought_id)
+        persistence.save_deferral_report_mapping(
+            str(sent.id), task_id, thought_id, package
+        )
 
     async def process_possible_correction(self, msg: IncomingMessage, raw_message: Any) -> bool:
         if not self.deferral_channel_id or str(self.deferral_channel_id) != msg.channel_id:
@@ -81,8 +83,8 @@ class DiscordDeferralSink(Service, DeferralSink):
         mapping = persistence.get_deferral_report_context(ref_message_id)
         if not mapping:
             return False
-        task_id, corrected_thought_id = mapping
-        deferral_data = None
+        task_id, corrected_thought_id, stored_package = mapping
+        deferral_data = stored_package
         try:
             replied_content = raw_message.reference.resolved.content if raw_message.reference.resolved else None
         except Exception:

--- a/ciris_engine/services/discord_service.py
+++ b/ciris_engine/services/discord_service.py
@@ -211,7 +211,7 @@ class DiscordService(Service):
                 if message.reference and message.reference.message_id:
                     mapping = persistence.get_deferral_report_context(str(message.reference.message_id))
                     if mapping:
-                        original_task_id, corrected_thought_id = mapping
+                        original_task_id, corrected_thought_id, _ = mapping
                         logger.info(
                             "Retrieved deferral mapping for message %s -> task %s, thought %s",
                             message.reference.message_id,
@@ -397,6 +397,7 @@ class DiscordService(Service):
                                     str(sent_report.id),
                                     source_task_id,
                                     deferred_thought_id,
+                                    package,
                                 )
                             except Exception as send_exc:
                                 logger.error(

--- a/ciris_engine/utils/graphql_context_provider.py
+++ b/ciris_engine/utils/graphql_context_provider.py
@@ -3,7 +3,7 @@ import logging
 import asyncio
 from typing import Dict, Any, List, Optional
 import httpx
-from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
+from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class GraphQLClient:
 
 class GraphQLContextProvider:
     def __init__(self, graphql_client: GraphQLClient | None = None,
-                 memory_service: Optional[DiscordGraphMemory] = None,
+                 memory_service: Optional[CIRISLocalGraph] = None,
                  enable_remote_graphql: bool = False):
         self.enable_remote_graphql = enable_remote_graphql
         if enable_remote_graphql:

--- a/run_cli_student.py
+++ b/run_cli_student.py
@@ -17,7 +17,7 @@ from ciris_engine.dma.csdma import CSDMAEvaluator
 from ciris_engine.dma.action_selection_pdma import ActionSelectionPDMAEvaluator
 from ciris_engine.guardrails import EthicalGuardrails
 from ciris_engine.services.llm_service import LLMService
-from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
+from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph
 from ciris_engine.core.agent_core_schemas import (
     HandlerActionType,
     SpeakParams,
@@ -97,7 +97,7 @@ async def main() -> None:
         app_config.agent_profiles[profile.name.lower()] = profile
 
     llm_service = LLMService(app_config.llm_services)
-    memory_service = DiscordGraphMemory()
+    memory_service = CIRISLocalGraph()
 
     await llm_service.start()
     await memory_service.start()

--- a/run_discord_teacher.py
+++ b/run_discord_teacher.py
@@ -26,7 +26,7 @@ from ciris_engine.dma.action_selection_pdma import ActionSelectionPDMAEvaluator
 import instructor # Added import for instructor.Mode
 from ciris_engine.guardrails import EthicalGuardrails
 from ciris_engine.services.llm_service import LLMService
-from ciris_engine.services.discord_graph_memory import DiscordGraphMemory, MemoryOpStatus # Import MemoryOpStatus
+from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph, MemoryOpStatus
 from ciris_engine.core.agent_core_schemas import (
     HandlerActionType,
     SpeakParams,
@@ -128,7 +128,7 @@ async def main() -> None:
         app_config.agent_profiles[profile.name.lower()] = profile
     
     llm_service = LLMService(app_config.llm_services)
-    memory_service = DiscordGraphMemory()
+    memory_service = CIRISLocalGraph()
     
     from ciris_engine.services.discord_observer import DiscordObserver
     discord_observer = DiscordObserver(

--- a/tests/core/test_dma_context_propagation.py
+++ b/tests/core/test_dma_context_propagation.py
@@ -11,7 +11,7 @@ from ciris_engine.utils.profile_loader import load_profile # AgentProfile will b
 from ciris_engine.core.config_schemas import SerializableAgentProfile as AgentProfile # Correct import
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem # Added import
 from ciris_engine.services.llm_service import LLMService
-from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
+from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph
 from ciris_engine.dma.pdma import EthicalPDMAEvaluator
 from ciris_engine.dma.csdma import CSDMAEvaluator
 from ciris_engine.dma.action_selection_pdma import ActionSelectionPDMAEvaluator
@@ -49,7 +49,7 @@ async def llm_service(app_config: AppConfig):
 
 @pytest_asyncio.fixture
 async def memory_service():
-    service = DiscordGraphMemory() # Using real one, can be mocked if complex
+    service = CIRISLocalGraph()
     await service.start()
     yield service
     await service.stop()
@@ -96,7 +96,7 @@ def workflow_coordinator(
     action_selection_pdma_evaluator: ActionSelectionPDMAEvaluator,
     ethical_guardrails: EthicalGuardrails,
     app_config: AppConfig,
-    memory_service: DiscordGraphMemory
+    memory_service: CIRISLocalGraph
 ):
     return WorkflowCoordinator(
         llm_client=llm_service.get_client().client, # raw client

--- a/tests/core/test_persistence.py
+++ b/tests/core/test_persistence.py
@@ -274,8 +274,9 @@ def test_deferral_report_mapping(initialized_db):
     persistence.add_task(task)
     persistence.add_thought(thought)
 
-    persistence.save_deferral_report_mapping("msg1", "task1", "th1")
+    package = {"k": "v"}
+    persistence.save_deferral_report_mapping("msg1", "task1", "th1", package)
     result = persistence.get_deferral_report_context("msg1")
-    assert result == ("task1", "th1")
+    assert result == ("task1", "th1", package)
 
     assert persistence.get_deferral_report_context("missing") is None

--- a/tests/core/test_workflow_coordinator.py
+++ b/tests/core/test_workflow_coordinator.py
@@ -18,7 +18,7 @@ from ciris_engine.core.agent_core_schemas import (
 from ciris_engine.core.foundational_schemas import ThoughtStatus, HandlerActionType, TaskStatus
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
 from ciris_engine.core.config_schemas import AppConfig, WorkflowConfig, LLMServicesConfig, OpenAIConfig, DatabaseConfig, GuardrailsConfig, SerializableAgentProfile
-from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
+from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph
 
 # --- Fixtures ---
 
@@ -66,7 +66,7 @@ def mock_ethical_guardrails():
 
 @pytest.fixture
 async def memory_service(tmp_path: Path):
-    service = DiscordGraphMemory(str(tmp_path / "graph.pkl"))
+    service = CIRISLocalGraph(str(tmp_path / "graph.pkl"))
     await service.start()
     yield service
 
@@ -131,7 +131,7 @@ def workflow_coordinator_instance(
 async def test_memory_meta_thought(
     mock_persistence,
     workflow_coordinator_instance: WorkflowCoordinator,
-    memory_service: DiscordGraphMemory,
+    memory_service: CIRISLocalGraph,
     dma_executor_patches,
     track_action_patch,
 ):

--- a/tests/memory/test_memory_handler.py
+++ b/tests/memory/test_memory_handler.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from datetime import datetime
 
 from ciris_engine.memory.memory_handler import MemoryHandler, MemoryWrite
-from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
+from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph
 from ciris_engine.core.agent_core_schemas import Thought, Task
 from ciris_engine.core.foundational_schemas import ThoughtStatus, HandlerActionType
 from ciris_engine.core import persistence
@@ -19,7 +19,7 @@ def init_db(tmp_path: Path, monkeypatch):
 
 @pytest.fixture
 async def memory_service(tmp_path: Path):
-    service = DiscordGraphMemory(str(tmp_path / "graph.pkl"))
+    service = CIRISLocalGraph(str(tmp_path / "graph.pkl"))
     await service.start()
     yield service
 

--- a/tests/services/test_ciris_local_graph.py
+++ b/tests/services/test_ciris_local_graph.py
@@ -4,8 +4,8 @@ from unittest.mock import AsyncMock
 import pickle
 import networkx as nx
 
-from ciris_engine.services.discord_graph_memory import (
-    DiscordGraphMemory,
+from ciris_engine.memory.ciris_local_graph import (
+    CIRISLocalGraph,
     MemoryOpStatus,
 )
 from ciris_engine.services.discord_observer import DiscordObserver
@@ -16,7 +16,7 @@ from ciris_engine.runtime.base_runtime import IncomingMessage
 @pytest.mark.asyncio
 async def test_memory_graph_starts_empty(tmp_path: Path):
     storage = tmp_path / "graph.pkl"
-    service = DiscordGraphMemory(str(storage))
+    service = CIRISLocalGraph(str(storage))
     await service.start()
     assert len(service.graph.nodes) == 0
 
@@ -27,16 +27,16 @@ async def test_memory_graph_loads_existing(tmp_path: Path):
     g = nx.DiGraph()
     g.add_node("alice", kind="nice")
     with storage.open("wb") as f:
-        pickle.dump(g, f)
+        pickle.dump({"task specific": g}, f)
 
-    service = DiscordGraphMemory(str(storage))
+    service = CIRISLocalGraph(str(storage))
     assert "alice" in service.graph
 
 
 @pytest.mark.asyncio
 async def test_memorize_channel_write(tmp_path: Path):
     storage = tmp_path / "graph.pkl"
-    service = DiscordGraphMemory(str(storage))
+    service = CIRISLocalGraph(str(storage))
     await service.start()
 
     result = await service.memorize("alice", "general", {"kind": "nice"})
@@ -49,7 +49,7 @@ async def test_memorize_channel_write(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_user_memorize_no_channel(tmp_path: Path):
     storage = tmp_path / "graph.pkl"
-    service = DiscordGraphMemory(str(storage))
+    service = CIRISLocalGraph(str(storage))
     await service.start()
     result = await service.memorize("bob", None, {"score": 1})
     assert result.status == MemoryOpStatus.SAVED
@@ -60,7 +60,7 @@ async def test_user_memorize_no_channel(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_observe_does_not_modify_graph(tmp_path: Path):
     storage = tmp_path / "graph.pkl"
-    service = DiscordGraphMemory(str(storage))
+    service = CIRISLocalGraph(str(storage))
     await service.start()
 
     dispatch_mock = AsyncMock()
@@ -76,7 +76,7 @@ async def test_observe_does_not_modify_graph(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_observe_queries_graph(tmp_path: Path):
     storage = tmp_path / "graph.pkl"
-    service = DiscordGraphMemory(str(storage))
+    service = CIRISLocalGraph(str(storage))
     await service.start()
 
     remember_mock = AsyncMock()
@@ -97,14 +97,14 @@ async def test_observe_queries_graph(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_graph_persistence_roundtrip(tmp_path: Path):
     storage = tmp_path / "graph.pkl"
-    service = DiscordGraphMemory(str(storage))
+    service = CIRISLocalGraph(str(storage))
     await service.start()
 
     result = await service.memorize("dave", "general", {"level": 5})
     assert result.status == MemoryOpStatus.SAVED
     await service.stop()
 
-    new_service = DiscordGraphMemory(str(storage))
+    new_service = CIRISLocalGraph(str(storage))
     await new_service.start()
     data = await new_service.remember("dave")
     assert data["level"] == 5
@@ -117,7 +117,7 @@ async def test_memorize_and_remember_multiple_key_values(tmp_path: Path):
     retrieved correctly.
     """
     storage_path = tmp_path / "test_multi_key_graph.pkl"
-    service = DiscordGraphMemory(str(storage_path))
+    service = CIRISLocalGraph(str(storage_path))
     await service.start()
 
     user_nick = "test_user_multi"

--- a/tests/utils/test_graphql_context_provider.py
+++ b/tests/utils/test_graphql_context_provider.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import AsyncMock
 
 from ciris_engine.utils.graphql_context_provider import GraphQLContextProvider, GraphQLClient
-from ciris_engine.services.discord_graph_memory import DiscordGraphMemory
+from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph
 
 class DummyTask:
     def __init__(self, author):
@@ -20,7 +20,7 @@ def _mk_client(response):
 
 @pytest.mark.asyncio
 async def test_fallback_to_memory(tmp_path):
-    mem = DiscordGraphMemory(str(tmp_path / "graph.pkl"))
+    mem = CIRISLocalGraph(str(tmp_path / "graph.pkl"))
     await mem.start()
     await mem.memorize("alice", None, {"nick": "AliceNick", "channel": "general"})
 
@@ -33,7 +33,7 @@ async def test_fallback_to_memory(tmp_path):
 
 @pytest.mark.asyncio
 async def test_partial_fallback(tmp_path):
-    mem = DiscordGraphMemory(str(tmp_path / "graph.pkl"))
+    mem = CIRISLocalGraph(str(tmp_path / "graph.pkl"))
     await mem.start()
     await mem.memorize("bob", None, {"nick": "Bobby", "channel": "random"})
 


### PR DESCRIPTION
## Summary
- add generic graph schemas
- implement `CIRISLocalGraph` service
- replace `DiscordGraphMemory` usages with the new service
- update docs and tests for the new memory layer

## Testing
- `pytest -q`