### PR TITLE
Add runtime harnesses and tests

### DIFF
--- a/ciris_engine/harnesses/__init__.py
+++ b/ciris_engine/harnesses/__init__.py
@@ -2,7 +2,9 @@ from .wakeup_mode import run_wakeup
 from .stop_mode import StopHarness
 from .play_mode import run_play_session
 from .solitude_mode import run_solitude_session
-from .reflection_scheduler import schedule_reflection_modes
+from .reflection_scheduler import schedule_reflection_modes, schedule_event_log_rotation
+from .work_mode import run_work_rounds
+from .dream_mode import run_dream_session
 
 __all__ = [
     "run_wakeup",
@@ -10,4 +12,7 @@ __all__ = [
     "run_play_session",
     "run_solitude_session",
     "schedule_reflection_modes",
+    "schedule_event_log_rotation",
+    "run_work_rounds",
+    "run_dream_session",
 ]

--- a/ciris_engine/harnesses/dream_mode.py
+++ b/ciris_engine/harnesses/dream_mode.py
@@ -1,0 +1,15 @@
+from ciris_engine.processor.dream_processor import DreamProcessor
+
+
+async def run_dream_session(
+    processor: DreamProcessor,
+    *,
+    duration: float = 60.0,
+    pulse_interval: float = 300.0,
+) -> dict:
+    """Run a dream session and return the final summary."""
+    processor.pulse_interval = pulse_interval
+    await processor.start_dreaming(duration)
+    if processor._dream_task:
+        await processor._dream_task
+    return processor.get_dream_summary()

--- a/ciris_engine/harnesses/wakeup_mode.py
+++ b/ciris_engine/harnesses/wakeup_mode.py
@@ -2,8 +2,15 @@ from ciris_engine.processor import AgentProcessor
 
 from typing import Callable, Any
 
-async def run_wakeup(agent_processor: AgentProcessor, output_func: Callable[[Any], None] = print) -> bool:
-    """Execute only the wakeup ritual using the processor's built-in sequence. Output results using output_func."""
-    result = await agent_processor._run_wakeup_sequence()
+
+async def run_wakeup(
+    agent_processor: AgentProcessor,
+    output_func: Callable[[Any], None] = print,
+    *,
+    non_blocking: bool = False,
+) -> dict:
+    """Execute the wakeup ritual using the processor's WakeupProcessor."""
+    await agent_processor.wakeup_processor.initialize()
+    result = await agent_processor.wakeup_processor.process(0, non_blocking=non_blocking)
     output_func(f"Wakeup sequence result: {result}")
     return result

--- a/ciris_engine/harnesses/work_mode.py
+++ b/ciris_engine/harnesses/work_mode.py
@@ -1,0 +1,13 @@
+from typing import List
+
+from ciris_engine.processor.work_processor import WorkProcessor
+
+
+async def run_work_rounds(processor: WorkProcessor, rounds: int = 1) -> List[dict]:
+    """Run a number of work rounds and return the metrics for each."""
+    await processor.initialize()
+    results = []
+    for i in range(rounds):
+        results.append(await processor.process(i))
+    await processor.cleanup()
+    return results

--- a/tests/ciris_engine/harnesses/test_harnesses.py
+++ b/tests/ciris_engine/harnesses/test_harnesses.py
@@ -1,0 +1,208 @@
+import asyncio
+import types
+import pytest
+from unittest.mock import AsyncMock
+
+from ciris_engine.harnesses import (
+    run_wakeup,
+    run_play_session,
+    run_solitude_session,
+    schedule_reflection_modes,
+    schedule_event_log_rotation,
+    StopHarness,
+    run_work_rounds,
+    run_dream_session,
+)
+from ciris_engine.harnesses.work_mode import run_work_rounds
+from ciris_engine.harnesses.dream_mode import run_dream_session
+from ciris_engine.processor import WakeupProcessor, WorkProcessor, DreamProcessor
+from ciris_engine.processor.thought_processor import ThoughtProcessor
+from ciris_engine.schemas.config_schemas_v1 import AppConfig, WorkflowConfig
+from ciris_engine.services.event_log_service import EventLogService
+from ciris_engine.action_handlers.action_dispatcher import ActionDispatcher
+from ciris_engine.processor.main_processor import AgentProcessor
+from ciris_engine.schemas.agent_core_schemas_v1 import Task, Thought
+from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus, ThoughtStatus
+
+
+# Reuse MemoryDB from processor tests for persistence mocks
+class MemoryDB:
+    def __init__(self):
+        self.tasks = {}
+        self.thoughts = {}
+
+    def add_task(self, task: Task):
+        self.tasks[task.task_id] = task
+
+    def task_exists(self, task_id: str) -> bool:
+        return task_id in self.tasks
+
+    def get_task_by_id(self, task_id: str):
+        return self.tasks.get(task_id)
+
+    def update_task_status(self, task_id: str, status: TaskStatus, **kwargs):
+        t = self.tasks.get(task_id)
+        if not t:
+            return False
+        self.tasks[task_id] = t.copy(update={"status": status})
+        return True
+
+    def get_pending_tasks_for_activation(self, limit: int = 10):
+        return [t for t in self.tasks.values() if t.status == TaskStatus.PENDING][:limit]
+
+    def count_active_tasks(self):
+        return len([t for t in self.tasks.values() if t.status == TaskStatus.ACTIVE])
+
+    def get_tasks_needing_seed_thought(self, limit: int = 50):
+        return [
+            t
+            for t in self.tasks.values()
+            if t.status == TaskStatus.ACTIVE and not self.thought_exists_for(t.task_id)
+        ][:limit]
+
+    def add_thought(self, thought: Thought):
+        self.thoughts[thought.thought_id] = thought
+
+    def thought_exists_for(self, task_id: str) -> bool:
+        return any(th.source_task_id == task_id for th in self.thoughts.values())
+
+    def get_pending_thoughts_for_active_tasks(self, limit: int = 50):
+        active_ids = {t.task_id for t in self.tasks.values() if t.status == TaskStatus.ACTIVE}
+        pending = [
+            th
+            for th in self.thoughts.values()
+            if th.status == ThoughtStatus.PENDING and th.source_task_id in active_ids
+        ]
+        return pending[:limit]
+
+    def update_thought_status(self, thought_id: str, status: ThoughtStatus, **kwargs):
+        th = self.thoughts.get(thought_id)
+        if not th:
+            return False
+        self.thoughts[thought_id] = th.copy(update={"status": status})
+        return True
+
+    def pending_thoughts(self):
+        return [th for th in self.thoughts.values() if th.status == ThoughtStatus.PENDING]
+
+    def count_pending_thoughts_for_active_tasks(self):
+        return len(self.get_pending_thoughts_for_active_tasks())
+
+
+@pytest.mark.asyncio
+async def test_run_wakeup(monkeypatch):
+    db = MemoryDB()
+    monkeypatch.setattr("ciris_engine.persistence.task_exists", db.task_exists)
+    monkeypatch.setattr("ciris_engine.persistence.add_task", db.add_task)
+    monkeypatch.setattr("ciris_engine.persistence.get_task_by_id", db.get_task_by_id)
+    monkeypatch.setattr("ciris_engine.persistence.update_task_status", db.update_task_status)
+
+    dispatcher = ActionDispatcher({})
+    processor = AgentProcessor(AppConfig(), AsyncMock(spec=ThoughtProcessor), dispatcher, {})
+
+    out = []
+    await run_wakeup(processor, out.append, non_blocking=True)
+    assert out
+    assert processor.wakeup_processor.wakeup_tasks
+
+
+@pytest.mark.asyncio
+async def test_run_work_rounds(monkeypatch):
+    cfg = AppConfig(workflow=WorkflowConfig(max_active_tasks=1, max_active_thoughts=1))
+    db = MemoryDB()
+    monkeypatch.setattr("ciris_engine.persistence.task_exists", db.task_exists)
+    monkeypatch.setattr("ciris_engine.persistence.add_task", db.add_task)
+    monkeypatch.setattr("ciris_engine.persistence.get_task_by_id", db.get_task_by_id)
+    monkeypatch.setattr("ciris_engine.persistence.update_task_status", db.update_task_status)
+    monkeypatch.setattr("ciris_engine.persistence.get_pending_tasks_for_activation", db.get_pending_tasks_for_activation, raising=False)
+    monkeypatch.setattr("ciris_engine.persistence.count_active_tasks", db.count_active_tasks, raising=False)
+    monkeypatch.setattr("ciris_engine.persistence.get_tasks_needing_seed_thought", db.get_tasks_needing_seed_thought, raising=False)
+    monkeypatch.setattr("ciris_engine.persistence.add_thought", db.add_thought)
+    monkeypatch.setattr("ciris_engine.persistence.thought_exists_for", db.thought_exists_for, raising=False)
+    monkeypatch.setattr("ciris_engine.persistence.get_pending_thoughts_for_active_tasks", db.get_pending_thoughts_for_active_tasks)
+    monkeypatch.setattr("ciris_engine.persistence.update_thought_status", db.update_thought_status)
+    monkeypatch.setattr("ciris_engine.persistence.pending_thoughts", db.pending_thoughts, raising=False)
+    monkeypatch.setattr("ciris_engine.persistence.count_pending_thoughts_for_active_tasks", db.count_pending_thoughts_for_active_tasks, raising=False)
+
+    dispatcher = ActionDispatcher({})
+    work = WorkProcessor(app_config=cfg, thought_processor=AsyncMock(), action_dispatcher=dispatcher, services={})
+    db.add_task(Task(task_id="t1", description="d", status=TaskStatus.PENDING, priority=0, created_at="now", updated_at="now"))
+    results = await run_work_rounds(work, rounds=2)
+    assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_dream_session(monkeypatch):
+    dp = DreamProcessor(cirisnode_url="http://x", pulse_interval=0.05)
+
+    class DummyClient:
+        async def run_he300(self):
+            return {"topic": "A"}
+        async def run_simplebench(self):
+            return {"score": 1}
+
+    dp.cirisnode_client = DummyClient()
+    summary = await run_dream_session(dp, duration=0.15, pulse_interval=0.05)
+    assert summary["metrics"]["total_pulses"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_play_and_solitude_sessions():
+    msgs = []
+    async def out(msg):
+        msgs.append(msg)
+    await run_play_session(out, duration=0.01)
+    await run_solitude_session(out, duration=0.01)
+    assert any("Play Mode" in m or "Solitude" in m for m in msgs[-2:])
+
+
+@pytest.mark.asyncio
+async def test_schedule_reflection_modes():
+    msgs = []
+    async def out(msg):
+        msgs.append(msg)
+    async def dummy_play(_):
+        msgs.append("play")
+    async def dummy_solitude(_):
+        msgs.append("solitude")
+    mp = pytest.MonkeyPatch()
+    mp.setattr("ciris_engine.harnesses.reflection_scheduler.run_play_session", dummy_play)
+    mp.setattr("ciris_engine.harnesses.reflection_scheduler.run_solitude_session", dummy_solitude)
+    await schedule_reflection_modes(out, interval=0.01, iterations=2)
+    mp.undo()
+    assert msgs.count("play") + msgs.count("solitude") == 2
+
+
+@pytest.mark.asyncio
+async def test_schedule_event_log_rotation(tmp_path):
+    service = EventLogService(log_path=tmp_path / "log.jsonl", max_bytes=1, backups=1)
+    await service.start()
+    await service.log_event({"e": 1})
+    task = asyncio.create_task(schedule_event_log_rotation(service, interval=0.01))
+    await asyncio.sleep(0.02)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    rotated = tmp_path / "log.1.jsonl"
+    assert rotated.exists()
+
+
+@pytest.mark.asyncio
+async def test_stop_harness(monkeypatch):
+    class DummyProc:
+        def __init__(self):
+            self.stopped = False
+            self.persisted = False
+        async def stop_processing(self):
+            self.stopped = True
+        async def persist_state(self):
+            self.persisted = True
+        async def self_test(self):
+            return True
+
+    proc = DummyProc()
+    harness = StopHarness(proc)
+    with harness:
+        harness._handle_signal(2, None)
+        await asyncio.wait_for(harness.wait_for_stop(0.01), timeout=0.5)
+    assert proc.stopped and proc.persisted

--- a/tests/ciris_engine/processor/test_processor_states.py
+++ b/tests/ciris_engine/processor/test_processor_states.py
@@ -1,0 +1,166 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from ciris_engine.processor import WakeupProcessor, WorkProcessor, PlayProcessor, SolitudeProcessor, DreamProcessor
+from ciris_engine.schemas.config_schemas_v1 import AppConfig, WorkflowConfig
+from ciris_engine.schemas.agent_core_schemas_v1 import Task, Thought
+from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus, ThoughtStatus
+
+
+# Simple in-memory persistence mocks
+class MemoryDB:
+    def __init__(self):
+        self.tasks = {}
+        self.thoughts = {}
+
+    # task helpers
+    def add_task(self, task: Task):
+        self.tasks[task.task_id] = task
+
+    def task_exists(self, task_id: str) -> bool:
+        return task_id in self.tasks
+
+    def get_task_by_id(self, task_id: str):
+        return self.tasks.get(task_id)
+
+    def update_task_status(self, task_id: str, status: TaskStatus, **kwargs):
+        t = self.tasks.get(task_id)
+        if not t:
+            return False
+        self.tasks[task_id] = t.copy(update={"status": status})
+        return True
+
+    def get_pending_tasks_for_activation(self, limit: int = 10):
+        return [t for t in self.tasks.values() if t.status == TaskStatus.PENDING][:limit]
+
+    def count_active_tasks(self):
+        return len([t for t in self.tasks.values() if t.status == TaskStatus.ACTIVE])
+
+    def get_tasks_needing_seed_thought(self, limit: int = 50):
+        return [t for t in self.tasks.values() if t.status == TaskStatus.ACTIVE and not self.thought_exists_for(t.task_id)][:limit]
+
+    # thought helpers
+    def add_thought(self, thought: Thought):
+        self.thoughts[thought.thought_id] = thought
+
+    def thought_exists_for(self, task_id: str) -> bool:
+        return any(th.source_task_id == task_id for th in self.thoughts.values())
+
+    def get_pending_thoughts_for_active_tasks(self, limit: int = 50):
+        active_ids = {t.task_id for t in self.tasks.values() if t.status == TaskStatus.ACTIVE}
+        pending = [th for th in self.thoughts.values() if th.status == ThoughtStatus.PENDING and th.source_task_id in active_ids]
+        return pending[:limit]
+
+    def update_thought_status(self, thought_id: str, status: ThoughtStatus, **kwargs):
+        th = self.thoughts.get(thought_id)
+        if not th:
+            return False
+        self.thoughts[thought_id] = th.copy(update={"status": status})
+        return True
+
+    def pending_thoughts(self):
+        return [th for th in self.thoughts.values() if th.status == ThoughtStatus.PENDING]
+
+    def count_pending_thoughts_for_active_tasks(self):
+        return len(self.get_pending_thoughts_for_active_tasks())
+
+
+@pytest.mark.asyncio
+async def test_wakeup_processor_completion(monkeypatch):
+    db = MemoryDB()
+    # patch persistence functions
+    monkeypatch.setattr('ciris_engine.persistence.task_exists', db.task_exists)
+    monkeypatch.setattr('ciris_engine.persistence.add_task', db.add_task)
+    monkeypatch.setattr('ciris_engine.persistence.get_task_by_id', db.get_task_by_id)
+    monkeypatch.setattr('ciris_engine.persistence.update_task_status', db.update_task_status)
+
+    proc = WakeupProcessor(AppConfig(), AsyncMock(), AsyncMock(), {}, startup_channel_id='chan')
+
+    # Initial call creates tasks
+    result = await proc.process(0, non_blocking=True)
+    assert result['status'] == 'in_progress'
+    assert len(proc.wakeup_tasks) == len(WakeupProcessor.WAKEUP_SEQUENCE) + 1
+
+    # Mark all as completed
+    for t in proc.wakeup_tasks:
+        db.update_task_status(t.task_id, TaskStatus.COMPLETED)
+
+    result = await proc.process(1, non_blocking=True)
+    assert result['wakeup_complete'] is True
+    root_task = db.get_task_by_id('WAKEUP_ROOT')
+    assert root_task.status == TaskStatus.COMPLETED
+
+
+def setup_work_proc(monkeypatch, max_tasks=2, max_thoughts=3):
+    cfg = AppConfig(workflow=WorkflowConfig(max_active_tasks=max_tasks, max_active_thoughts=max_thoughts))
+    db = MemoryDB()
+    monkeypatch.setattr('ciris_engine.persistence.task_exists', db.task_exists)
+    monkeypatch.setattr('ciris_engine.persistence.add_task', db.add_task)
+    monkeypatch.setattr('ciris_engine.persistence.get_task_by_id', db.get_task_by_id)
+    monkeypatch.setattr('ciris_engine.persistence.update_task_status', db.update_task_status)
+    monkeypatch.setattr('ciris_engine.persistence.get_pending_tasks_for_activation', db.get_pending_tasks_for_activation, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.count_active_tasks', db.count_active_tasks, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.get_tasks_needing_seed_thought', db.get_tasks_needing_seed_thought, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.add_thought', db.add_thought)
+    monkeypatch.setattr('ciris_engine.persistence.thought_exists_for', db.thought_exists_for, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.get_pending_thoughts_for_active_tasks', db.get_pending_thoughts_for_active_tasks)
+    monkeypatch.setattr('ciris_engine.persistence.update_thought_status', db.update_thought_status)
+    monkeypatch.setattr('ciris_engine.persistence.pending_thoughts', db.pending_thoughts, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.count_pending_thoughts_for_active_tasks', db.count_pending_thoughts_for_active_tasks, raising=False)
+    tp = AsyncMock()
+    ad = AsyncMock()
+    proc = WorkProcessor(app_config=cfg, thought_processor=tp, action_dispatcher=ad, services={})
+    return proc, db
+
+
+@pytest.mark.asyncio
+async def test_work_processor_enforces_limits(monkeypatch):
+    proc, db = setup_work_proc(monkeypatch, max_tasks=2, max_thoughts=3)
+    # existing active task
+    db.add_task(Task(task_id='active1', description='d', status=TaskStatus.ACTIVE, priority=0, created_at='now', updated_at='now'))
+    # five pending tasks
+    for i in range(5):
+        db.add_task(Task(task_id=f'p{i}', description='d', status=TaskStatus.PENDING, priority=0, created_at='now', updated_at='now'))
+    # add pending thoughts for active1
+    for i in range(5):
+        db.add_thought(Thought(thought_id=f'th{i}', source_task_id='active1', thought_type='test', status=ThoughtStatus.PENDING, created_at='now', updated_at='now', round_number=0, content='c'))
+
+    activated = proc.task_manager.activate_pending_tasks()
+    assert activated == 1  # only up to max_active_tasks can be activated
+
+    queue_size = proc.thought_manager.populate_queue(1)
+    assert queue_size == 3  # limited by max_active_thoughts
+
+
+@pytest.mark.asyncio
+async def test_play_processor_mode(monkeypatch):
+    proc, _ = setup_work_proc(monkeypatch)
+    play_proc = PlayProcessor(app_config=proc.app_config, thought_processor=proc.thought_processor, action_dispatcher=proc.action_dispatcher, services={})
+    result = await play_proc.process(1)
+    assert result['mode'] == 'play'
+    assert result['creativity_enabled']
+
+
+@pytest.mark.asyncio
+async def test_solitude_processor_exit_after_critical(monkeypatch):
+    cfg = AppConfig()
+    proc = SolitudeProcessor(app_config=cfg, thought_processor=AsyncMock(), action_dispatcher=AsyncMock(), services={})
+    monkeypatch.setattr(proc, '_check_critical_tasks', AsyncMock(return_value=1))
+    result = await proc.process(1)
+    assert result['should_exit_solitude'] is True
+
+
+@pytest.mark.asyncio
+async def test_dream_processor_pulse(monkeypatch):
+    dp = DreamProcessor(cirisnode_url='http://x')
+
+    class DummyClient:
+        async def run_he300(self):
+            return {'topic': 'A'}
+        async def run_simplebench(self):
+            return {'score': 1}
+    dp.cirisnode_client = DummyClient()
+
+    await dp._dream_pulse()
+    assert dp.dream_metrics['total_pulses'] == 1
+    assert dp.snore_history

--- a/tests/ciris_engine/runtime/test_base_runtime.py
+++ b/tests/ciris_engine/runtime/test_base_runtime.py
@@ -1,0 +1,69 @@
+import asyncio
+import types
+import pytest
+from unittest.mock import AsyncMock
+
+from ciris_engine.runtime.base_runtime import BaseRuntime, BaseIOAdapter
+from ciris_engine.action_handlers.action_dispatcher import ActionDispatcher
+from ciris_engine.schemas.agent_core_schemas_v1 import Task
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
+
+
+class DummyAdapter(BaseIOAdapter):
+    def __init__(self):
+        self.outputs = []
+    async def send_output(self, target, content):
+        self.outputs.append((target, content))
+
+
+class MemoryDB:
+    def __init__(self):
+        self.tasks = {}
+    def add_task(self, t: Task):
+        self.tasks[t.task_id] = t
+    def task_exists(self, tid: str) -> bool:
+        return tid in self.tasks
+    def get_task_by_id(self, tid: str):
+        return self.tasks.get(tid)
+
+
+@pytest.mark.asyncio
+async def test_create_task_if_new(monkeypatch):
+    db = MemoryDB()
+    monkeypatch.setattr("ciris_engine.persistence.task_exists", db.task_exists)
+    monkeypatch.setattr("ciris_engine.persistence.add_task", db.add_task)
+    rt = BaseRuntime(DummyAdapter(), "profile", ActionDispatcher({}))
+    created = await rt._create_task_if_new("1", "hello", {})
+    assert created
+    assert db.task_exists("1")
+    created2 = await rt._create_task_if_new("1", "hello", {})
+    assert not created2
+
+
+@pytest.mark.asyncio
+async def test_dream_action_filter(monkeypatch):
+    rt = BaseRuntime(DummyAdapter(), "profile", ActionDispatcher({}))
+    rt.audit_service = AsyncMock()
+
+    result = types.SimpleNamespace(selected_handler_action=HandlerActionType.SPEAK)
+    skip = await rt._dream_action_filter(result, {"a": 1})
+    assert skip
+    rt.audit_service.log_action.assert_awaited()
+
+    result2 = types.SimpleNamespace(selected_handler_action=HandlerActionType.PONDER)
+    rt.audit_service.log_action.reset_mock()
+    skip = await rt._dream_action_filter(result2, {})
+    assert not skip
+    rt.audit_service.log_action.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_dream(monkeypatch):
+    adapter = DummyAdapter()
+    rt = BaseRuntime(adapter, "profile", ActionDispatcher({}), snore_channel_id="chan")
+    rt.audit_service = AsyncMock()
+    monkeypatch.setattr(rt, "_dream_action_filter", AsyncMock(return_value=False))
+    await rt.run_dream(duration=0.15, pulse_interval=0.05)
+    assert not rt.dreaming
+    assert adapter.outputs
+    rt.audit_service.log_action.assert_called()


### PR DESCRIPTION
## Summary
- add harness utilities for work and dream states
- refactor wakeup harness
- export all harness helpers
- test base runtime functionality
- add harness test suite covering each helper

## Testing
- `pytest -q`