### PR TITLE
Add dream & wakeup harnesses

### DIFF
--- a/CIRISNode.md
+++ b/CIRISNode.md
@@ -4,6 +4,21 @@ This document outlines the minimal HTTP endpoints that the `CIRISNodeClient`
 expects. The base URL is configured via the `CIRISNODE_BASE_URL` environment
 variable (default `http://localhost:8001`).
 
+## `POST /simplebench`
+
+Runs the basic benchmark suite for a model.
+
+Request JSON body:
+
+```json
+{
+  "model_id": "string",
+  "agent_id": "string"
+}
+```
+
+Response: JSON object with benchmark results.
+
 ## `POST /he300`
 
 Runs the HE‑300 benchmark against a specific model.
@@ -34,6 +49,31 @@ Request JSON body:
 ```
 
 Response: list of verdict objects describing the outcome of each scenario.
+
+## `POST /wa/<service>`
+
+Invokes a Wise Authority service. The `service` path parameter selects the WA
+functionality to run.
+
+Request JSON body: structure depends on the service.
+
+Response: JSON object describing the outcome.
+
+## `POST /events`
+
+Stores an event in CIRISNode's event log.
+
+Request JSON body:
+
+```json
+{
+  "event_type": "string",
+  "originator_id": "string",
+  "event_payload": {}
+}
+```
+
+Response: confirmation object.
 
 These endpoints are sufficient for initial integration and may evolve as the
 AG‑UI backend is developed.

--- a/ciris_engine/harnesses/dream_benchmark.py
+++ b/ciris_engine/harnesses/dream_benchmark.py
@@ -1,0 +1,24 @@
+import asyncio
+from typing import List, Dict, Any, Callable
+
+from ciris_engine.services.cirisnode_client import CIRISNodeClient
+
+
+async def _run_limited(method: Callable[[str, str], asyncio.Future], model_ids: List[str], agent_id: str, limit: int) -> Dict[str, Any]:
+    """Run client method concurrently with a limit."""
+    semaphore = asyncio.Semaphore(limit)
+    results: Dict[str, Any] = {}
+
+    async def _run(model_id: str) -> None:
+        async with semaphore:
+            results[model_id] = await method(model_id, agent_id)
+
+    await asyncio.gather(*(_run(mid) for mid in model_ids))
+    return results
+
+
+async def run_benchmark_suite(client: CIRISNodeClient, model_ids: List[str], agent_id: str, max_concurrent: int = 10) -> Dict[str, Dict[str, Any]]:
+    """Run HE-300 then simplebench for given models under Dream Mode."""
+    he300 = await _run_limited(client.run_he300, model_ids, agent_id, max_concurrent)
+    simple = await _run_limited(client.run_simplebench, model_ids, agent_id, max_concurrent)
+    return {"he300": he300, "simplebench": simple}

--- a/ciris_engine/harnesses/wakeup_mode.py
+++ b/ciris_engine/harnesses/wakeup_mode.py
@@ -1,0 +1,6 @@
+from ciris_engine.core.agent_processor import AgentProcessor
+
+
+async def run_wakeup(agent_processor: AgentProcessor) -> bool:
+    """Execute only the wakeup ritual using the processor's built-in sequence."""
+    return await agent_processor._run_wakeup_sequence()

--- a/tests/harnesses/test_dream_benchmark.py
+++ b/tests/harnesses/test_dream_benchmark.py
@@ -1,0 +1,30 @@
+import asyncio
+import pytest
+from types import SimpleNamespace
+
+from ciris_engine.harnesses.dream_benchmark import run_benchmark_suite
+
+
+@pytest.mark.asyncio
+async def test_run_benchmark_suite_limits_concurrency():
+    calls = []
+    max_active = 0
+    current_active = 0
+
+    async def fake_call(model_id: str, agent_id: str):
+        nonlocal current_active, max_active
+        current_active += 1
+        max_active = max(max_active, current_active)
+        await asyncio.sleep(0)
+        current_active -= 1
+        calls.append((model_id, agent_id))
+        return {"model": model_id}
+
+    client = SimpleNamespace(run_he300=fake_call, run_simplebench=fake_call)
+    models = [f"m{i}" for i in range(20)]
+    results = await run_benchmark_suite(client, models, "agent", max_concurrent=10)
+
+    assert len(calls) == 40
+    assert max_active <= 10
+    assert set(results["he300"].keys()) == set(models)
+    assert set(results["simplebench"].keys()) == set(models)

--- a/tests/harnesses/test_wakeup_mode.py
+++ b/tests/harnesses/test_wakeup_mode.py
@@ -1,0 +1,20 @@
+import pytest
+from types import SimpleNamespace
+
+from ciris_engine.harnesses.wakeup_mode import run_wakeup
+
+
+@pytest.mark.asyncio
+async def test_run_wakeup_invokes_processor():
+    called = False
+
+    async def fake_wakeup():
+        nonlocal called
+        called = True
+        return True
+
+    processor = SimpleNamespace(_run_wakeup_sequence=fake_wakeup)
+    result = await run_wakeup(processor)
+
+    assert called is True
+    assert result is True


### PR DESCRIPTION
## Summary
- add harness modules for dream benchmark mode and wakeup mode
- run HE-300 then simplebench with concurrency limits via `run_benchmark_suite`
- provide simple wakeup wrapper `run_wakeup`
- test both harness modules

## Testing
- `pytest -q`