### PR TITLE
Refactor imports and update schemas

### DIFF
--- a/ciris_engine/core/agent_processing_queue.py
+++ b/ciris_engine/core/agent_processing_queue.py
@@ -41,7 +41,7 @@ class ProcessingQueueItem(BaseModel):
         """
         Creates a ProcessingQueueItem from a Thought instance.
         """
-        final_initial_ctx = initial_ctx if initial_ctx is not None else thought_instance.processing_context
+        final_initial_ctx = initial_ctx if initial_ctx is not None else thought_instance.context
 
         # Use provided queue_item_content if available, otherwise default to thought_instance.content
         resolved_content = queue_item_content if queue_item_content is not None else thought_instance.content

--- a/ciris_engine/core/processor/base_processor.py
+++ b/ciris_engine/core/processor/base_processor.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 from ciris_engine.schemas.config_schemas_v1 import AppConfig
 from ciris_engine.schemas.states import AgentState
-from ciris_engine.core.workflow_coordinator import WorkflowCoordinator
+from ciris_engine.core.thought_processor import ThoughtProcessor
 from ciris_engine.core.action_dispatcher import ActionDispatcher
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
 
@@ -21,13 +21,13 @@ class BaseProcessor(ABC):
     def __init__(
         self,
         app_config: AppConfig,
-        workflow_coordinator: WorkflowCoordinator,
+        thought_processor: ThoughtProcessor,
         action_dispatcher: ActionDispatcher,
         services: Dict[str, Any]
     ):
         """Initialize base processor with common dependencies."""
         self.app_config = app_config
-        self.workflow_coordinator = workflow_coordinator
+        self.thought_processor = thought_processor
         self.action_dispatcher = action_dispatcher
         self.services = services
         self.metrics: Dict[str, Any] = {
@@ -108,11 +108,11 @@ class BaseProcessor(ABC):
         context: Optional[Dict[str, Any]] = None
     ) -> Any:
         """
-        Process a single thought item through workflow coordinator.
+        Process a single thought item through the thought processor.
         Returns the processing result.
         """
         try:
-            result = await self.workflow_coordinator.process_thought(item, context)
+            result = await self.thought_processor.process_thought(item, context)
             self.metrics["items_processed"] += 1
             return result
         except Exception as e:

--- a/ciris_engine/core/processor/main_processor.py
+++ b/ciris_engine/core/processor/main_processor.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from ciris_engine.schemas.config_schemas_v1 import AppConfig
 from ciris_engine.schemas.states import AgentState
 
-from ciris_engine.core.workflow_coordinator import WorkflowCoordinator
+from ciris_engine.core.thought_processor import ThoughtProcessor
 from ciris_engine.core.action_dispatcher import ActionDispatcher
 
 from .state_manager import StateManager
@@ -32,14 +32,14 @@ class AgentProcessor:
     def __init__(
         self,
         app_config: AppConfig,
-        workflow_coordinator: WorkflowCoordinator,
+        thought_processor: ThoughtProcessor,
         action_dispatcher: ActionDispatcher,
         services: Dict[str, Any],
         startup_channel_id: Optional[str] = None,
     ):
         """Initialize the agent processor with v1 configuration."""
         self.app_config = app_config
-        self.workflow_coordinator = workflow_coordinator
+        self.thought_processor = thought_processor
         self.action_dispatcher = action_dispatcher
         self.services = services
         self.startup_channel_id = startup_channel_id
@@ -50,7 +50,7 @@ class AgentProcessor:
         # Initialize specialized processors
         self.wakeup_processor = WakeupProcessor(
             app_config=app_config,
-            workflow_coordinator=workflow_coordinator,
+            thought_processor=thought_processor,
             action_dispatcher=action_dispatcher,
             services=services,
             startup_channel_id=startup_channel_id
@@ -58,21 +58,21 @@ class AgentProcessor:
         
         self.work_processor = WorkProcessor(
             app_config=app_config,
-            workflow_coordinator=workflow_coordinator,
+            thought_processor=thought_processor,
             action_dispatcher=action_dispatcher,
             services=services
         )
         
         self.play_processor = PlayProcessor(
             app_config=app_config,
-            workflow_coordinator=workflow_coordinator,
+            thought_processor=thought_processor,
             action_dispatcher=action_dispatcher,
             services=services
         )
         
         self.solitude_processor = SolitudeProcessor(
             app_config=app_config,
-            workflow_coordinator=workflow_coordinator,
+            thought_processor=thought_processor,
             action_dispatcher=action_dispatcher,
             services=services
         )
@@ -190,8 +190,8 @@ class AgentProcessor:
                 break
             
             # Update round number
-            self.workflow_coordinator.advance_round()
-            self.current_round_number = self.workflow_coordinator.current_round_number
+            self.thought_processor.advance_round()
+            self.current_round_number = getattr(self.thought_processor, "current_round_number", self.current_round_number + 1)
             
             # Check for automatic state transitions
             next_state = self.state_manager.should_auto_transition()

--- a/ciris_engine/dma/csdma.py
+++ b/ciris_engine/dma/csdma.py
@@ -4,7 +4,7 @@ import logging
 import instructor
 from openai import AsyncOpenAI
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
-from ciris_engine.core.dma_results import CSDMAResult
+from ciris_engine.schemas.dma_results_v1 import CSDMAResult
 from ciris_engine.core.config_manager import get_config
 from ciris_engine.formatters import (
     format_system_snapshot,

--- a/ciris_engine/dma/dma_executor.py
+++ b/ciris_engine/dma/dma_executor.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, Optional, Callable, Awaitable
 
 from ..core.thought_escalation import escalate_dma_failure
-from ..core.agent_core_schemas import Thought
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
 from ..core.agent_processing_queue import ProcessingQueueItem
 
 from .pdma import EthicalPDMAEvaluator
@@ -10,11 +10,11 @@ from .csdma import CSDMAEvaluator
 from .dsdma_base import BaseDSDMA
 from .action_selection_pdma import ActionSelectionPDMAEvaluator
 from ..core.agent_processing_queue import ProcessingQueueItem
-from ..core.dma_results import (
-    EthicalPDMAResult,
+from ciris_engine.schemas.dma_results_v1 import (
+    EthicalDMAResult,
     CSDMAResult,
     DSDMAResult,
-    ActionSelectionPDMAResult,
+    ActionSelectionResult,
 )
 
 logger = logging.getLogger(__name__)
@@ -60,7 +60,7 @@ async def run_dma_with_retries(
 
 async def run_pdma(
     evaluator: EthicalPDMAEvaluator, thought: ProcessingQueueItem
-) -> EthicalPDMAResult:
+) -> EthicalDMAResult:
     """Run the Ethical PDMA for the given thought."""
     return await evaluator.evaluate(thought)
 
@@ -83,6 +83,6 @@ async def run_dsdma(
 
 async def run_action_selection_pdma(
     evaluator: ActionSelectionPDMAEvaluator, triaged_inputs: Dict[str, Any]
-) -> ActionSelectionPDMAResult:
+) -> ActionSelectionResult:
     """Select the next handler action using the triaged DMA results."""
     return await evaluator.evaluate(triaged_inputs=triaged_inputs)

--- a/ciris_engine/dma/dsdma_base.py
+++ b/ciris_engine/dma/dsdma_base.py
@@ -7,7 +7,7 @@ from openai import AsyncOpenAI # For type hinting raw client
 
 # Corrected imports based on project structure
 from ciris_engine.core.agent_processing_queue import ProcessingQueueItem
-from ciris_engine.core.agent_core_schemas import DSDMAResult
+from ciris_engine.schemas.dma_results_v1 import DSDMAResult
 from ciris_engine.utils.context_formatters import format_user_profiles_for_prompt, format_system_snapshot_for_prompt # New import
 from pydantic import BaseModel, Field
 from instructor.exceptions import InstructorRetryException

--- a/ciris_engine/dma/factory.py
+++ b/ciris_engine/dma/factory.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Type
 from openai import AsyncOpenAI
 
 from .dsdma_base import BaseDSDMA
-from ..core.config_schemas import SerializableAgentProfile
+from ciris_engine.schemas.config_schemas_v1 import SerializableAgentProfile
 from ..utils.profile_loader import load_profile
 
 logger = logging.getLogger(__name__)

--- a/ciris_engine/memory/ciris_local_graph.py
+++ b/ciris_engine/memory/ciris_local_graph.py
@@ -7,14 +7,13 @@ import asyncio
 
 import networkx as nx
 
-from ..core.graph_schemas import (
+from ciris_engine.schemas.graph_schemas_v1 import (
     GraphScope,
     GraphNode,
     NodeType,
     GraphEdge,
-    GraphUpdateEvent,
 )
-from ..core.foundational_schemas import CaseInsensitiveEnum
+from ciris_engine.schemas.foundational_schemas_v1 import CaseInsensitiveEnum
 from ..services.base import Service
 from pydantic import BaseModel
 

--- a/ciris_engine/runtime/base_runtime.py
+++ b/ciris_engine/runtime/base_runtime.py
@@ -9,9 +9,9 @@ from ciris_engine.core.config_manager import get_config_async
 from ciris_engine.core.action_dispatcher import ActionDispatcher
 from ciris_engine.services.audit_service import AuditService
 from ciris_engine.core import persistence
-from ciris_engine.core.agent_core_schemas import Task, ActionSelectionPDMAResult
-from ciris_engine.core.config_schemas import SerializableAgentProfile as AgentProfile
-from ciris_engine.core.foundational_schemas import TaskStatus, HandlerActionType
+from ciris_engine.schemas.agent_core_schemas_v1 import Task, ActionSelectionResult
+from ciris_engine.schemas.config_schemas_v1 import SerializableAgentProfile as AgentProfile
+from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus, HandlerActionType
 from ciris_engine.utils.profile_loader import load_profile
 
 logger = logging.getLogger(__name__)
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 def datetime_from_seconds(sec: float) -> str:
     return datetime.fromtimestamp(sec, tz=timezone.utc).isoformat()
 
-# IncomingMessage is now in ciris_engine.core.foundational_schemas
-from ciris_engine.core.foundational_schemas import IncomingMessage
+# IncomingMessage is now defined in the schemas module
+from ciris_engine.schemas.foundational_schemas_v1 import IncomingMessage
 
 class BaseIOAdapter:
     """Abstract interface for runtime I/O."""
@@ -186,7 +186,7 @@ class BaseRuntime:
         finally:
             await self.stop()
 
-    async def _dream_action_filter(self, result: ActionSelectionPDMAResult, ctx: dict) -> bool:
+    async def _dream_action_filter(self, result: ActionSelectionResult, ctx: dict) -> bool:
         allowed = result.selected_handler_action in self.DREAM_ALLOWED
         if not allowed and self.audit_service:
             await self.audit_service.log_action(

--- a/ciris_engine/schemas/agent_core_schemas_v1.py
+++ b/ciris_engine/schemas/agent_core_schemas_v1.py
@@ -3,6 +3,18 @@ from typing import Optional, List, Dict, Any
 
 # Import enums from foundational_schemas_v1
 from .foundational_schemas_v1 import TaskStatus, ThoughtStatus
+from .action_params_v1 import (
+    ObserveParams,
+    SpeakParams,
+    ToolParams,
+    PonderParams,
+    RejectParams,
+    DeferParams,
+    MemorizeParams,
+    RememberParams,
+    ForgetParams,
+)
+from .dma_results_v1 import ActionSelectionResult
 
 class Task(BaseModel):
     """Core task object - minimal v1"""
@@ -26,10 +38,46 @@ class Thought(BaseModel):
     status: ThoughtStatus = ThoughtStatus.PENDING
     created_at: str
     updated_at: str
-    round_number: int = 0  # Simplified from round_created/round_processed
+    round_number: int = Field(default=0, alias="round_created")
     content: str
     context: Dict[str, Any] = Field(default_factory=dict)  # Renamed from processing_context
     ponder_count: int = 0
     ponder_notes: Optional[List[str]] = None
     parent_thought_id: Optional[str] = None  # Renamed from related_thought_id
     final_action: Dict[str, Any] = Field(default_factory=dict)  # Simplified from final_action_result
+
+
+class ActionSelectionPDMAResult(BaseModel):
+    """Compatibility result model expected by legacy tests."""
+
+    context_summary_for_action_selection: str
+    action_alignment_check: Dict[str, Any]
+    selected_handler_action: Any
+    action_parameters: Any
+    action_selection_rationale: str
+    monitoring_for_selected_action: Any
+    confidence_score: Optional[float] = None
+    action_conflicts: Optional[Any] = None
+    action_resolution: Optional[Any] = None
+    raw_llm_response: Optional[str] = None
+    ethical_assessment_summary: Optional[Dict[str, Any]] = None
+    csdma_assessment_summary: Optional[Dict[str, Any]] = None
+    dsdma_assessment_summary: Optional[Dict[str, Any]] = None
+
+
+__all__ = [
+    "Task",
+    "Thought",
+    "ObserveParams",
+    "SpeakParams",
+    "ToolParams",
+    "PonderParams",
+    "RejectParams",
+    "DeferParams",
+    "MemorizeParams",
+    "RememberParams",
+    "ForgetParams",
+    "ActionSelectionResult",
+    "ActionSelectionPDMAResult",
+]
+

--- a/ciris_engine/schemas/dma_results_v1.py
+++ b/ciris_engine/schemas/dma_results_v1.py
@@ -34,3 +34,4 @@ class DSDMAResult(BaseModel):
     reasoning: Optional[str] = None
     recommended_action: Optional[str] = None
     raw_llm_response: Optional[str] = None
+

--- a/ciris_engine/schemas/feedback_schemas_v1.py
+++ b/ciris_engine/schemas/feedback_schemas_v1.py
@@ -73,3 +73,22 @@ class FeedbackMapping(BaseModel):
     transport_data: Dict[str, Any] = Field(default_factory=dict)
     
     created_at: str
+
+
+class OptimizationVetoResult(BaseModel):
+    """Result of the optimization veto guardrail."""
+
+    decision: str
+    justification: str
+    entropy_reduction_ratio: float
+    affected_values: List[str] = Field(default_factory=list)
+    confidence: float = 1.0
+
+
+class EpistemicHumilityResult(BaseModel):
+    """Result of the epistemic humility check."""
+
+    epistemic_certainty: str
+    identified_uncertainties: List[str] = Field(default_factory=list)
+    reflective_justification: str
+    recommended_action: str

--- a/ciris_engine/schemas/foundational_schemas_v1.py
+++ b/ciris_engine/schemas/foundational_schemas_v1.py
@@ -66,3 +66,21 @@ class IncomingMessage(BaseModel):
 class CIRISSchemaVersion(str, Enum):
     """Version tracking for schema evolution."""
     V1_0_BETA = "1.0-beta"
+
+
+class DKGAssetType(str, Enum):
+    """Simplified asset type identifiers for tests."""
+    AGENT_PROFILE = "AgentProfile"
+    KNOWLEDGE_ASSET = "KnowledgeAsset"
+
+
+__all__ = [
+    "CaseInsensitiveEnum",
+    "HandlerActionType",
+    "TaskStatus",
+    "ThoughtStatus",
+    "ObservationSourceType",
+    "IncomingMessage",
+    "CIRISSchemaVersion",
+    "DKGAssetType",
+]

--- a/ciris_engine/services/cirisnode_client.py
+++ b/ciris_engine/services/cirisnode_client.py
@@ -5,7 +5,7 @@ import httpx
 
 from ciris_engine.services.audit_service import AuditService
 from ciris_engine.core.config_manager import get_config
-from ciris_engine.core.config_schemas import CIRISNodeConfig # ERIC
+from ciris_engine.schemas.config_schemas_v1 import CIRISNodeConfig
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 
 logger = logging.getLogger(__name__)

--- a/ciris_engine/services/discord_observer.py
+++ b/ciris_engine/services/discord_observer.py
@@ -3,7 +3,7 @@ import os
 import asyncio
 from typing import Callable, Awaitable, Dict, Any, Optional
 
-from ciris_engine.core.foundational_schemas import IncomingMessage
+from ciris_engine.schemas.foundational_schemas_v1 import IncomingMessage
 from ciris_engine.core.ports import DeferralSink
 from .base import Service
 from .discord_event_queue import DiscordEventQueue

--- a/ciris_engine/utils/graphql_context_provider.py
+++ b/ciris_engine/utils/graphql_context_provider.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import Dict, Any, List, Optional
 import httpx
 from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph
-from ciris_engine.core.graph_schemas import GraphScope
+from ciris_engine.schemas.graph_schemas_v1 import GraphScope
 
 logger = logging.getLogger(__name__)
 

--- a/ciris_engine/utils/profile_loader.py
+++ b/ciris_engine/utils/profile_loader.py
@@ -4,7 +4,7 @@ import asyncio
 from pathlib import Path
 from typing import Optional
 
-from ciris_engine.core.config_schemas import SerializableAgentProfile
+from ciris_engine.schemas.config_schemas_v1 import SerializableAgentProfile
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ async def load_profile(profile_path: Optional[Path]) -> Optional[SerializableAge
 
         # Convert permitted_actions from string to HandlerActionType if needed
         if "permitted_actions" in profile_data:
-            from ciris_engine.core.foundational_schemas import HandlerActionType
+            from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
             profile_data["permitted_actions"] = [
                 HandlerActionType(a) if not isinstance(a, HandlerActionType) else a
                 for a in profile_data["permitted_actions"]

--- a/run_discord_teacher.py
+++ b/run_discord_teacher.py
@@ -27,7 +27,7 @@ import instructor # Added import for instructor.Mode
 from ciris_engine.guardrails import EthicalGuardrails
 from ciris_engine.services.llm_service import LLMService
 from ciris_engine.memory.ciris_local_graph import CIRISLocalGraph, MemoryOpStatus
-from ciris_engine.core.agent_core_schemas import (
+from ciris_engine.schemas.agent_core_schemas_v1 import (
     HandlerActionType,
     SpeakParams,
     DeferParams,
@@ -36,12 +36,11 @@ from ciris_engine.core.agent_core_schemas import (
     RememberParams,
     ForgetParams,
     ActParams,
-    ObserveParams, # ObserveParams is used by ObserveHandler
+    ObserveParams,
     Thought,
-    # ActParams, DeferParams, MemorizeParams, RejectParams, SpeakParams are used by their respective handlers
 )
 from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
-from ciris_engine.core.foundational_schemas import ThoughtStatus, TaskStatus
+from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus, TaskStatus
 from pydantic import BaseModel # Used by handlers for params
 import uuid # Used by handlers
 from ciris_engine.utils.constants import DEFAULT_WA, WA_USER_ID # Potentially used by handlers or context

--- a/tests/core/test_action_dispatcher.py
+++ b/tests/core/test_action_dispatcher.py
@@ -16,7 +16,7 @@ async def test_dispatch_invokes_correct_handler():
         source_task_id="task",
         created_at="",
         updated_at="",
-        round_created=0,
+        round_number=0,
         content="",
     )
     handler = DummyHandler()
@@ -41,7 +41,7 @@ async def test_action_dispatcher_wrapper():
         source_task_id="task",
         created_at="",
         updated_at="",
-        round_created=0,
+        round_number=0,
         content="",
     )
     result = ActionSelectionPDMAResult(

--- a/tests/core/test_defer_handler.py
+++ b/tests/core/test_defer_handler.py
@@ -1,9 +1,7 @@
 import pytest
-from ciris_engine.schemas.agent_core_schemas_v1 import (
-    Thought,
-    ActionSelectionPDMAResult,
-    DeferParams,
-)
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.action_params_v1 import DeferParams
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, ThoughtStatus
 from ciris_engine.core.action_handlers.defer_handler import DeferHandler
 from ciris_engine.core.action_handlers.base_handler import ActionHandlerDependencies
@@ -11,7 +9,7 @@ from ciris_engine.core import persistence
 
 @pytest.mark.asyncio
 async def test_handle_defer(monkeypatch):
-    t = Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_created=0, content="")
+    t = Thought(thought_id="t", source_task_id="task", created_at="", updated_at="", round_number=0, content="")
     class DummyDeferral:
         def __init__(self):
             self.called = []
@@ -23,13 +21,10 @@ async def test_handle_defer(monkeypatch):
     def record_status(**kwargs):
         called.update(kwargs)
     monkeypatch.setattr(persistence, "update_thought_status", record_status)
-    result = ActionSelectionPDMAResult(
-        context_summary_for_action_selection="c",
-        action_alignment_check={},
-        selected_handler_action=HandlerActionType.DEFER,
-        action_parameters=DeferParams(reason="r", target_wa_ual="wa", deferral_package_content={}),
-        action_selection_rationale="r",
-        monitoring_for_selected_action="m",
+    result = ActionSelectionResult(
+        selected_action=HandlerActionType.DEFER,
+        action_parameters=DeferParams(reason="r"),
+        rationale="r",
     )
     await handler.handle(result, t, {"channel_id": "1"})
     assert called.get("new_status") == ThoughtStatus.DEFERRED

--- a/tests/core/test_graph_schema_updates.py
+++ b/tests/core/test_graph_schema_updates.py
@@ -5,28 +5,19 @@ from ciris_engine.schemas.graph_schemas_v1 import (
     GraphEdge,
     NodeType,
     GraphScope,
-    ValidationState,
-    EmergencyState,
-    ConfidentialityLevel,
 )
 
 
 def test_graph_node_defaults():
     node = GraphNode(id="n", type=NodeType.USER, scope=GraphScope.LOCAL)
     assert node.version == 1
-    assert node.validation_state is ValidationState.PENDING
-    assert node.confidentiality_level is ConfidentialityLevel.PUBLIC
-    assert node.validated_by is None
+    assert node.attributes == {}
 
 
-def test_emergency_requires_timestamp():
-    with pytest.raises(ValidationError):
-        GraphNode(
-            id="n",
-            type=NodeType.USER,
-            scope=GraphScope.LOCAL,
-            emergency_state=EmergencyState.ACTIVE,
-        )
+
+def test_edge_requires_basic_fields():
+    edge = GraphEdge(source="a", target="b", relationship="knows", scope=GraphScope.LOCAL)
+    assert edge.weight == 1.0
 
 
 def test_validated_by_requires_non_pending_state():

--- a/tests/core/test_memory_meta_round.py
+++ b/tests/core/test_memory_meta_round.py
@@ -38,7 +38,7 @@ async def test_memory_meta_round_isolated(mock_persistence, processor: AgentProc
         status=ThoughtStatus.PENDING,
         created_at="",
         updated_at="",
-        round_created=0,
+        round_number=0,
         content="",
     )
     normal_thought = Thought(
@@ -48,7 +48,7 @@ async def test_memory_meta_round_isolated(mock_persistence, processor: AgentProc
         status=ThoughtStatus.PENDING,
         created_at="",
         updated_at="",
-        round_created=0,
+        round_number=0,
         content="",
     )
     mock_persistence.get_pending_thoughts_for_active_tasks.return_value = [memory_thought, normal_thought]

--- a/tests/core/test_observe_handler.py
+++ b/tests/core/test_observe_handler.py
@@ -4,9 +4,9 @@ from types import SimpleNamespace
 
 from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
-    ActionSelectionPDMAResult,
     ObserveParams,
 )
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 from ciris_engine.core.action_handlers.observe_handler import ObserveHandler
 from ciris_engine.core.action_handlers.base_handler import ActionHandlerDependencies
@@ -26,7 +26,7 @@ async def test_handle_observe(monkeypatch):
     monkeypatch.setattr(persistence, "add_thought", lambda th: added.append(th))
     monkeypatch.setattr(persistence, "update_thought_status", lambda **k: None)
     params = ObserveParams(sources=["discord"], perform_active_look=False)
-    result = ActionSelectionPDMAResult(
+    result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.OBSERVE,

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -69,8 +69,8 @@ def test_task_instantiation_and_defaults():
     assert task.task_id == "task_123"
     assert task.status == TaskStatus.PENDING # Default
     assert task.priority == 0 # Default
-    assert task.due_date is None # Added field, default None
-    assert task.parent_goal_id is None # Added field, default None
+    assert isinstance(task.created_at, str)
+    assert isinstance(task.updated_at, str)
     assert isinstance(task.created_at, str)
     assert isinstance(task.updated_at, str)
 
@@ -82,20 +82,13 @@ def test_thought_instantiation_and_defaults():
         thought_id="thought_abc",
         created_at=datetime.utcnow().isoformat(),
         updated_at=datetime.utcnow().isoformat(),
-        round_created=1 # Added field
+        round_number=1
     )
     assert thought.content == thought_content
     assert thought.thought_id == "thought_abc"
     assert thought.status == ThoughtStatus.PENDING # Default
-    assert thought.priority == 0 # Added field, default 0
-    assert thought.round_created == 1 # Added field
-    assert thought.action_count == 0
-    assert thought.history == []
-    assert thought.escalations == []
-    assert thought.is_terminal is False
-    assert thought.round_processed is None # Added field, default None
-    assert thought.depth == 0 # Default
-    assert thought.ponder_count == 0 # Default
+    assert thought.round_number == 1
+    assert thought.ponder_count == 0
 
 def test_action_selection_pdma_result_instantiation():
     # Basic instantiation check with all required fields
@@ -157,8 +150,8 @@ def test_processing_queue_item_from_thought():
         status=ThoughtStatus.PENDING,
         created_at=now_iso,
         updated_at=now_iso,
-        round_created=2,
-        processing_context={"key": "value"},
+        round_number=2,
+        context={"key": "value"},
         ponder_notes=["question1"]
     )
 
@@ -169,7 +162,7 @@ def test_processing_queue_item_from_thought():
     assert queue_item.thought_type == thought_instance.thought_type
     assert queue_item.content == thought_instance.content
     assert queue_item.priority == thought_instance.priority
-    assert queue_item.initial_context == thought_instance.processing_context
+    assert queue_item.initial_context == thought_instance.context
     assert queue_item.ponder_notes == thought_instance.ponder_notes
     assert queue_item.raw_input_string == str(thought_instance.content)
 
@@ -180,7 +173,7 @@ def test_processing_queue_item_from_thought_with_overrides():
         source_task_id="task_789",
         content="Original",
         priority=1,
-        created_at=now_iso, updated_at=now_iso, round_created=1
+        created_at=now_iso, updated_at=now_iso, round_number=1
     )
     
     custom_content = {"detail": "richer content for queue"}

--- a/tests/core/test_workflow_context.py
+++ b/tests/core/test_workflow_context.py
@@ -54,7 +54,7 @@ def sample_thought():
         status=ThoughtStatus.PENDING,
         created_at=now_iso,
         updated_at=now_iso,
-        round_created=0,
+        round_number=0,
         content="ctx",
     )
 

--- a/tests/core/test_workflow_coordinator.py
+++ b/tests/core/test_workflow_coordinator.py
@@ -140,9 +140,9 @@ async def test_memory_meta_thought(
         status=ThoughtStatus.PENDING,
         created_at=now,
         updated_at=now,
-        round_created=0,
+        round_number=0,
         content="meta",
-        processing_context={"user_nick": "alice", "channel": "general", "metadata": {"kind": "friend"}},
+        context={"user_nick": "alice", "channel": "general", "metadata": {"kind": "friend"}},
         priority=0,
     )
     item = ProcessingQueueItem.from_thought(thought)
@@ -181,7 +181,7 @@ def sample_thought():
         status=ThoughtStatus.PENDING,
         created_at=now_iso,
         updated_at=now_iso,
-        round_created=0,
+        round_number=0,
         content="This is a test thought.",
         priority=1
     )


### PR DESCRIPTION
## Summary
- define SerializableAgentProfile and CIRISNodeConfig in config schemas
- provide compatibility result models and export action params
- sync queue builder with new context field
- begin updating tests for new field names

## Testing
- `pytest -q` *(fails: 13 errors during collection)*
