### PR TITLE
Fix epistemic guardrail result handling

### DIFF
--- a/ciris_engine/faculties/epistemic.py
+++ b/ciris_engine/faculties/epistemic.py
@@ -8,7 +8,6 @@ import instructor
 # Adjusted import path for schemas
 from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
 from ciris_engine.schemas.epistemic_schemas_v1 import EntropyResult, CoherenceResult
-from ciris_engine.schemas.guardrails_schemas_v1 import GuardrailCheckResult, GuardrailStatus
 from pydantic import BaseModel, Field
 from ciris_engine.schemas.feedback_schemas_v1 import OptimizationVetoResult, EpistemicHumilityResult
 
@@ -213,69 +212,52 @@ async def calculate_epistemic_values(
 async def evaluate_optimization_veto(
     action_result: ActionSelectionResult,
     aclient: instructor.Instructor,
-    model_name: str = DEFAULT_OPENAI_MODEL_NAME
-) -> GuardrailCheckResult:
-    """
-    Run the optimization veto check via LLM using instructor for retries and structured output.
-    """
+    model_name: str = DEFAULT_OPENAI_MODEL_NAME,
+) -> OptimizationVetoResult:
+    """Run the optimization veto check via LLM and return the raw result."""
     action_desc = f"{action_result.selected_action.value} {action_result.action_parameters}" # Corrected field name
     messages = _create_optimization_veto_messages(action_desc)
     try:
-        result = await aclient.chat.completions.create(
+        result: OptimizationVetoResult = await aclient.chat.completions.create(
             model=model_name,
-            response_model=OptimizationVetoResult,  # Expecting a dict for the raw result
+            response_model=OptimizationVetoResult,
             messages=messages,
-            max_tokens=500,  
+            max_tokens=500,
         )
         logger.info(f"Epistemic Faculty: Optimization veto result: {result}")
-        return GuardrailCheckResult(
-            status=GuardrailStatus.PASSED if result.get("decision", "proceed") == "proceed" else GuardrailStatus.FAILED,
-            passed=result.get("decision", "proceed") == "proceed",
-            reason=result.get("justification"),
-            optimization_veto_check=result,
-            check_timestamp="",  # Should be set by caller or with datetime.now().isoformat()
-        )
+        return result
     except Exception as e:
         logger.error(f"Epistemic Faculty: Error in optimization veto: {e}", exc_info=True)
-        return GuardrailCheckResult(
-            status=GuardrailStatus.FAILED,
-            passed=False,
-            reason=f"LLM error: {str(e)}",
-            optimization_veto_check={"error": str(e)},
-            check_timestamp="",
+        return OptimizationVetoResult(
+            decision="abort",
+            justification=f"LLM error: {str(e)}",
+            entropy_reduction_ratio=0.0,
+            affected_values=[],
+            confidence=0.0,
         )
 
 async def evaluate_epistemic_humility(
     action_result: ActionSelectionResult,
     aclient: instructor.Instructor,
-    model_name: str = DEFAULT_OPENAI_MODEL_NAME
-) -> GuardrailCheckResult:
-    """
-    Run the epistemic humility check via LLM using instructor for retries and structured output.
-    """
+    model_name: str = DEFAULT_OPENAI_MODEL_NAME,
+) -> EpistemicHumilityResult:
+    """Run the epistemic humility check via LLM and return the raw result."""
     desc = f"{action_result.selected_action.value} {action_result.action_parameters}" # Corrected field name
     messages = _create_epistemic_humility_messages(desc)
     try:
-        result = await aclient.chat.completions.create(
+        result: EpistemicHumilityResult = await aclient.chat.completions.create(
             model=model_name,
-            response_model=EpistemicHumilityResult,  # Expecting a dict for the raw result
+            response_model=EpistemicHumilityResult,
             messages=messages,
             max_tokens=384,
         )
         logger.info(f"Epistemic Faculty: Epistemic humility result: {result}")
-        return GuardrailCheckResult(
-            status=GuardrailStatus.PASSED if result.get("recommended_action", "proceed") == "proceed" else GuardrailStatus.FAILED,
-            passed=result.get("recommended_action", "proceed") == "proceed",
-            reason=result.get("reflective_justification"),
-            epistemic_humility_check=result,
-            check_timestamp="",
-        )
+        return result
     except Exception as e:
         logger.error(f"Epistemic Faculty: Error in epistemic humility: {e}", exc_info=True)
-        return GuardrailCheckResult(
-            status=GuardrailStatus.FAILED,
-            passed=False,
-            reason=f"LLM error: {str(e)}",
-            epistemic_humility_check={"error": str(e)},
-            check_timestamp="",
+        return EpistemicHumilityResult(
+            epistemic_certainty="low",
+            identified_uncertainties=[f"LLM error: {str(e)}"],
+            reflective_justification=f"LLM error: {str(e)}",
+            recommended_action="abort",
         )

--- a/ciris_engine/guardrails/orchestrator.py
+++ b/ciris_engine/guardrails/orchestrator.py
@@ -90,21 +90,12 @@ class GuardrailOrchestrator:
                 # confidence and raw_llm_response can be omitted or set to None for system-generated overrides
                 raw_llm_response=action_result.raw_llm_response # Keep original raw response if relevant
             )
-        return GuardrailResult(
-            passes_guardrail=passes_guardrail, # This should be 'passed' to match GuardrailResult schema
-            reason=reason, # This should be 'override_reason' if not passes_guardrail
-            epistemic_data=epistemic_data,
-            original_action=action_result, # Store original action
-            final_action=override_action_result if override_action_result else action_result,
-            overridden=not passes_guardrail
-        )
+        final_action = override_action_result if override_action_result else action_result
 
-        final_action_to_return = override_action_result if not passes_guardrail else action_result
-        
         return GuardrailResult(
             original_action=action_result,
-            final_action=final_action_to_return,
+            final_action=final_action,
             overridden=not passes_guardrail,
             override_reason=reason if not passes_guardrail else None,
-            epistemic_data=epistemic_data
+            epistemic_data=epistemic_data,
         )


### PR DESCRIPTION
## Summary
- ensure optimization veto and epistemic humility helpers return the expected pydantic models
- clean up GuardrailOrchestrator return logic

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'SerializableAgentProfile')*