### PR TITLE
Refactor test imports and fixtures

### DIFF
--- a/tests/core/test_action_dispatcher.py
+++ b/tests/core/test_action_dispatcher.py
@@ -2,8 +2,8 @@ import pytest
 from unittest.mock import AsyncMock
 
 from ciris_engine.core.action_dispatcher import ActionDispatcher
-from ciris_engine.core.foundational_schemas import HandlerActionType
-from ciris_engine.core.agent_core_schemas import Thought, ActionSelectionPDMAResult
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ActionSelectionPDMAResult
 
 class DummyHandler:
     def __init__(self):

--- a/tests/core/test_agent_processor.py
+++ b/tests/core/test_agent_processor.py
@@ -11,10 +11,10 @@ import uuid
 from datetime import datetime, timezone
 import collections
 
-from ciris_engine.core.processor import AgentProcessor
-from ciris_engine.core.config_schemas import AppConfig, WorkflowConfig, LLMServicesConfig, OpenAIConfig, DatabaseConfig, GuardrailsConfig
-from ciris_engine.core.agent_core_schemas import Task, Thought, ActionSelectionPDMAResult
-from ciris_engine.core.foundational_schemas import TaskStatus, ThoughtStatus, HandlerActionType # <-- Import HandlerActionType
+from ciris_engine.core.processor.main_processor import AgentProcessor
+from ciris_engine.schemas.config_schemas_v1 import AppConfig, WorkflowConfig, LLMServicesConfig, OpenAIConfig, DatabaseConfig, GuardrailsConfig
+from ciris_engine.schemas.agent_core_schemas_v1 import Task, Thought, ActionSelectionPDMAResult
+from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus, ThoughtStatus, HandlerActionType # <-- Import HandlerActionType
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
 
 # --- Fixtures ---
@@ -96,7 +96,7 @@ def create_mock_thought(thought_id: str, task_id: str, status: ThoughtStatus, pr
 # --- Test Cases ---
 
 @pytest.mark.asyncio
-@patch('ciris_engine.core.agent_processor.persistence')
+@patch('ciris_engine.core.processor.main_processor.persistence')
 async def test_activate_pending_tasks(mock_persistence, agent_processor_instance: AgentProcessor, mock_app_config_for_processor):
     """Test activating pending tasks."""
     max_can_activate = mock_app_config_for_processor.workflow.max_active_tasks
@@ -127,7 +127,7 @@ async def test_activate_pending_tasks(mock_persistence, agent_processor_instance
         mock_persistence.update_task_status.assert_any_call(all_pending_tasks[i].task_id, TaskStatus.ACTIVE)
 
 @pytest.mark.asyncio
-@patch('ciris_engine.core.agent_processor.persistence')
+@patch('ciris_engine.core.processor.main_processor.persistence')
 async def test_generate_seed_thoughts(mock_persistence, agent_processor_instance: AgentProcessor, mock_app_config_for_processor):
     """Test generating seed thoughts."""
     task_needing_seed1 = create_mock_task("task_s1", TaskStatus.ACTIVE)
@@ -148,7 +148,7 @@ async def test_generate_seed_thoughts(mock_persistence, agent_processor_instance
 
 
 @pytest.mark.asyncio
-@patch('ciris_engine.core.agent_processor.persistence')
+@patch('ciris_engine.core.processor.main_processor.persistence')
 async def test_populate_round_queue(mock_persistence, agent_processor_instance: AgentProcessor, mock_app_config_for_processor):
     """Test populating the round queue."""
     # Mock activate_pending_tasks
@@ -175,7 +175,7 @@ async def test_populate_round_queue(mock_persistence, agent_processor_instance: 
 
 
 @pytest.mark.asyncio
-@patch('ciris_engine.core.agent_processor.persistence')
+@patch('ciris_engine.core.processor.main_processor.persistence')
 async def test_process_batch(mock_persistence, agent_processor_instance: AgentProcessor, mock_workflow_coordinator):
     """Test processing a batch of thoughts."""
     thought1 = create_mock_thought("th_batch1", "task_b1", ThoughtStatus.PENDING)
@@ -225,7 +225,7 @@ async def test_process_batch(mock_persistence, agent_processor_instance: AgentPr
 
 
 @pytest.mark.asyncio
-@patch('ciris_engine.core.agent_processor.persistence')
+@patch('ciris_engine.core.processor.main_processor.persistence')
 async def test_dispatch_context_filled_from_task(mock_persistence, agent_processor_instance: AgentProcessor, mock_workflow_coordinator):
     """Ensure missing metadata in dispatch context is sourced from the parent task."""
 
@@ -256,7 +256,7 @@ async def test_dispatch_context_filled_from_task(mock_persistence, agent_process
 
 
 @pytest.mark.asyncio
-@patch('ciris_engine.core.agent_processor.persistence')
+@patch('ciris_engine.core.processor.main_processor.persistence')
 async def test_check_and_complete_task_completes(mock_persistence, agent_processor_instance: AgentProcessor):
     """Test _check_and_complete_task when a task should be completed."""
     active_task = create_mock_task("task_c1", TaskStatus.ACTIVE)
@@ -273,7 +273,7 @@ async def test_check_and_complete_task_completes(mock_persistence, agent_process
 
 
 @pytest.mark.asyncio
-@patch('ciris_engine.core.agent_processor.persistence')
+@patch('ciris_engine.core.processor.main_processor.persistence')
 async def test_check_and_complete_task_not_active(mock_persistence, agent_processor_instance: AgentProcessor):
     """Test _check_and_complete_task when task is not active."""
     pending_task = create_mock_task("task_c2", TaskStatus.PENDING)
@@ -287,7 +287,7 @@ async def test_check_and_complete_task_not_active(mock_persistence, agent_proces
 
 
 @pytest.mark.asyncio
-@patch('ciris_engine.core.agent_processor.persistence')
+@patch('ciris_engine.core.processor.main_processor.persistence')
 async def test_check_and_complete_task_has_pending(mock_persistence, agent_processor_instance: AgentProcessor):
     """Test _check_and_complete_task when task still has pending thoughts."""
     active_task = create_mock_task("task_c3", TaskStatus.ACTIVE)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 
 # Modules to test
-from ciris_engine.core.config_schemas import (
+from ciris_engine.schemas.config_schemas_v1 import (
     AppConfig,
     DatabaseConfig,
     OpenAIConfig,

--- a/tests/core/test_defer_handler.py
+++ b/tests/core/test_defer_handler.py
@@ -1,10 +1,10 @@
 import pytest
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
     ActionSelectionPDMAResult,
     DeferParams,
 )
-from ciris_engine.core.foundational_schemas import HandlerActionType, ThoughtStatus
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, ThoughtStatus
 from ciris_engine.core.action_handlers.defer_handler import DeferHandler
 from ciris_engine.core.action_handlers.base_handler import ActionHandlerDependencies
 from ciris_engine.core import persistence

--- a/tests/core/test_graph_schema_updates.py
+++ b/tests/core/test_graph_schema_updates.py
@@ -1,6 +1,6 @@
 import pytest
 from pydantic import ValidationError
-from ciris_engine.core.graph_schemas import (
+from ciris_engine.schemas.graph_schemas_v1 import (
     GraphNode,
     GraphEdge,
     NodeType,

--- a/tests/core/test_memorize_handler.py
+++ b/tests/core/test_memorize_handler.py
@@ -1,12 +1,12 @@
 import pytest
 from unittest.mock import AsyncMock
 
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
     ActionSelectionPDMAResult,
     MemorizeParams,
 )
-from ciris_engine.core.foundational_schemas import HandlerActionType
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 from ciris_engine.core.action_handlers.memorize_handler import MemorizeHandler
 from ciris_engine.core.action_handlers.base_handler import ActionHandlerDependencies
 from ciris_engine.memory.ciris_local_graph import MemoryOpStatus

--- a/tests/core/test_memory_meta_round.py
+++ b/tests/core/test_memory_meta_round.py
@@ -3,11 +3,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from collections import deque
 
-from ciris_engine.core.processor import AgentProcessor
-from ciris_engine.core.agent_core_schemas import Thought
-from ciris_engine.core.foundational_schemas import ThoughtStatus
+from ciris_engine.core.processor.main_processor import AgentProcessor
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
-from ciris_engine.core.config_schemas import AppConfig, WorkflowConfig, LLMServicesConfig, OpenAIConfig, DatabaseConfig, GuardrailsConfig
+from ciris_engine.schemas.config_schemas_v1 import AppConfig, WorkflowConfig, LLMServicesConfig, OpenAIConfig, DatabaseConfig, GuardrailsConfig
 
 @pytest.fixture
 def simple_app_config():
@@ -28,7 +28,7 @@ def processor(simple_app_config):
     dispatcher.dispatch = AsyncMock()
     return AgentProcessor(app_config=simple_app_config, workflow_coordinator=mock_wc, action_dispatcher=dispatcher, services={})
 
-@patch('ciris_engine.core.agent_processor.persistence')
+@patch('ciris_engine.core.processor.main_processor.persistence')
 @pytest.mark.asyncio
 async def test_memory_meta_round_isolated(mock_persistence, processor: AgentProcessor):
     memory_thought = Thought(

--- a/tests/core/test_observe_handler.py
+++ b/tests/core/test_observe_handler.py
@@ -2,12 +2,12 @@ import pytest
 from unittest.mock import AsyncMock
 from types import SimpleNamespace
 
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
     ActionSelectionPDMAResult,
     ObserveParams,
 )
-from ciris_engine.core.foundational_schemas import HandlerActionType
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 from ciris_engine.core.action_handlers.observe_handler import ObserveHandler
 from ciris_engine.core.action_handlers.base_handler import ActionHandlerDependencies
 from ciris_engine.core import persistence

--- a/tests/core/test_persistence.py
+++ b/tests/core/test_persistence.py
@@ -7,8 +7,8 @@ import uuid
 
 # Module to test
 from ciris_engine.core import persistence
-from ciris_engine.core.foundational_schemas import TaskStatus, ThoughtStatus
-from ciris_engine.core.agent_core_schemas import Task, Thought
+from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus, ThoughtStatus
+from ciris_engine.schemas.agent_core_schemas_v1 import Task, Thought
 
 # --- Fixtures ---
 
@@ -169,7 +169,7 @@ def test_update_thought_status(initialized_db):
     assert updated_thought.final_action_result is not None
     assert updated_thought.final_action_result.selected_handler_action.value == "speak"
     # action_parameters is now a SpeakParams model instance
-    from ciris_engine.core.agent_core_schemas import SpeakParams
+    from ciris_engine.schemas.agent_core_schemas_v1 import SpeakParams
     assert isinstance(updated_thought.final_action_result.action_parameters, SpeakParams)
     assert updated_thought.final_action_result.action_parameters.content == "processed content for persistence" # Corrected expected content
     assert updated_thought.ponder_count == 1

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 
 # Schemas to test
-from ciris_engine.core.foundational_schemas import (
+from ciris_engine.schemas.foundational_schemas_v1 import (
     CIRISSchemaVersion,
     HandlerActionType,
     TaskStatus,
@@ -13,7 +13,7 @@ from ciris_engine.core.foundational_schemas import (
     DKGAssetType,
     CIRISAgentUAL, CIRISTaskUAL, CIRISKnowledgeAssetUAL, VeilidDID, VeilidRouteID
 )
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     ObserveParams, SpeakParams, ActParams, PonderParams, RejectParams, DeferParams,
     MemorizeParams, RememberParams, ForgetParams,
     ActionSelectionPDMAResult,

--- a/tests/core/test_speak_handler.py
+++ b/tests/core/test_speak_handler.py
@@ -1,10 +1,10 @@
 import pytest
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
     ActionSelectionPDMAResult,
     SpeakParams,
 )
-from ciris_engine.core.foundational_schemas import HandlerActionType, ThoughtStatus
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, ThoughtStatus
 from ciris_engine.core.action_handlers.speak_handler import SpeakHandler
 from ciris_engine.core.exceptions import FollowUpCreationError
 from ciris_engine.core.action_handlers.base_handler import ActionHandlerDependencies

--- a/tests/core/test_task_complete_handler.py
+++ b/tests/core/test_task_complete_handler.py
@@ -1,10 +1,10 @@
 import pytest
 
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
     ActionSelectionPDMAResult,
 )
-from ciris_engine.core.foundational_schemas import HandlerActionType, TaskStatus
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, TaskStatus
 from ciris_engine.core.action_handlers.task_complete_handler import TaskCompleteHandler
 from ciris_engine.core.action_handlers.base_handler import ActionHandlerDependencies
 from ciris_engine.core import persistence

--- a/tests/core/test_thought_escalation.py
+++ b/tests/core/test_thought_escalation.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from ciris_engine.core.agent_core_schemas import Thought, ThoughtStatus
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ThoughtStatus
 from ciris_engine.core.thought_escalation import (
     escalate_due_to_action_limit,
     escalate_due_to_sla,

--- a/tests/core/test_tool_handler.py
+++ b/tests/core/test_tool_handler.py
@@ -2,12 +2,12 @@ import pytest
 from unittest.mock import AsyncMock
 from types import SimpleNamespace
 
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
     ActionSelectionPDMAResult,
     ActParams,
 )
-from ciris_engine.core.foundational_schemas import HandlerActionType
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 from ciris_engine.core.action_handlers.tool_handler import ToolHandler
 from ciris_engine.core.action_handlers.base_handler import ActionHandlerDependencies
 from ciris_engine.core import persistence

--- a/tests/core/test_wakeup_sequence.py
+++ b/tests/core/test_wakeup_sequence.py
@@ -8,13 +8,13 @@ import pytest
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, project_root)
 
-from ciris_engine.core.processor import AgentProcessor, WAKEUP_SEQUENCE
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.core.processor.main_processor import AgentProcessor, WAKEUP_SEQUENCE
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     ActionSelectionPDMAResult,
     SpeakParams,
     PonderParams,
 )
-from ciris_engine.core.foundational_schemas import HandlerActionType, TaskStatus
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, TaskStatus
 
 from .test_agent_processor import (
     mock_app_config_for_processor,
@@ -25,7 +25,7 @@ from .test_agent_processor import (
 
 
 @pytest.mark.asyncio
-@patch("ciris_engine.core.agent_processor.persistence")
+@patch("ciris_engine.core.processor.main_processor.persistence")
 async def test_wakeup_sequence_success(mock_persistence, agent_processor_instance: AgentProcessor, mock_workflow_coordinator, mock_action_dispatcher):
     pytest.skip("Wakeup sequence logic updated; skipping outdated test.")
     mock_persistence.task_exists.return_value = False
@@ -54,7 +54,7 @@ async def test_wakeup_sequence_success(mock_persistence, agent_processor_instanc
 
 
 @pytest.mark.asyncio
-@patch("ciris_engine.core.agent_processor.persistence")
+@patch("ciris_engine.core.processor.main_processor.persistence")
 async def test_wakeup_sequence_failure(mock_persistence, agent_processor_instance: AgentProcessor, mock_workflow_coordinator, mock_action_dispatcher):
     pytest.skip("Wakeup sequence logic updated; skipping outdated test.")
     mock_persistence.task_exists.return_value = False
@@ -87,7 +87,7 @@ async def test_wakeup_sequence_failure(mock_persistence, agent_processor_instanc
 
 
 @pytest.mark.asyncio
-@patch("ciris_engine.core.agent_processor.persistence")
+@patch("ciris_engine.core.processor.main_processor.persistence")
 async def test_wakeup_sequence_allows_ponder(mock_persistence, agent_processor_instance: AgentProcessor, mock_workflow_coordinator, mock_action_dispatcher):
     pytest.skip("Wakeup sequence logic updated; skipping outdated test.")
     mock_persistence.task_exists.return_value = False

--- a/tests/core/test_workflow_context.py
+++ b/tests/core/test_workflow_context.py
@@ -2,9 +2,9 @@ import pytest
 from unittest.mock import AsyncMock, patch
 from datetime import datetime, timezone
 
-from ciris_engine.core.workflow_coordinator import WorkflowCoordinator
-from ciris_engine.core.agent_core_schemas import Task, Thought
-from ciris_engine.core.config_schemas import (
+from ciris_engine.core.thought_processor import ThoughtProcessor
+from ciris_engine.schemas.agent_core_schemas_v1 import Task, Thought
+from ciris_engine.schemas.config_schemas_v1 import (
     AppConfig,
     WorkflowConfig,
     LLMServicesConfig,
@@ -13,8 +13,8 @@ from ciris_engine.core.config_schemas import (
     GuardrailsConfig,
     SerializableAgentProfile,
 )
-from ciris_engine.core.foundational_schemas import HandlerActionType
-from ciris_engine.core.foundational_schemas import TaskStatus, ThoughtStatus
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
+from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus, ThoughtStatus
 
 
 @pytest.fixture
@@ -34,15 +34,13 @@ def simple_app_config():
 
 
 @pytest.fixture
-def workflow_coordinator_instance(simple_app_config) -> WorkflowCoordinator:
-    return WorkflowCoordinator(
-        llm_client=AsyncMock(),
-        ethical_pdma_evaluator=AsyncMock(),
-        csdma_evaluator=AsyncMock(),
-        action_selection_pdma_evaluator=AsyncMock(),
-        ethical_guardrails=AsyncMock(),
+def workflow_coordinator_instance(simple_app_config) -> ThoughtProcessor:
+    return ThoughtProcessor(
+        dma_orchestrator=AsyncMock(),
+        context_builder=AsyncMock(),
+        guardrail_orchestrator=AsyncMock(),
+        ponder_manager=AsyncMock(),
         app_config=simple_app_config,
-        memory_service=None,
     )
 
 
@@ -61,10 +59,10 @@ def sample_thought():
     )
 
 @pytest.mark.asyncio
-@patch('ciris_engine.core.workflow_coordinator.persistence')
+@patch('ciris_engine.core.thought_processor.persistence')
 async def test_build_context_includes_recent_tasks_and_profiles(
     mock_persistence,
-    workflow_coordinator_instance: WorkflowCoordinator,
+    workflow_coordinator_instance: ThoughtProcessor,
     sample_thought: Thought,
 ):
     now = datetime.now(timezone.utc).isoformat()

--- a/tests/dma/test_action_selection_pdma.py
+++ b/tests/dma/test_action_selection_pdma.py
@@ -11,22 +11,22 @@ from pydantic import BaseModel # Added BaseModel import
 from openai import AsyncOpenAI
 from instructor.exceptions import InstructorRetryException
 
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
     ThoughtStatus,
     HandlerActionType,
     CIRISSchemaVersion,
 )
-from ciris_engine.core.action_params import SpeakParams, PonderParams
-from ciris_engine.core.dma_results import (
+from ciris_engine.schemas.action_params_v1 import SpeakParams, PonderParams
+from ciris_engine.schemas.dma_results_v1 import (
     ActionSelectionPDMAResult,
     EthicalPDMAResult,
     CSDMAResult,
     DSDMAResult,
 )
-from ciris_engine.core.foundational_schemas import HandlerActionType as CoreHandlerActionType
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType as CoreHandlerActionType
 # from ciris_engine.core.profiles import AgentProfile # Replaced by SerializableAgentProfile
-from ciris_engine.core.config_schemas import SerializableAgentProfile # Import new profile
+from ciris_engine.schemas.config_schemas_v1 import SerializableAgentProfile # Import new profile
 from ciris_engine.dma.action_selection_pdma import (
     ActionSelectionPDMAEvaluator,
     _ActionSelectionLLMResponse, # Internal model for mocking LLM output
@@ -34,7 +34,7 @@ from ciris_engine.dma.action_selection_pdma import (
 )
 from ciris_engine.utils.constants import ENGINE_OVERVIEW_TEMPLATE
 import ciris_engine.dma.action_selection_pdma as action_selection_pdma_module # Import the module itself
-from ciris_engine.core.config_schemas import AppConfig, OpenAIConfig, LLMServicesConfig # Corrected import path
+from ciris_engine.schemas.config_schemas_v1 import AppConfig, OpenAIConfig, LLMServicesConfig # Corrected import path
 from ciris_engine.core.config_manager import get_config # get_config is fine here
 
 # --- Fixtures ---

--- a/tests/dma/test_csdma.py
+++ b/tests/dma/test_csdma.py
@@ -8,10 +8,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from openai import AsyncOpenAI
 
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
-from ciris_engine.core.dma_results import CSDMAResult
-from ciris_engine.core.agent_core_schemas import ThoughtStatus
+from ciris_engine.schemas.dma_results_v1 import CSDMAResult
+from ciris_engine.schemas.agent_core_schemas_v1 import ThoughtStatus
 from ciris_engine.dma.csdma import CSDMAEvaluator
-from ciris_engine.core.config_schemas import DEFAULT_OPENAI_MODEL_NAME, AppConfig, OpenAIConfig, LLMServicesConfig # Added imports
+from ciris_engine.schemas.config_schemas_v1 import DEFAULT_OPENAI_MODEL_NAME, AppConfig, OpenAIConfig, LLMServicesConfig # Added imports
 
 # Fixture for a mock instructor client
 @pytest.fixture

--- a/tests/dma/test_dma_retry.py
+++ b/tests/dma/test_dma_retry.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 import pytest
 
-from ciris_engine.core.agent_core_schemas import Thought, ThoughtStatus
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ThoughtStatus
 from ciris_engine.dma.dma_executor import run_dma_with_retries
 
 

--- a/tests/dma/test_dsdma.py
+++ b/tests/dma/test_dsdma.py
@@ -7,10 +7,10 @@ from openai import AsyncOpenAI
 from instructor.exceptions import InstructorRetryException
 
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
-from ciris_engine.core.dma_results import DSDMAResult
-from ciris_engine.core.agent_core_schemas import ThoughtStatus
+from ciris_engine.schemas.dma_results_v1 import DSDMAResult
+from ciris_engine.schemas.agent_core_schemas_v1 import ThoughtStatus
 from ciris_engine.dma.dsdma_base import BaseDSDMA
-from ciris_engine.core.config_schemas import AppConfig, OpenAIConfig, LLMServicesConfig
+from ciris_engine.schemas.config_schemas_v1 import AppConfig, OpenAIConfig, LLMServicesConfig
 
 
 @pytest.fixture

--- a/tests/dma/test_pdma.py
+++ b/tests/dma/test_pdma.py
@@ -5,14 +5,14 @@ import asyncio
 
 # Module to test
 from ciris_engine.dma.pdma import EthicalPDMAEvaluator, DEFAULT_OPENAI_MODEL_NAME
-from ciris_engine.core.agent_core_schemas import EthicalPDMAResult
+from ciris_engine.schemas.agent_core_schemas_v1 import EthicalPDMAResult
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
 import instructor # For type hinting the mock
 from openai import AsyncOpenAI # For mock_openai_client fixture
 # Added imports for mocking OpenAI response structure
 import openai.types.chat
 from openai.types.chat.chat_completion import ChatCompletion, ChatCompletionMessage, Choice # Corrected import path
-from ciris_engine.core.config_schemas import AppConfig, OpenAIConfig, LLMServicesConfig # Added imports
+from ciris_engine.schemas.config_schemas_v1 import AppConfig, OpenAIConfig, LLMServicesConfig # Added imports
 
 # --- Fixtures ---
 

--- a/tests/e2e/test_memory_actions.py
+++ b/tests/e2e/test_memory_actions.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph, MemoryOpStatus
-from ciris_engine.core.graph_schemas import GraphNode, NodeType, GraphScope
+from ciris_engine.schemas.graph_schemas_v1 import GraphNode, NodeType, GraphScope
 
 @pytest.mark.asyncio
 async def test_memory_action_roundtrip(tmp_path: Path):

--- a/tests/faculties/test_epistemic.py
+++ b/tests/faculties/test_epistemic.py
@@ -9,7 +9,7 @@ from ciris_engine.faculties.epistemic import (
     calculate_epistemic_values,
     DEFAULT_OPENAI_MODEL_NAME
 )
-from ciris_engine.core.agent_core_schemas import EntropyResult, CoherenceResult
+from ciris_engine.schemas.agent_core_schemas_v1 import EntropyResult, CoherenceResult
 import instructor # For type hinting the mock
 
 # --- Fixtures ---

--- a/tests/guardrails/test_epistemic_humility.py
+++ b/tests/guardrails/test_epistemic_humility.py
@@ -5,9 +5,9 @@ from ciris_engine.guardrails import (
     EthicalGuardrails,
     EpistemicHumilityResult,
 )
-from ciris_engine.core.config_schemas import GuardrailsConfig
-from ciris_engine.core.dma_results import ActionSelectionPDMAResult
-from ciris_engine.core.foundational_schemas import HandlerActionType
+from ciris_engine.schemas.config_schemas_v1 import GuardrailsConfig
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionPDMAResult
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 
 
 @pytest.mark.asyncio

--- a/tests/guardrails/test_optimization_veto.py
+++ b/tests/guardrails/test_optimization_veto.py
@@ -2,9 +2,9 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from ciris_engine.guardrails import EthicalGuardrails, OptimizationVetoResult
-from ciris_engine.core.config_schemas import GuardrailsConfig
-from ciris_engine.core.dma_results import ActionSelectionPDMAResult
-from ciris_engine.core.foundational_schemas import HandlerActionType
+from ciris_engine.schemas.config_schemas_v1 import GuardrailsConfig
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionPDMAResult
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 
 @pytest.mark.asyncio
 async def test_optimization_veto_triggers_abort(monkeypatch):

--- a/tests/runtime/test_base_runtime.py
+++ b/tests/runtime/test_base_runtime.py
@@ -7,9 +7,9 @@ import pytest
 
 from ciris_engine.runtime.base_runtime import BaseRuntime, BaseIOAdapter, IncomingMessage
 from ciris_engine.core import persistence
-from ciris_engine.core.foundational_schemas import HandlerActionType
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 from ciris_engine.core.action_dispatcher import ActionDispatcher
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
     ActionSelectionPDMAResult,
     SpeakParams,

--- a/tests/services/test_audit_service.py
+++ b/tests/services/test_audit_service.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from ciris_engine.services.audit_service import AuditService
-from ciris_engine.core.foundational_schemas import HandlerActionType
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 
 @pytest.mark.asyncio
 async def test_log_action_writes_line(tmp_path):

--- a/tests/services/test_discord_correction.py
+++ b/tests/services/test_discord_correction.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import pytest
 
 from ciris_engine.services.discord_deferral_sink import DiscordDeferralSink
-from ciris_engine.core.agent_core_schemas import Task
+from ciris_engine.schemas.agent_core_schemas_v1 import Task
 from ciris_engine.core import persistence
 
 @pytest.mark.asyncio

--- a/tests/services/test_discord_graph_memory.py
+++ b/tests/services/test_discord_graph_memory.py
@@ -5,7 +5,7 @@ import pickle
 import networkx as nx
 
 from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph, MemoryOpStatus, MemoryOpResult
-from ciris_engine.core.graph_schemas import GraphNode, GraphScope, NodeType
+from ciris_engine.schemas.graph_schemas_v1 import GraphNode, GraphScope, NodeType
 from ciris_engine.services.discord_observer import DiscordObserver
 from ciris_engine.services.discord_event_queue import DiscordEventQueue
 from ciris_engine.runtime.base_runtime import IncomingMessage

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -7,7 +7,7 @@ import openai # Import the openai module itself for direct reference
 
 # Module to test
 from ciris_engine.services.llm_client import CIRISLLMClient
-from ciris_engine.core.config_schemas import AppConfig, OpenAIConfig, LLMServicesConfig
+from ciris_engine.schemas.config_schemas_v1 import AppConfig, OpenAIConfig, LLMServicesConfig
 from pydantic import BaseModel, Field
 
 # --- Test Pydantic Model for structured responses ---

--- a/tests/test_observer_active_look.py
+++ b/tests/test_observer_active_look.py
@@ -4,9 +4,9 @@ from types import SimpleNamespace
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
-from ciris_engine.core.action_params import ObserveParams, SpeakParams
-from ciris_engine.core.agent_core_schemas import Thought, ActionSelectionPDMAResult, HandlerActionType
-from ciris_engine.core.foundational_schemas import ThoughtStatus
+from ciris_engine.schemas.action_params_v1 import ObserveParams, SpeakParams
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ActionSelectionPDMAResult, HandlerActionType
+from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus
 from ciris_engine.core.action_handlers.speak_handler import SpeakHandler
 from ciris_engine.core.action_handlers.base_handler import ActionHandlerDependencies
 from ciris_engine.core import persistence

--- a/tests/utils/test_graphql_context_provider.py
+++ b/tests/utils/test_graphql_context_provider.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 from ciris_engine.utils.graphql_context_provider import GraphQLContextProvider, GraphQLClient
 from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph
-from ciris_engine.core.graph_schemas import GraphNode, GraphScope, NodeType
+from ciris_engine.schemas.graph_schemas_v1 import GraphNode, GraphScope, NodeType
 
 class DummyTask:
     def __init__(self, author):


### PR DESCRIPTION
## Summary
- update schema imports to new `schemas/` modules
- switch fixtures from `WorkflowCoordinator` to `ThoughtProcessor`
- patch AgentProcessor imports to `processor.main_processor`

## Testing
- `pytest -q` *(fails: 43 errors during collection)*