### PR TITLE
Introduce simplified core processor/coordinator

### DIFF
--- a/ciris_core/__init__.py
+++ b/ciris_core/__init__.py
@@ -1,0 +1,7 @@
+"""Simplified CIRIS runtime core logic."""
+
+from .states import AgentState
+from .coordinator import Coordinator
+from .processor import Processor
+
+__all__ = ["AgentState", "Coordinator", "Processor"]

--- a/ciris_core/coordinator.py
+++ b/ciris_core/coordinator.py
@@ -1,0 +1,19 @@
+"""Minimal workflow coordinator.
+
+This coordinator is intentionally small for pre-alpha refactoring work. It
+receives a :class:`Thought` and returns the recommended
+:class:`HandlerActionType`. Real DMA logic will be integrated later.
+"""
+
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
+
+
+class Coordinator:
+    """Simplified coordinator that decides on a final action."""
+
+    async def process_thought(self, thought: Thought) -> HandlerActionType:
+        """Return a basic action recommendation for the given thought."""
+        if thought.thought_type == "seed":
+            return HandlerActionType.SPEAK
+        return HandlerActionType.PONDER

--- a/ciris_core/processor.py
+++ b/ciris_core/processor.py
@@ -1,0 +1,56 @@
+"""Simplified agent processor for pre-alpha refactoring."""
+
+import asyncio
+from typing import Dict, Optional
+from datetime import datetime, timezone
+
+from ciris_engine.schemas.agent_core_schemas_v1 import Task, Thought
+from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus, ThoughtStatus
+
+from .states import AgentState
+from .coordinator import Coordinator
+
+
+class Processor:
+    """Minimal in-memory processor managing tasks and thoughts."""
+
+    def __init__(self, coordinator: Coordinator):
+        self.coordinator = coordinator
+        self.tasks: Dict[str, Task] = {}
+        self.thoughts: Dict[str, Thought] = {}
+        self.current_state: Optional[AgentState] = None
+
+    def set_state(self, state: AgentState) -> None:
+        """Create or replace the root task for the given state."""
+        now = datetime.now(timezone.utc).isoformat()
+        self.current_state = state
+        root_task = Task(
+            task_id=state.value,
+            description=f"{state.value} root",
+            status=TaskStatus.ACTIVE,
+            priority=0,
+            created_at=now,
+            updated_at=now,
+            parent_task_id=None,
+            context={},
+        )
+        self.tasks[state.value] = root_task
+
+    def add_thought(self, thought: Thought) -> None:
+        """Add a thought to the processing pool."""
+        self.thoughts[thought.thought_id] = thought
+
+    async def process_round(self) -> None:
+        """Process all pending thoughts once."""
+        pending = [t for t in self.thoughts.values() if t.status == ThoughtStatus.PENDING]
+        for thought in pending:
+            thought.status = ThoughtStatus.PROCESSING
+            action = await self.coordinator.process_thought(thought)
+            thought.final_action = {"type": action.value}
+            thought.status = ThoughtStatus.COMPLETED
+
+    async def run(self) -> None:
+        """Continuously process rounds until cancelled."""
+        while True:
+            await self.process_round()
+            await asyncio.sleep(0.1)

--- a/ciris_core/states.py
+++ b/ciris_core/states.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class AgentState(str, Enum):
+    """High-level operational states for CIRIS agent."""
+    WAKEUP = "wakeup"
+    DREAM = "dream"
+    PLAY = "play"
+    SOLITUDE = "solitude"
+    SHUTDOWN = "shutdown"

--- a/tests/ciris_core/test_processor_coordinator.py
+++ b/tests/ciris_core/test_processor_coordinator.py
@@ -1,0 +1,50 @@
+import asyncio
+import pytest
+
+from ciris_core import AgentState, Coordinator, Processor
+from ciris_engine.schemas.agent_core_schemas_v1 import Task, Thought
+from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus, ThoughtStatus
+
+
+@pytest.mark.asyncio
+async def test_set_state_creates_root_task():
+    coord = Coordinator()
+    proc = Processor(coord)
+    proc.set_state(AgentState.WAKEUP)
+    assert proc.current_state == AgentState.WAKEUP
+    assert "wakeup" in proc.tasks
+    root_task = proc.tasks["wakeup"]
+    assert root_task.status == TaskStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_process_round_completes_thought(monkeypatch):
+    coord = Coordinator()
+    proc = Processor(coord)
+    proc.set_state(AgentState.WAKEUP)
+
+    thought = Thought(
+        thought_id="t1",
+        source_task_id="wakeup",
+        thought_type="seed",
+        status=ThoughtStatus.PENDING,
+        created_at="0",
+        updated_at="0",
+        round_number=0,
+        content="hi",
+    )
+    proc.add_thought(thought)
+
+    called = {}
+
+    async def fake_process(th: Thought):
+        called["thought_id"] = th.thought_id
+        return await Coordinator().process_thought(th)
+
+    monkeypatch.setattr(coord, "process_thought", fake_process)
+
+    await proc.process_round()
+
+    assert called.get("thought_id") == "t1"
+    assert thought.status == ThoughtStatus.COMPLETED
+    assert thought.final_action["type"] == "speak"


### PR DESCRIPTION
## Summary
- add new `ciris_core` module with `Processor`, `Coordinator`, and `AgentState`
- include basic tests for the new simplified processor and coordinator

## Testing
- `pytest -q` *(fails: tests/memory/test_memory_handler.py)*