### PR TITLE
Add processor module tests

### DIFF
--- a/tests/ciris_engine/memory/test_memory.py
+++ b/tests/ciris_engine/memory/test_memory.py
@@ -35,9 +35,10 @@ def test_export_identity_context():
     assert "id1" in out and "admin" in out
 
 @pytest.mark.asyncio
-async def test_memory_handler_process_memorize_user():
+async def test_memory_handler_process_memorize_user(monkeypatch):
     g = CIRISLocalGraph(storage_path=None)
     handler = MemoryHandler(g)
+    monkeypatch.setattr("ciris_engine.persistence.update_thought_status", lambda *a, **k: None)
     thought = Thought(
         thought_id="th1", source_task_id="t1", thought_type="test", status=ThoughtStatus.PENDING,
         created_at="now", updated_at="now", round_number=1, content="test", context={},
@@ -50,9 +51,10 @@ async def test_memory_handler_process_memorize_user():
     assert remembered.data is not None
 
 @pytest.mark.asyncio
-async def test_memory_handler_process_memorize_channel_wa_feedback():
+async def test_memory_handler_process_memorize_channel_wa_feedback(monkeypatch):
     g = CIRISLocalGraph(storage_path=None)
     handler = MemoryHandler(g)
+    monkeypatch.setattr("ciris_engine.persistence.update_thought_status", lambda *a, **k: None)
     thought = Thought(
         thought_id="th2", source_task_id="t1", thought_type="test", status=ThoughtStatus.PENDING,
         created_at="now", updated_at="now", round_number=1, content="test",
@@ -66,9 +68,10 @@ async def test_memory_handler_process_memorize_channel_wa_feedback():
     assert remembered.data is not None
 
 @pytest.mark.asyncio
-async def test_memory_handler_process_memorize_channel_wa_feedback_invalid():
+async def test_memory_handler_process_memorize_channel_wa_feedback_invalid(monkeypatch):
     g = CIRISLocalGraph(storage_path=None)
     handler = MemoryHandler(g)
+    monkeypatch.setattr("ciris_engine.persistence.update_thought_status", lambda *a, **k: None)
     thought = Thought(
         thought_id="th3", source_task_id="t1", thought_type="test", status=ThoughtStatus.PENDING,
         created_at="now", updated_at="now", round_number=1, content="test",
@@ -81,9 +84,10 @@ async def test_memory_handler_process_memorize_channel_wa_feedback_invalid():
     assert result.selected_action.value == "defer"
 
 @pytest.mark.asyncio
-async def test_memory_handler_process_memorize_channel_wa_required():
+async def test_memory_handler_process_memorize_channel_wa_required(monkeypatch):
     g = CIRISLocalGraph(storage_path=None)
     handler = MemoryHandler(g)
+    monkeypatch.setattr("ciris_engine.persistence.update_thought_status", lambda *a, **k: None)
     thought = Thought(
         thought_id="th4", source_task_id="t1", thought_type="test", status=ThoughtStatus.PENDING,
         created_at="now", updated_at="now", round_number=1, content="test",

--- a/tests/ciris_engine/processor/test_base_processor.py
+++ b/tests/ciris_engine/processor/test_base_processor.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from ciris_engine.processor.base_processor import BaseProcessor
+from ciris_engine.schemas.config_schemas_v1 import AppConfig
+from ciris_engine.schemas.states import AgentState
+from ciris_engine.processor.processing_queue import ProcessingQueueItem
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus
+
+
+class DummyProcessor(BaseProcessor):
+    def get_supported_states(self):
+        return [AgentState.WORK]
+
+    async def can_process(self, state: AgentState) -> bool:
+        return True
+
+    async def process(self, round_number: int):
+        return {}
+
+
+def make_thought():
+    return Thought(
+        thought_id="th1",
+        source_task_id="t1",
+        thought_type="test",
+        status=ThoughtStatus.PENDING,
+        created_at="now",
+        updated_at="now",
+        round_number=1,
+        content="hello",
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_action_success():
+    ad = AsyncMock()
+    tp = AsyncMock()
+    proc = DummyProcessor(AppConfig(), tp, ad, {})
+
+    result = object()
+    thought = object()
+    ctx = {"a": 1}
+
+    assert await proc.dispatch_action(result, thought, ctx)
+    ad.dispatch.assert_awaited_with(action_selection_result=result, thought=thought, dispatch_context=ctx)
+    assert proc.metrics["errors"] == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_action_failure():
+    ad = AsyncMock()
+    ad.dispatch.side_effect = Exception("boom")
+    tp = AsyncMock()
+    proc = DummyProcessor(AppConfig(), tp, ad, {})
+
+    ok = await proc.dispatch_action(object(), object(), {})
+    assert not ok
+    assert proc.metrics["errors"] == 1
+
+
+@pytest.mark.asyncio
+async def test_process_thought_item_updates_metrics():
+    ad = AsyncMock()
+    tp = AsyncMock()
+    proc = DummyProcessor(AppConfig(), tp, ad, {})
+
+    item = ProcessingQueueItem(
+        thought_id="th1",
+        source_task_id="t1",
+        thought_type="test",
+        content="hello",
+    )
+
+    tp.process_thought = AsyncMock(return_value="r")
+
+    result = await proc.process_thought_item(item)
+    assert result == "r"
+    assert proc.metrics["items_processed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_process_thought_item_error(monkeypatch):
+    ad = AsyncMock()
+    tp = AsyncMock()
+    tp.process_thought = AsyncMock(side_effect=Exception("err"))
+    proc = DummyProcessor(AppConfig(), tp, ad, {})
+
+    item = ProcessingQueueItem(
+        thought_id="th1",
+        source_task_id="t1",
+        thought_type="test",
+        content="hello",
+    )
+
+    with pytest.raises(Exception):
+        await proc.process_thought_item(item)
+    assert proc.metrics["errors"] == 1

--- a/tests/ciris_engine/processor/test_processing_queue.py
+++ b/tests/ciris_engine/processor/test_processing_queue.py
@@ -1,0 +1,45 @@
+import pytest
+from ciris_engine.processor.processing_queue import ProcessingQueueItem
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus
+
+
+def make_thought():
+    return Thought(
+        thought_id="th1",
+        source_task_id="t1",
+        thought_type="test",
+        status=ThoughtStatus.PENDING,
+        created_at="now",
+        updated_at="now",
+        round_number=1,
+        content="hello",
+        context={"foo": "bar"},
+        ponder_count=0,
+        ponder_notes=None,
+        parent_thought_id=None,
+        final_action={},
+    )
+
+
+def test_from_thought_with_overrides():
+    t = make_thought()
+    item = ProcessingQueueItem.from_thought(
+        t,
+        raw_input="raw",
+        initial_ctx={"x": 1},
+        queue_item_content="override",
+    )
+    assert item.thought_id == t.thought_id
+    assert item.raw_input_string == "raw"
+    assert item.initial_context == {"x": 1}
+    assert item.content == "override"
+    assert item.ponder_notes is None
+
+
+def test_from_thought_defaults():
+    t = make_thought()
+    item = ProcessingQueueItem.from_thought(t)
+    assert item.raw_input_string == str(t.content)
+    assert item.initial_context == t.context
+    assert item.content == t.content

--- a/tests/ciris_engine/processor/test_state_manager.py
+++ b/tests/ciris_engine/processor/test_state_manager.py
@@ -1,0 +1,40 @@
+import time
+from ciris_engine.processor.state_manager import StateManager
+from ciris_engine.schemas.states import AgentState
+
+
+def test_valid_transition_records_history():
+    sm = StateManager(initial_state=AgentState.SHUTDOWN)
+    assert sm.get_state() == AgentState.SHUTDOWN
+    assert len(sm.state_history) == 1
+
+    assert sm.transition_to(AgentState.WAKEUP)
+    assert sm.get_state() == AgentState.WAKEUP
+    # history should now have two entries
+    assert len(sm.state_history) == 2
+    # metadata should have WAKEUP entry
+    assert AgentState.WAKEUP in sm.state_metadata
+
+
+def test_invalid_transition_does_not_change_state():
+    sm = StateManager(initial_state=AgentState.WAKEUP)
+    # WAKEUP -> SHUTDOWN is invalid
+    assert not sm.transition_to(AgentState.SHUTDOWN)
+    assert sm.get_state() == AgentState.WAKEUP
+    # history size remains 1
+    assert len(sm.state_history) == 1
+
+
+def test_state_duration(monkeypatch):
+    sm = StateManager(initial_state=AgentState.SHUTDOWN)
+    sm.transition_to(AgentState.WAKEUP)
+    enter_time = sm.state_metadata[AgentState.WAKEUP]["entered_at"]
+    past = time.time() - 5
+    monkeypatch.setitem(
+        sm.state_metadata[AgentState.WAKEUP],
+        "entered_at",
+        time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime(past)),
+    )
+    duration = sm.get_state_duration()
+    assert duration >= 5
+    sm.state_metadata[AgentState.WAKEUP]["entered_at"] = enter_time


### PR DESCRIPTION
## Summary
- add schema-driven tests for ProcessingQueueItem
- cover BaseProcessor dispatch and thought processing
- validate StateManager transitions and duration calculation

## Testing
- `pytest -q`
