### PR TITLE
Realign tests with refactored processors

### DIFF
--- a/tests/core/test_action_dispatcher.py
+++ b/tests/core/test_action_dispatcher.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 
 from ciris_engine.action_handlers.action_dispatcher import ActionDispatcher
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
-from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ActionSelectionPDMAResult
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ActionSelectionResult
 
 class DummyHandler:
     def __init__(self):
@@ -21,7 +21,7 @@ async def test_dispatch_invokes_correct_handler():
     )
     handler = DummyHandler()
     dispatcher = ActionDispatcher({HandlerActionType.SPEAK: handler})
-    result = ActionSelectionPDMAResult(
+    result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.SPEAK,
@@ -44,7 +44,7 @@ async def test_action_dispatcher_wrapper():
         round_number=0,
         content="",
     )
-    result = ActionSelectionPDMAResult(
+    result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.SPEAK,

--- a/tests/core/test_memorize_handler.py
+++ b/tests/core/test_memorize_handler.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 
 from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
-    ActionSelectionPDMAResult,
+    ActionSelectionResult,
     MemorizeParams,
 )
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
@@ -34,7 +34,7 @@ async def test_handle_memorize(monkeypatch):
         confidence=0.9,
         channel_metadata={"channel": "c"},
     )
-    result = ActionSelectionPDMAResult(
+    result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.MEMORIZE,

--- a/tests/core/test_memory_meta_round.py
+++ b/tests/core/test_memory_meta_round.py
@@ -4,9 +4,10 @@ import pytest
 from collections import deque
 
 from ciris_engine.processor.main_processor import AgentProcessor
+from ciris_engine.processor.thought_processor import ThoughtProcessor
 from ciris_engine.schemas.agent_core_schemas_v1 import Thought
 from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus
-from ciris_engine.agent_processing_queue import ProcessingQueueItem
+from ciris_engine.processor.processing_queue import ProcessingQueueItem
 from ciris_engine.schemas.config_schemas_v1 import AppConfig, WorkflowConfig, LLMServicesConfig, OpenAIConfig, DatabaseConfig, GuardrailsConfig
 
 @pytest.fixture
@@ -20,13 +21,11 @@ def simple_app_config():
 
 @pytest.fixture
 def processor(simple_app_config):
-    mock_wc = AsyncMock()
-    mock_wc.process_thought = AsyncMock()
-    mock_wc.advance_round = MagicMock()
-    mock_wc.current_round_number = 0
+    mock_tp = AsyncMock(spec=ThoughtProcessor)
+    mock_tp.process_thought = AsyncMock()
     dispatcher = AsyncMock()
     dispatcher.dispatch = AsyncMock()
-    return AgentProcessor(app_config=simple_app_config, workflow_coordinator=mock_wc, action_dispatcher=dispatcher, services={})
+    return AgentProcessor(app_config=simple_app_config, thought_processor=mock_tp, action_dispatcher=dispatcher, services={})
 
 @patch('ciris_engine.processor.main_processor.persistence')
 @pytest.mark.asyncio

--- a/tests/core/test_persistence.py
+++ b/tests/core/test_persistence.py
@@ -136,7 +136,7 @@ def test_update_thought_status(initialized_db):
     )
     persistence.add_thought(thought_data)
 
-    # Create a more complete ActionSelectionPDMAResult-like dict
+    # Create a more complete ActionSelectionResult-like dict
     complete_action_result_dict = {
         "schema_version": "1.0-beta",
         "context_summary_for_action_selection": "Summary for persistence test",
@@ -165,7 +165,7 @@ def test_update_thought_status(initialized_db):
     assert updated_thought is not None
     assert updated_thought.status == ThoughtStatus.PROCESSING
     assert updated_thought.round_processed == 1
-    # Pydantic will have converted the dict to the ActionSelectionPDMAResult model
+    # Pydantic will have converted the dict to the ActionSelectionResult model
     assert updated_thought.final_action_result is not None
     assert updated_thought.final_action_result.selected_handler_action.value == "speak"
     # action_parameters is now a SpeakParams model instance

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -11,18 +11,17 @@ from ciris_engine.schemas.foundational_schemas_v1 import (
     ThoughtStatus,
     ObservationSourceType,
     DKGAssetType,
-    CIRISAgentUAL, CIRISTaskUAL, CIRISKnowledgeAssetUAL, VeilidDID, VeilidRouteID
 )
 from ciris_engine.schemas.agent_core_schemas_v1 import (
-    ObserveParams, SpeakParams, ActParams, PonderParams, RejectParams, DeferParams,
+    ObserveParams, SpeakParams, PonderParams, RejectParams, DeferParams,
     MemorizeParams, RememberParams, ForgetParams,
-    ActionSelectionPDMAResult,
     Task, Thought
 )
-from ciris_engine.agent_processing_queue import ProcessingQueueItem, ProcessingQueue
+from ciris_engine.schemas.action_params_v1 import ToolParams
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
+from ciris_engine.processor.processing_queue import ProcessingQueueItem, ProcessingQueue
 
-from ciris_engine.observation_schemas import ObservationRecord
-from ciris_engine.audit_schemas import AuditLogEntry
+from ciris_engine.schemas.audit_schemas_v1 import AuditLogEntry
 from ciris_engine.memory.ciris_local_graph import MemoryOpStatus
 
 # --- Tests for foundational_schemas.py ---
@@ -47,18 +46,6 @@ def test_enum_case_insensitive():
     assert TaskStatus("PENDING") is TaskStatus.PENDING
     assert MemoryOpStatus("OK") is MemoryOpStatus.OK
 
-def test_ual_did_types():
-    """Test that UAL/DID types are essentially strings."""
-    agent_ual: CIRISAgentUAL = "did:example:agent1"
-    task_ual: CIRISTaskUAL = "ual:task:abc"
-    ka_ual: CIRISKnowledgeAssetUAL = "ual:ka:xyz"
-    veilid_did: VeilidDID = "did:key:zExampleKey"
-    veilid_route: VeilidRouteID = "route_id_example"
-    assert isinstance(agent_ual, str)
-    assert isinstance(task_ual, str)
-    assert isinstance(ka_ual, str)
-    assert isinstance(veilid_did, str)
-    assert isinstance(veilid_route, str)
 
 # --- Tests for agent_core_schemas.py ---
 
@@ -92,7 +79,7 @@ def test_thought_instantiation_and_defaults():
 
 def test_action_selection_pdma_result_instantiation():
     # Basic instantiation check with all required fields
-    result = ActionSelectionPDMAResult(
+    result = ActionSelectionResult(
         context_summary_for_action_selection="Test context summary",
         action_alignment_check={"speak": "aligned", "ponder": "neutral"},
         selected_handler_action=HandlerActionType.SPEAK,

--- a/tests/core/test_speak_handler.py
+++ b/tests/core/test_speak_handler.py
@@ -1,12 +1,12 @@
 import pytest
 from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
-    ActionSelectionPDMAResult,
+    ActionSelectionResult,
     SpeakParams,
 )
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, ThoughtStatus
 from ciris_engine.action_handlers.speak_handler import SpeakHandler
-from ciris_engine.exceptions import FollowUpCreationError
+from ciris_engine.action_handlers.exceptions import FollowUpCreationError
 from ciris_engine.action_handlers.base_handler import ActionHandlerDependencies
 from ciris_engine import persistence
 
@@ -25,7 +25,7 @@ async def test_handle_speak(monkeypatch):
     added = []
     monkeypatch.setattr(persistence, "add_thought", lambda th: added.append(th))
     monkeypatch.setattr(persistence, "update_thought_status", lambda **k: None)
-    result = ActionSelectionPDMAResult(
+    result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.SPEAK,
@@ -51,7 +51,7 @@ async def test_speak_follow_up_failure(monkeypatch):
 
     monkeypatch.setattr(persistence, "add_thought", fail_add)
 
-    result = ActionSelectionPDMAResult(
+    result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.SPEAK,

--- a/tests/core/test_task_complete_handler.py
+++ b/tests/core/test_task_complete_handler.py
@@ -2,7 +2,7 @@ import pytest
 
 from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
-    ActionSelectionPDMAResult,
+    ActionSelectionResult,
 )
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, TaskStatus
 from ciris_engine.action_handlers.task_complete_handler import TaskCompleteHandler
@@ -18,7 +18,7 @@ async def test_handle_task_complete(monkeypatch):
     monkeypatch.setattr(persistence, "update_task_status", record_task_status)
     monkeypatch.setattr(persistence, "update_thought_status", lambda **k: called.update(k))
     handler = TaskCompleteHandler(ActionHandlerDependencies(action_sink=None))
-    result = ActionSelectionPDMAResult(
+    result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.TASK_COMPLETE,

--- a/tests/core/test_thought_escalation.py
+++ b/tests/core/test_thought_escalation.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 
 from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ThoughtStatus
-from ciris_engine.thought_escalation import (
+from ciris_engine.processor.thought_escalation import (
     escalate_due_to_action_limit,
     escalate_due_to_sla,
     escalate_due_to_guardrail,

--- a/tests/core/test_tool_handler.py
+++ b/tests/core/test_tool_handler.py
@@ -4,9 +4,9 @@ from types import SimpleNamespace
 
 from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
-    ActionSelectionPDMAResult,
-    ActParams,
+    ActionSelectionResult,
 )
+from ciris_engine.schemas.action_params_v1 import ToolParams
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 from ciris_engine.action_handlers.tool_handler import ToolHandler
 from ciris_engine.action_handlers.base_handler import ActionHandlerDependencies
@@ -25,8 +25,8 @@ async def test_handle_tool(monkeypatch):
     added = []
     monkeypatch.setattr(persistence, "add_thought", lambda th: added.append(th))
     monkeypatch.setattr(persistence, "update_thought_status", lambda **k: None)
-    params = ActParams(tool_name="x", arguments={"a": 1})
-    result = ActionSelectionPDMAResult(
+    params = ToolParams(name="x", args={"a": 1})
+    result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.TOOL,

--- a/tests/core/test_workflow_context.py
+++ b/tests/core/test_workflow_context.py
@@ -59,7 +59,7 @@ def sample_thought():
     )
 
 @pytest.mark.asyncio
-@patch('ciris_engine.thought_processor.persistence')
+@patch('ciris_engine.processor.thought_processor.persistence')
 async def test_build_context_includes_recent_tasks_and_profiles(
     mock_persistence,
     workflow_coordinator_instance: ThoughtProcessor,

--- a/tests/dma/test_action_selection_pdma.py
+++ b/tests/dma/test_action_selection_pdma.py
@@ -14,17 +14,15 @@ from instructor.exceptions import InstructorRetryException
 from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
     ThoughtStatus,
-    HandlerActionType,
-    CIRISSchemaVersion,
 )
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, CIRISSchemaVersion, HandlerActionType as CoreHandlerActionType
 from ciris_engine.schemas.action_params_v1 import SpeakParams, PonderParams
 from ciris_engine.schemas.dma_results_v1 import (
-    ActionSelectionPDMAResult,
-    EthicalPDMAResult,
+    ActionSelectionResult,
+    EthicalDMAResult,
     CSDMAResult,
     DSDMAResult,
 )
-from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType as CoreHandlerActionType
 # from ciris_engine.profiles import AgentProfile # Replaced by SerializableAgentProfile
 from ciris_engine.schemas.config_schemas_v1 import SerializableAgentProfile # Import new profile
 from ciris_engine.dma.action_selection_pdma import (

--- a/tests/dma/test_csdma.py
+++ b/tests/dma/test_csdma.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from openai import AsyncOpenAI
 
-from ciris_engine.agent_processing_queue import ProcessingQueueItem
+from ciris_engine.processor.processing_queue import ProcessingQueueItem
 from ciris_engine.schemas.dma_results_v1 import CSDMAResult
 from ciris_engine.schemas.agent_core_schemas_v1 import ThoughtStatus
 from ciris_engine.dma.csdma import CSDMAEvaluator

--- a/tests/dma/test_dsdma.py
+++ b/tests/dma/test_dsdma.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 from openai import AsyncOpenAI
 from instructor.exceptions import InstructorRetryException
 
-from ciris_engine.agent_processing_queue import ProcessingQueueItem
+from ciris_engine.processor.processing_queue import ProcessingQueueItem
 from ciris_engine.schemas.dma_results_v1 import DSDMAResult
 from ciris_engine.schemas.agent_core_schemas_v1 import ThoughtStatus
 from ciris_engine.dma.dsdma_base import BaseDSDMA

--- a/tests/faculties/test_epistemic.py
+++ b/tests/faculties/test_epistemic.py
@@ -9,7 +9,7 @@ from ciris_engine.faculties.epistemic import (
     calculate_epistemic_values,
     DEFAULT_OPENAI_MODEL_NAME
 )
-from ciris_engine.schemas.agent_core_schemas_v1 import EntropyResult, CoherenceResult
+from ciris_engine.schemas.epistemic_schemas_v1 import EntropyResult, CoherenceResult
 import instructor # For type hinting the mock
 
 # --- Fixtures ---

--- a/tests/guardrails/test_epistemic_humility.py
+++ b/tests/guardrails/test_epistemic_humility.py
@@ -6,7 +6,7 @@ from ciris_engine.guardrails import (
     EpistemicHumilityResult,
 )
 from ciris_engine.schemas.config_schemas_v1 import GuardrailsConfig
-from ciris_engine.schemas.dma_results_v1 import ActionSelectionPDMAResult
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 
 
@@ -25,7 +25,7 @@ async def test_humility_defer(monkeypatch):
     )
 
     guardrails = EthicalGuardrails(mock_client, GuardrailsConfig())
-    asp_result = ActionSelectionPDMAResult(
+    asp_result = ActionSelectionResult(
         context_summary_for_action_selection="",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.MEMORIZE,
@@ -72,7 +72,7 @@ async def test_humility_proceed(monkeypatch):
     )
 
     guardrails = EthicalGuardrails(mock_client, GuardrailsConfig())
-    asp_result = ActionSelectionPDMAResult(
+    asp_result = ActionSelectionResult(
         context_summary_for_action_selection="",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.SPEAK,

--- a/tests/guardrails/test_optimization_veto.py
+++ b/tests/guardrails/test_optimization_veto.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from ciris_engine.guardrails import EthicalGuardrails, OptimizationVetoResult
 from ciris_engine.schemas.config_schemas_v1 import GuardrailsConfig
-from ciris_engine.schemas.dma_results_v1 import ActionSelectionPDMAResult
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 
 @pytest.mark.asyncio
@@ -22,7 +22,7 @@ async def test_optimization_veto_triggers_abort(monkeypatch):
     )
 
     guardrails = EthicalGuardrails(mock_client, GuardrailsConfig())
-    asp_result = ActionSelectionPDMAResult(
+    asp_result = ActionSelectionResult(
         context_summary_for_action_selection="",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.MEMORIZE,
@@ -69,7 +69,7 @@ async def test_optimization_veto_allows_proceed(monkeypatch):
     )
 
     guardrails = EthicalGuardrails(mock_client, GuardrailsConfig())
-    asp_result = ActionSelectionPDMAResult(
+    asp_result = ActionSelectionResult(
         context_summary_for_action_selection="",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.SPEAK,

--- a/tests/runtime/test_base_runtime.py
+++ b/tests/runtime/test_base_runtime.py
@@ -11,9 +11,9 @@ from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
 from ciris_engine.action_handlers.action_dispatcher import ActionDispatcher
 from ciris_engine.schemas.agent_core_schemas_v1 import (
     Thought,
-    ActionSelectionPDMAResult,
     SpeakParams,
 )
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
 from ciris_engine.action_handlers.speak_handler import SpeakHandler
 from ciris_engine.action_handlers.base_handler import ActionHandlerDependencies
 from types import SimpleNamespace
@@ -52,7 +52,7 @@ async def test_dream_action_filter_blocks(mocker):
     runtime = BaseRuntime(DummyAdapter(), "ciris_profiles/student.yaml", dispatcher)
 
     with patch.object(persistence, "add_thought", lambda t: t), patch.object(persistence, "update_thought_status", lambda **k: None):
-        result = ActionSelectionPDMAResult(
+        result = ActionSelectionResult(
             context_summary_for_action_selection="c",
             action_alignment_check={},
             selected_handler_action=HandlerActionType.SPEAK,
@@ -67,7 +67,7 @@ async def test_dream_action_filter_blocks(mocker):
     runtime.dreaming = True
     runtime.dispatcher.action_filter = runtime._dream_action_filter
     with patch.object(persistence, "add_thought", lambda t: t), patch.object(persistence, "update_thought_status", lambda **k: None):
-        result2 = ActionSelectionPDMAResult(
+        result2 = ActionSelectionResult(
             context_summary_for_action_selection="c",
             action_alignment_check={},
             selected_handler_action=HandlerActionType.SPEAK,

--- a/tests/services/test_cirisnode_client.py
+++ b/tests/services/test_cirisnode_client.py
@@ -5,7 +5,7 @@ import pytest
 
 from ciris_engine.services.cirisnode_client import CIRISNodeClient
 from ciris_engine.services.audit_service import AuditService
-from ciris_engine.audit_schemas import AuditLogEntry
+from ciris_engine.schemas.audit_schemas_v1 import AuditLogEntry
 
 
 @pytest.fixture

--- a/tests/test_observer_active_look.py
+++ b/tests/test_observer_active_look.py
@@ -5,8 +5,9 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
 from ciris_engine.schemas.action_params_v1 import ObserveParams, SpeakParams
-from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ActionSelectionPDMAResult, HandlerActionType
-from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
+from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus, HandlerActionType
 from ciris_engine.action_handlers.speak_handler import SpeakHandler
 from ciris_engine.action_handlers.base_handler import ActionHandlerDependencies
 from ciris_engine import persistence
@@ -76,7 +77,7 @@ async def test_observer_handler_active_look_creates_thought(monkeypatch):
     monkeypatch.setattr(persistence, "update_thought_status", lambda *a, **k: None)
 
     params = ObserveParams(sources=["discord"], perform_active_look=True)
-    result = ActionSelectionPDMAResult(
+    result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.OBSERVE,
@@ -104,7 +105,7 @@ async def test_active_look_pipeline(monkeypatch):
     monkeypatch.setattr(persistence, "update_thought_status", lambda *a, **k: None)
 
     obs_params = ObserveParams(sources=["discord"], perform_active_look=True)
-    obs_result = ActionSelectionPDMAResult(
+    obs_result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.OBSERVE,
@@ -118,7 +119,7 @@ async def test_active_look_pipeline(monkeypatch):
     active_th = added[0]
 
     speak_params = SpeakParams(content="done")
-    speak_result = ActionSelectionPDMAResult(
+    speak_result = ActionSelectionResult(
         context_summary_for_action_selection="c",
         action_alignment_check={},
         selected_handler_action=HandlerActionType.SPEAK,


### PR DESCRIPTION
## Summary
- update tests after the refactor to use `ThoughtProcessor` fixtures
- update imports to new schema locations and processing queue module
- replace deprecated action params and result schemas
- clean obsolete references to `WorkflowCoordinator`
- adjust wakeup sequence constant usage

## Testing
- `pytest -q` *(fails: 96 failed, 66 passed, 3 skipped, 25 warnings, 13 errors)*