### PR TITLE
Fix deferral package retrieval

### DIFF
--- a/ciris_engine/core/graph_schemas.py
+++ b/ciris_engine/core/graph_schemas.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+from enum import Enum
+from typing import Dict, Any, Optional
+from pydantic import BaseModel, Field
+
+from .foundational_schemas import (
+    CIRISSchemaVersion,
+    CIRISAgentUAL,
+)
+
+class GraphScope(str, Enum):
+    LOCAL = "task specific"            # users / channels
+    IDENTITY = "identity"      # agent’s self-model (WA-gated)
+    ENVIRONMENT = "environment"  # external, OriginTrail-mirrored
+
+class NodeType(str, Enum):
+    AGENT = "agent"
+    USER = "user"
+    CHANNEL = "channel"
+    TASK = "task"
+    KNOWLEDGE_ASSET = "knowledge_asset"
+    EXTERNAL_ENTITY = "external_entity"
+
+class EdgeLabel(str, Enum):
+    PARTICIPATES_IN = "participates_in"
+    ASSOCIATED_WITH = "associated_with"
+    PRODUCES = "produces"
+    DERIVED_FROM = "derived_from"
+
+class GraphNode(BaseModel):
+    schema_version: CIRISSchemaVersion = CIRISSchemaVersion.V1_0_BETA
+    id: str                                 # e.g. "User:1234"
+    ual: Optional[str] = None               # optional global ID
+    type: NodeType
+    scope: GraphScope
+    attrs: Dict[str, Any] = Field(default_factory=dict)
+
+class GraphEdge(BaseModel):
+    schema_version: CIRISSchemaVersion = CIRISSchemaVersion.V1_0_BETA
+    source: str                             # node.id
+    target: str
+    label: EdgeLabel
+    scope: GraphScope
+    attrs: Dict[str, Any] = Field(default_factory=dict)
+
+class GraphUpdateEvent(BaseModel):
+    node: Optional[GraphNode] = None
+    edge: Optional[GraphEdge] = None
+    actor: CIRISAgentUAL                    # requester
+    rationale: Optional[str] = None         # mandatory for IDENTITY writes
+
+class MemoryActionType(str, Enum):
+    MEMORIZE = "memorize"
+    REMEMBER = "remember"
+    FORGET = "forget"
+
+class MemoryAction(BaseModel):
+    """Generic message the MemoryHandler sends to the graph backend."""
+
+    action: MemoryActionType
+    scope: GraphScope
+    payload: Optional[GraphUpdateEvent] = None
+    query: Optional[str] = None
+    actor: CIRISAgentUAL

--- a/ciris_engine/services/discord_deferral_sink.py
+++ b/ciris_engine/services/discord_deferral_sink.py
@@ -69,7 +69,9 @@ class DiscordDeferralSink(Service, DeferralSink):
                 f"**Deferral Package:** ```json\n{json.dumps(package, indent=2)}\n```"
             )
         sent = await channel.send(_truncate_discord_message(report))
-        persistence.save_deferral_report_mapping(str(sent.id), task_id, thought_id)
+        persistence.save_deferral_report_mapping(
+            str(sent.id), task_id, thought_id, package
+        )
 
     async def process_possible_correction(self, msg: IncomingMessage, raw_message: Any) -> bool:
         if not self.deferral_channel_id or str(self.deferral_channel_id) != msg.channel_id:
@@ -81,8 +83,8 @@ class DiscordDeferralSink(Service, DeferralSink):
         mapping = persistence.get_deferral_report_context(ref_message_id)
         if not mapping:
             return False
-        task_id, corrected_thought_id = mapping
-        deferral_data = None
+        task_id, corrected_thought_id, stored_package = mapping
+        deferral_data = stored_package
         try:
             replied_content = raw_message.reference.resolved.content if raw_message.reference.resolved else None
         except Exception:

--- a/ciris_engine/services/discord_service.py
+++ b/ciris_engine/services/discord_service.py
@@ -211,7 +211,7 @@ class DiscordService(Service):
                 if message.reference and message.reference.message_id:
                     mapping = persistence.get_deferral_report_context(str(message.reference.message_id))
                     if mapping:
-                        original_task_id, corrected_thought_id = mapping
+                        original_task_id, corrected_thought_id, _ = mapping
                         logger.info(
                             "Retrieved deferral mapping for message %s -> task %s, thought %s",
                             message.reference.message_id,
@@ -397,6 +397,7 @@ class DiscordService(Service):
                                     str(sent_report.id),
                                     source_task_id,
                                     deferred_thought_id,
+                                    package,
                                 )
                             except Exception as send_exc:
                                 logger.error(

--- a/tests/core/test_persistence.py
+++ b/tests/core/test_persistence.py
@@ -274,8 +274,9 @@ def test_deferral_report_mapping(initialized_db):
     persistence.add_task(task)
     persistence.add_thought(thought)
 
-    persistence.save_deferral_report_mapping("msg1", "task1", "th1")
+    package = {"k": "v"}
+    persistence.save_deferral_report_mapping("msg1", "task1", "th1", package)
     result = persistence.get_deferral_report_context("msg1")
-    assert result == ("task1", "th1")
+    assert result == ("task1", "th1", package)
 
     assert persistence.get_deferral_report_context("missing") is None

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -217,3 +217,14 @@ def test_memorize_params_confidence_validation():
     # Valid
     params = MemorizeParams(knowledge_unit_description="test", knowledge_data="data", knowledge_type="fact", source="test", confidence=0.5)
     assert params.confidence == 0.5
+
+from ciris_engine.core.graph_schemas import GraphScope, MemoryAction, MemoryActionType
+
+
+def test_memory_action_scope_required():
+    m = MemoryAction(
+        action=MemoryActionType.MEMORIZE,
+        scope=GraphScope.LOCAL,
+        actor="did:example:agent1",
+    )
+    assert m.scope == GraphScope.LOCAL

--- a/tests/services/test_discord_correction.py
+++ b/tests/services/test_discord_correction.py
@@ -5,8 +5,23 @@ from datetime import datetime, timezone
 import pytest
 
 from ciris_engine.services.discord_deferral_sink import DiscordDeferralSink
-from ciris_engine.core.agent_core_schemas import Task
+from ciris_engine.core.agent_core_schemas import Task, Thought
+from ciris_engine.core.foundational_schemas import IncomingMessage
+from pathlib import Path
 from ciris_engine.core import persistence
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "test_service.db"
+
+@pytest.fixture
+def mock_db_path(monkeypatch, db_path: Path):
+    monkeypatch.setattr(persistence, "get_sqlite_db_full_path", lambda: str(db_path))
+
+@pytest.fixture
+def initialized_db(mock_db_path):
+    persistence.initialize_database()
+    yield
 
 @pytest.mark.asyncio
 async def test_create_correction_thought(monkeypatch):
@@ -27,3 +42,39 @@ async def test_create_correction_thought(monkeypatch):
     service._create_correction_thought("task1", "th0", msg, None)
     assert added["thought"].source_task_id == "task1"
     assert added["thought"].related_thought_id == "th0"
+
+@pytest.mark.asyncio
+async def test_correction_fallback_to_stored_package(initialized_db, monkeypatch):
+    adapter = SimpleNamespace(client=SimpleNamespace())
+    service = DiscordDeferralSink(adapter, "1")
+
+    # persist mapping with package
+    pkg = {"foo": "bar"}
+    now = datetime.now(timezone.utc).isoformat()
+    persistence.add_task(Task(task_id="t", description="d", created_at=now, updated_at=now))
+    persistence.add_thought(
+        Thought(
+            thought_id="th",
+            source_task_id="t",
+            thought_type="t",
+            content="c",
+            created_at=now,
+            updated_at=now,
+            round_created=0,
+        )
+    )
+    persistence.save_deferral_report_mapping("99", "t", "th", pkg)
+
+    captured = {}
+    def fake_create(task_id, thought_id, msg, package):
+        captured["package"] = package
+    monkeypatch.setattr(service, "_create_correction_thought", fake_create)
+
+    msg = IncomingMessage(
+        message_id="m", author_id="2", author_name="wa", content="c", channel_id="1", reference_message_id="99"
+    )
+    raw = SimpleNamespace(reference=SimpleNamespace(message_id="99", resolved=SimpleNamespace(content="no json")), author=SimpleNamespace(id=2, name="wa"), id=5, content="c", created_at=datetime.now(timezone.utc))
+
+    handled = await service.process_possible_correction(msg, raw)
+    assert handled
+    assert captured["package"] == pkg


### PR DESCRIPTION
## Summary
- add graph schemas with GraphScope and MemoryAction
- document required deferral package fields and provide `make_defer_result`
- refactor workflow coordinator to use helper
- include test covering stored package fallback
- verify new memory action schema

## Testing
- `pytest -q`
