### PR TITLE
Fix channel_id propagation for monitoring tasks

### DIFF
--- a/ciris_engine/processor/main_processor.py
+++ b/ciris_engine/processor/main_processor.py
@@ -63,8 +63,9 @@ class AgentProcessor:
         self.work_processor = WorkProcessor(
             app_config=app_config,
             thought_processor=thought_processor,
-            action_dispatcher=self._action_dispatcher, # Use internal dispatcher
-            services=services
+            action_dispatcher=self._action_dispatcher,  # Use internal dispatcher
+            services=services,
+            startup_channel_id=startup_channel_id,
         )
         
         self.play_processor = PlayProcessor(

--- a/ciris_engine/processor/task_manager.py
+++ b/ciris_engine/processor/task_manager.py
@@ -168,7 +168,7 @@ class TaskManager:
         
         return tasks
     
-    def ensure_monitoring_task(self) -> Task:
+    def ensure_monitoring_task(self, channel_id: Optional[str] = None) -> Task:
         """Ensure the Discord monitoring task exists."""
         task_id = "job-discord-monitor"
         
@@ -183,7 +183,8 @@ class TaskManager:
                 updated_at=now_iso,
                 context={
                     "meta_goal": "continuous_monitoring",
-                    "origin_service": "discord_runtime_startup"
+                    "origin_service": "discord_runtime_startup",
+                    **({"channel_id": channel_id} if channel_id else {})
                 },
             )
             persistence.add_task(monitor_task)

--- a/ciris_engine/processor/wakeup_processor.py
+++ b/ciris_engine/processor/wakeup_processor.py
@@ -245,7 +245,8 @@ class WakeupProcessor(BaseProcessor):
                 updated_at=now_iso,
                 context={
                     "meta_goal": "continuous_monitoring",
-                    "origin_service": "wakeup_processor"
+                    "origin_service": "wakeup_processor",
+                    **({"channel_id": self.startup_channel_id} if self.startup_channel_id else {})
                 },
             )
             persistence.add_task(monitor_task)

--- a/ciris_engine/processor/work_processor.py
+++ b/ciris_engine/processor/work_processor.py
@@ -18,9 +18,10 @@ logger = logging.getLogger(__name__)
 
 class WorkProcessor(BaseProcessor):
     """Handles the WORK state for normal task/thought processing."""
-    
-    def __init__(self, *args, **kwargs):
+
+    def __init__(self, *args, startup_channel_id: Optional[str] = None, **kwargs):
         """Initialize work processor."""
+        self.startup_channel_id = startup_channel_id
         super().__init__(*args, **kwargs)
         
         # Extract config values with defaults
@@ -33,7 +34,10 @@ class WorkProcessor(BaseProcessor):
             max_active_thoughts = 50
         
         self.task_manager = TaskManager(max_active_tasks=max_active_tasks)
-        self.thought_manager = ThoughtManager(max_active_thoughts=max_active_thoughts)
+        self.thought_manager = ThoughtManager(
+            max_active_thoughts=max_active_thoughts,
+            default_channel_id=self.startup_channel_id,
+        )
         self.last_activity_time = datetime.now(timezone.utc)
         self.idle_rounds = 0
     


### PR DESCRIPTION
## Summary
- pass startup_channel_id into WorkProcessor via AgentProcessor
- store default channel_id in ThoughtManager
- include channel_id when creating monitoring task and job thoughts
- allow TaskManager.ensure_monitoring_task to take channel id
- propagate channel_id in WakeupProcessor when creating monitoring task

## Testing
- `pytest -q`