### PR TITLE
Fix observe channel context and add tests

### DIFF
--- a/ciris_engine/action_handlers/discord_observe_handler.py
+++ b/ciris_engine/action_handlers/discord_observe_handler.py
@@ -70,6 +70,9 @@ async def handle_discord_observe_event(
             logger.error("Active observation mode requires 'discord_service' in context.")
             return
         channel_id = payload.get("channel_id") or context.get("default_channel_id")
+        if not channel_id:
+            logger.error("Active observation mode requires a channel_id")
+            return
         offset = payload.get("offset", 0)
         limit = payload.get("limit", 20)
         include_agent = payload.get("include_agent", True)

--- a/ciris_engine/action_handlers/observe_handler.py
+++ b/ciris_engine/action_handlers/observe_handler.py
@@ -36,9 +36,13 @@ class ObserveHandler(BaseActionHandler):
         elif params.active:  # v1 uses 'active'
             # Use the Discord observe handler in active mode
             try:
+                target_channel_id = params.channel_id or dispatch_context.get("channel_id")
+                if not target_channel_id:
+                    target_channel_id = os.getenv("DISCORD_CHANNEL_ID")
+
                 await handle_discord_observe_event(
                     payload={
-                        "channel_id": params.sources[0] if params.sources else None,
+                        "channel_id": target_channel_id,
                         "offset": params.offset if hasattr(params, 'offset') else 0,
                         "limit": params.limit if hasattr(params, 'limit') else 10,
                         "include_agent": True
@@ -51,7 +55,7 @@ class ObserveHandler(BaseActionHandler):
                     }
                 )
                 action_performed_successfully = True
-                follow_up_content_key_info = f"Active Discord observe handler invoked for sources: {params.sources}"
+                follow_up_content_key_info = f"Active Discord observe handler invoked for channel: {target_channel_id}"
             except Exception as e:
                 self.logger.exception(f"Error during active Discord observe handler for thought {thought_id}: {e}")
                 final_thought_status = ThoughtStatus.FAILED
@@ -69,7 +73,7 @@ class ObserveHandler(BaseActionHandler):
                     mode="passive"
                 )
                 action_performed_successfully = True
-                follow_up_content_key_info = f"Passive Discord observe handler invoked for sources: {params.sources}"
+                follow_up_content_key_info = "Passive Discord observe handler invoked"
             except Exception as e:
                 self.logger.exception(f"Error during passive Discord observe handler for thought {thought_id}: {e}")
                 final_thought_status = ThoughtStatus.FAILED

--- a/tests/ciris_engine/action_handlers/test_followup_helpers.py
+++ b/tests/ciris_engine/action_handlers/test_followup_helpers.py
@@ -1,0 +1,30 @@
+import pytest
+from ciris_engine.action_handlers.helpers import create_follow_up_thought
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus
+
+
+def make_parent():
+    return Thought(
+        thought_id="p1",
+        source_task_id="task1",
+        thought_type="test",
+        status=ThoughtStatus.PENDING,
+        created_at="now",
+        updated_at="now",
+        round_number=1,
+        content="parent",
+        context={"channel_id": "chan", "foo": "bar"},
+        ponder_count=0,
+        ponder_notes=None,
+        parent_thought_id=None,
+        final_action={},
+    )
+
+
+def test_follow_up_copies_context():
+    parent = make_parent()
+    child = create_follow_up_thought(parent, content="child")
+    assert child.parent_thought_id == parent.thought_id
+    assert child.context.get("channel_id") == "chan"
+    assert child.context.get("foo") == "bar"

--- a/tests/ciris_engine/action_handlers/test_observe_active_channel.py
+++ b/tests/ciris_engine/action_handlers/test_observe_active_channel.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from ciris_engine.action_handlers.observe_handler import ObserveHandler
+from ciris_engine.schemas.action_params_v1 import ObserveParams
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, ThoughtStatus
+from ciris_engine.action_handlers.base_handler import ActionHandlerDependencies
+
+
+DEFAULT_THOUGHT_KWARGS = dict(
+    thought_id="t1",
+    source_task_id="task1",
+    thought_type="test",
+    status=ThoughtStatus.PENDING,
+    created_at="now",
+    updated_at="now",
+    round_number=1,
+    content="content",
+    context={},
+    ponder_count=0,
+    ponder_notes=None,
+    parent_thought_id=None,
+    final_action={},
+)
+
+
+@pytest.mark.asyncio
+async def test_observe_handler_active_injects_channel(monkeypatch):
+    handle_event = AsyncMock()
+    monkeypatch.setattr(
+        "ciris_engine.action_handlers.observe_handler.handle_discord_observe_event",
+        handle_event,
+    )
+    update_status = MagicMock()
+    add_thought = MagicMock()
+    monkeypatch.setattr("ciris_engine.persistence.update_thought_status", update_status)
+    monkeypatch.setattr("ciris_engine.persistence.add_thought", add_thought)
+
+    deps = ActionHandlerDependencies()
+    handler = ObserveHandler(deps)
+
+    params = ObserveParams(active=True, channel_id=None, context={})
+    action_result = ActionSelectionResult.model_construct(
+        selected_action=HandlerActionType.OBSERVE,
+        action_parameters=params,
+        rationale="r",
+    )
+    thought = Thought(**DEFAULT_THOUGHT_KWARGS)
+
+    await handler.handle(action_result, thought, {"channel_id": "chanX"})
+
+    handle_event.assert_awaited()
+    payload = handle_event.call_args.kwargs["payload"]
+    assert payload["channel_id"] == "chanX"

--- a/tests/ciris_engine/context/test_builder.py
+++ b/tests/ciris_engine/context/test_builder.py
@@ -84,3 +84,13 @@ async def test_discord_channel_context(monkeypatch):
     ctx = await builder.build_thought_context(thought)
     assert "12345" in ctx.identity_context
     monkeypatch.delenv("DISCORD_CHANNEL_ID", raising=False)
+
+@pytest.mark.asyncio
+async def test_build_context_includes_task_summaries():
+    builder = ContextBuilder(memory_service=DummyMemoryService())
+    thought = make_thought()
+    task = make_task()
+    ctx = await builder.build_thought_context(thought, task)
+    snap = ctx.system_snapshot
+    assert len(snap.recently_completed_tasks_summary) == 10
+    assert len(snap.top_pending_tasks_summary) == 10


### PR DESCRIPTION
## Summary
- ensure `channel_id` from dispatch context is used for active OBSERVE actions
- validate channel_id before fetching active observations
- test follow-up thoughts preserve channel context
- test OBSERVE active uses provided channel
- test context builder includes recent and top task summaries

## Testing
- `pytest -q`