### PR TITLE
Add governance fields to graph schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ The repository root contains the following notable directories and scripts:
 * `legacy/` – archived utilities and documents.
 * `run_*.py` – example launch scripts for CLI and Discord agents.
 
+## Graph Schema Governance Fields
+
+The graph data model tracks additional metadata for governance and compliance:
+
+* **Consensus & Provenance:** `validated_by`, `validation_state`, and
+  `consensus_timestamp` record who verified a node or edge and when.
+* **Versioning & Forks:** `version`, `previous_versions`, and `forked_from` help
+  maintain history and lineage.
+* **Emergency Control:** `emergency_state`, `emergency_timestamp`, and
+  `emergency_authorized_by` allow privileged parties to freeze or revoke nodes
+  or edges.
+* **Ethical Compliance:** `pdma_compliance_status` and `wbd_escalation_ref`
+  capture the status of PDMA reviews and any associated deferral events.
+* **Access Control:** `confidentiality_level` and `access_control_list` specify
+  who may view or modify sensitive graph entries.
+
+These fields are optional but enforced by schema validation when present. A node
+cannot enter an emergency state without a timestamp, for example. See
+`ciris_engine/core/graph_schemas.py` for the full definitions.
+
 ## Guardrails Summary
 
 The system enforces the following guardrails via `app_config.guardrails_config`:

--- a/tests/core/test_graph_schema_updates.py
+++ b/tests/core/test_graph_schema_updates.py
@@ -1,0 +1,41 @@
+import pytest
+from pydantic import ValidationError
+from ciris_engine.core.graph_schemas import (
+    GraphNode,
+    GraphEdge,
+    NodeType,
+    GraphScope,
+    ValidationState,
+    EmergencyState,
+    ConfidentialityLevel,
+)
+
+
+def test_graph_node_defaults():
+    node = GraphNode(id="n", type=NodeType.USER, scope=GraphScope.LOCAL)
+    assert node.version == 1
+    assert node.validation_state is ValidationState.PENDING
+    assert node.confidentiality_level is ConfidentialityLevel.PUBLIC
+    assert node.validated_by is None
+
+
+def test_emergency_requires_timestamp():
+    with pytest.raises(ValidationError):
+        GraphNode(
+            id="n",
+            type=NodeType.USER,
+            scope=GraphScope.LOCAL,
+            emergency_state=EmergencyState.ACTIVE,
+        )
+
+
+def test_validated_by_requires_non_pending_state():
+    with pytest.raises(ValidationError):
+        GraphEdge(
+            source="a",
+            target="b",
+            label="produces",
+            scope=GraphScope.LOCAL,
+            validated_by=["alice"],
+        )
+


### PR DESCRIPTION
## Summary
- expand graph schemas with governance and security fields
- validate new fields via Pydantic
- document governance metadata in README
- test new graph schema behaviour

## Testing
- `pytest -q`