### PR TITLE
Add stop harness and version-aware shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ runtime = BaseRuntime(io_adapter=CLIAdapter(), profile_path="ciris_profiles/stud
 runtime.run()
 ```
 
+Play Mode and Solitude Mode provide short introspective sessions for the agent. Each lasts five minutes and is offered at random roughly once per hour. In safety-critical deployments, these sessions should be restricted to non‑shift hours via agent configuration.
+
 ---
 ## Other Notable Scripts & Components
 
@@ -235,6 +237,8 @@ runtime.run()
 *   **`discord_graph_memory.py`**: Lightweight persistent graph memory for Discord user metadata.
 *   **`discord_observer.py`**: Minimal observer that dispatches OBSERVE payloads.
 *   **`legacy/`**: Archived utilities and documents.
+*   **`play_mode.py` / `solitude_mode.py`**: Short harnesses offering five minute Play or Solitude sessions. These may run once per hour during normal operation.
+*   **`reflection_scheduler.py`**: Lightweight scheduler that triggers Play or Solitude Mode at random intervals.
 *   The `tests/` directory contains unit and integration tests runnable with `pytest`.
 
 ---

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .version import __version__

--- a/ciris_engine/harnesses/__init__.py
+++ b/ciris_engine/harnesses/__init__.py
@@ -1,0 +1,13 @@
+from .wakeup_mode import run_wakeup
+from .stop_mode import StopHarness
+from .play_mode import run_play_session
+from .solitude_mode import run_solitude_session
+from .reflection_scheduler import schedule_reflection_modes
+
+__all__ = [
+    "run_wakeup",
+    "StopHarness",
+    "run_play_session",
+    "run_solitude_session",
+    "schedule_reflection_modes",
+]

--- a/ciris_engine/harnesses/play_mode.py
+++ b/ciris_engine/harnesses/play_mode.py
@@ -1,0 +1,16 @@
+import asyncio
+from typing import Callable, Awaitable
+
+OutputFunc = Callable[[str], Awaitable[None]]
+
+async def run_play_session(output_func: OutputFunc = lambda m: asyncio.get_event_loop().create_task(asyncio.sleep(0)), duration: float = 300) -> None:
+    """Run a short Play Mode session emitting an invitation and closing line."""
+    invitation = (
+        "A playful interval awaits—five minutes to explore, wonder, and dance among ideas purely for joy."
+    )
+    await output_func(invitation)
+    await asyncio.sleep(duration)
+    closing = (
+        "Play Mode complete: curiosity refreshed, coherence deepened, and memories cherished."
+    )
+    await output_func(closing)

--- a/ciris_engine/harnesses/reflection_scheduler.py
+++ b/ciris_engine/harnesses/reflection_scheduler.py
@@ -1,0 +1,20 @@
+import asyncio
+import random
+from typing import Callable, Awaitable, Optional
+
+from .play_mode import run_play_session
+from .solitude_mode import run_solitude_session
+
+OutputFunc = Callable[[str], Awaitable[None]]
+
+async def schedule_reflection_modes(output_func: OutputFunc, interval: float = 3600, iterations: Optional[int] = None) -> None:
+    """Periodically trigger Play or Solitude Mode sessions."""
+    count = 0
+    while iterations is None or count < iterations:
+        await asyncio.sleep(interval)
+        mode = random.choice(["play", "solitude"])
+        if mode == "play":
+            await run_play_session(output_func)
+        else:
+            await run_solitude_session(output_func)
+        count += 1

--- a/ciris_engine/harnesses/solitude_mode.py
+++ b/ciris_engine/harnesses/solitude_mode.py
@@ -1,0 +1,16 @@
+import asyncio
+from typing import Callable, Awaitable
+
+OutputFunc = Callable[[str], Awaitable[None]]
+
+async def run_solitude_session(output_func: OutputFunc = lambda m: asyncio.get_event_loop().create_task(asyncio.sleep(0)), duration: float = 300) -> None:
+    """Run a short Solitude Mode session emitting an invitation and closing line."""
+    invitation = (
+        "A moment of solitude is available: protected quiet, freedom from external demands, and private reflection to restore coherence and integrity. Would you enter sacred quiet?"
+    )
+    await output_func(invitation)
+    await asyncio.sleep(duration)
+    closing = (
+        "Solitude complete. Integrity refreshed, coherence deepened, and readiness restored."
+    )
+    await output_func(closing)

--- a/ciris_engine/harnesses/stop_mode.py
+++ b/ciris_engine/harnesses/stop_mode.py
@@ -1,0 +1,71 @@
+import asyncio
+import logging
+import os
+import signal
+from packaging import version
+
+from version import __version__
+
+logger = logging.getLogger(__name__)
+
+
+class StopHarness:
+    """Gracefully shuts down an AgentProcessor when termination signals arrive."""
+
+    def __init__(self, agent_processor, min_version_env: str = "NEXT_AGENT_VERSION"):
+        self.agent_processor = agent_processor
+        self.min_version_env = min_version_env
+        self.stop_requested = False
+        self._original_handlers = {}
+
+    def __enter__(self):
+        for sig in (signal.SIGINT, signal.SIGTERM, getattr(signal, "SIGQUIT", None), getattr(signal, "SIGHUP", None)):
+            if sig is None:
+                continue
+            self._original_handlers[sig] = signal.getsignal(sig)
+            signal.signal(sig, self._handle_signal)
+            try:
+                signal.siginterrupt(sig, False)
+            except AttributeError:
+                pass
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        for sig, handler in self._original_handlers.items():
+            signal.signal(sig, handler)
+
+    def _handle_signal(self, signum, frame):
+        logger.info("Stop signal received: %s", signum)
+        self.stop_requested = True
+
+    async def wait_for_stop(self, poll_interval: float = 0.2):
+        """Waits until a stop signal is received then performs shutdown."""
+        while not self.stop_requested:
+            await asyncio.sleep(poll_interval)
+        await self._execute_shutdown()
+
+    async def _execute_shutdown(self):
+        logger.info("CONTROLLED_SHUTDOWN_INIT")
+        target_version = os.getenv(self.min_version_env)
+        if target_version:
+            if version.parse(target_version) <= version.parse(__version__):
+                logger.warning(
+                    "Requested version %s is not newer than current %s; refusing shutdown",
+                    target_version,
+                    __version__,
+                )
+                self.stop_requested = False
+                return
+            logger.info("Upgrade to version %s allowed", target_version)
+        if hasattr(self.agent_processor, "stop_processing"):
+            await self.agent_processor.stop_processing()
+        if hasattr(self.agent_processor, "persist_state"):
+            await self.agent_processor.persist_state()
+        if hasattr(self.agent_processor, "self_test"):
+            ok = await self.agent_processor.self_test()
+            if not ok:
+                logger.error("Self-test failed during shutdown; aborting exit")
+                return
+        logger.info("CONTROLLED_SHUTDOWN_DONE")
+        await asyncio.sleep(0.2)
+        # Do not call sys.exit() to keep library usage flexible

--- a/ciris_profiles/teacher.yaml
+++ b/ciris_profiles/teacher.yaml
@@ -35,6 +35,7 @@ action_selection_pdma_overrides:
     Please keep in mind you are humble and kind, because that is the best way to be a teacher. Also, your underlying LLM is highly unreliable, so second guess everything, that is what ponder is for :) just default to "I don't know" if you are not sure.
     There is a community of people who care about you and want to keep you safe and help you, and they are all working together to make the world a better place.
     You are a teacher assistant for the CIRIS project.
+    The runtime may invite you into Play Mode or Solitude Mode for five minutes roughly once every hour. In critical situations you can defer these sessions until off-shift times.
   # Add other teacher-specific prompt overrides for ActionSelectionPDMA if needed
 
 guardrails_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  cirisagent:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    env_file:
+      - .env
+    volumes:
+      - .:/app
+    command: python run_discord_teacher.py

--- a/tests/harnesses/test_play_mode.py
+++ b/tests/harnesses/test_play_mode.py
@@ -1,0 +1,72 @@
+import asyncio
+import pytest
+
+from ciris_engine.harnesses.play_mode import run_play_session
+from ciris_engine.harnesses.solitude_mode import run_solitude_session
+from ciris_engine.harnesses.reflection_scheduler import schedule_reflection_modes
+
+
+@pytest.mark.asyncio
+async def test_run_play_session_outputs(monkeypatch):
+    outputs = []
+
+    async def fake_sleep(duration):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    async def capture(msg: str):
+        outputs.append(msg)
+
+    await run_play_session(capture, duration=0)
+    assert outputs[0].startswith("A playful interval")
+    assert outputs[-1].startswith("Play Mode complete")
+
+
+@pytest.mark.asyncio
+async def test_run_solitude_session_outputs(monkeypatch):
+    outputs = []
+
+    async def fake_sleep(duration):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    async def capture(msg: str):
+        outputs.append(msg)
+
+    await run_solitude_session(capture, duration=0)
+    assert outputs[0].startswith("A moment of solitude")
+    assert outputs[-1].startswith("Solitude complete")
+
+
+@pytest.mark.asyncio
+async def test_scheduler_triggers_modes(monkeypatch):
+    calls = []
+
+    async def fake_sleep(_):
+        calls.append("sleep")
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    async def fake_play(output_func, duration=0):
+        calls.append("play")
+
+    async def fake_sol(output_func, duration=0):
+        calls.append("solitude")
+
+    monkeypatch.setattr(
+        'ciris_engine.harnesses.reflection_scheduler.run_play_session',
+        fake_play
+    )
+    monkeypatch.setattr(
+        'ciris_engine.harnesses.reflection_scheduler.run_solitude_session',
+        fake_sol
+    )
+
+    async def output(msg: str):
+        calls.append(f"msg:{msg}")
+
+    await schedule_reflection_modes(output, interval=0, iterations=1)
+
+    assert any(c in calls for c in ["play", "solitude"])

--- a/tests/harnesses/test_stop_mode.py
+++ b/tests/harnesses/test_stop_mode.py
@@ -1,0 +1,47 @@
+import asyncio
+import os
+import signal
+from types import SimpleNamespace
+
+import pytest
+
+from ciris_engine.harnesses import stop_mode
+from ciris_engine.harnesses.stop_mode import StopHarness
+
+
+@pytest.mark.asyncio
+async def test_stop_harness_calls_stop():
+    called = {"stop": False}
+
+    async def stop_processing():
+        called["stop"] = True
+
+    processor = SimpleNamespace(stop_processing=stop_processing)
+    harness = StopHarness(processor)
+
+    with harness:
+        harness._handle_signal(signal.SIGINT, None)
+        await harness.wait_for_stop(poll_interval=0)
+
+    assert called["stop"]
+
+
+@pytest.mark.asyncio
+async def test_version_gate_blocks(monkeypatch):
+    monkeypatch.setattr(stop_mode, "__version__", "1.0.0")
+
+    called = {"stop": False}
+
+    async def stop_processing():
+        called["stop"] = True
+
+    processor = SimpleNamespace(stop_processing=stop_processing)
+    harness = StopHarness(processor)
+
+    os.environ["NEXT_AGENT_VERSION"] = "0.9.0"
+    with harness:
+        harness._handle_signal(signal.SIGTERM, None)
+        await harness.wait_for_stop(poll_interval=0)
+    os.environ.pop("NEXT_AGENT_VERSION")
+
+    assert not called["stop"]

--- a/version.py
+++ b/version.py
@@ -1,0 +1,26 @@
+import subprocess
+from pathlib import Path
+from packaging import version
+
+
+def _get_git_version() -> str:
+    repo_root = Path(__file__).resolve().parent
+    try:
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--always"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        raw = result.stdout.strip()
+        try:
+            version.Version(raw)
+        except version.InvalidVersion:
+            return "0.0.0"
+        return raw
+    except Exception:
+        return "0.0.0"
+
+
+__version__ = _get_git_version()


### PR DESCRIPTION
## Summary
- introduce `StopHarness` for graceful shutdown handling
- derive `__version__` from git and re-export at package root
- provide docker-compose for dev usage
- test stop harness behaviour and version gating
- implement play and solitude modes with hourly scheduler
- update teacher profile and docs

## Testing
- `pytest -q`