### PR TITLE
Fix missing discord_service for observe handler

### DIFF
--- a/ciris_engine/adapters/cli/cli_runtime.py
+++ b/ciris_engine/adapters/cli/cli_runtime.py
@@ -56,6 +56,8 @@ class InteractiveCLIAdapter(CLIAdapter):
                     "content": line,
                 }
             )
+            # Ensure the database is initialized before adding the task
+            persistence.initialize_database()
             persistence.add_task(task)
             logger.info(f"Created task {task_id} from CLI input")
             return []

--- a/ciris_engine/processor/base_processor.py
+++ b/ciris_engine/processor/base_processor.py
@@ -32,6 +32,9 @@ class BaseProcessor(ABC):
         self.thought_processor = thought_processor  # type: ignore  # ThoughtProcessor is imported at runtime or via forward reference
         self.action_dispatcher = action_dispatcher
         self.services = services
+        # Propagate commonly used services as direct attributes for convenience
+        if services and "discord_service" in services:
+            self.discord_service = services["discord_service"]
         self.metrics: Dict[str, Any] = {
             "start_time": None,
             "end_time": None,

--- a/ciris_engine/processor/main_processor.py
+++ b/ciris_engine/processor/main_processor.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from ciris_engine.schemas.config_schemas_v1 import AppConfig
 from ciris_engine.schemas.states import AgentState
 from ciris_engine import persistence
-from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ThoughtStatus
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ThoughtStatus, Task
 from ciris_engine.processor.processing_queue import ProcessingQueueItem
 
 from ciris_engine.processor.thought_processor import ThoughtProcessor
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from ciris_engine.action_handlers.action_dispatcher import ActionDispatcher
 
 # For main_processor.py and work_processor.py (or anywhere else you need it)
-from ciris_engine.utils.context_utils import build_dispatch_context
 from .state_manager import StateManager
 from .wakeup_processor import WakeupProcessor
 from .work_processor import WorkProcessor
@@ -102,8 +101,31 @@ class AgentProcessor:
         self.current_round_number = 0
         self._stop_event = asyncio.Event()
         self._processing_task: Optional[asyncio.Task] = None
-        
+
         logger.info("AgentProcessor initialized with v1 schemas and modular processors")
+
+    def _build_dispatch_context(self, thought: Thought, task: Optional[Task]):
+        dispatch_context = {
+            "thought_id": thought.thought_id,
+            "source_task_id": thought.source_task_id,
+            "origin_service": "CLI" if self.app_config and getattr(self.app_config, "agent_mode", "").lower() == "cli" else "discord",
+            "round_number": self.current_round_number,
+        }
+        channel_id = None
+        if task and getattr(task, "context", None):
+            for key in ["channel_id", "author_name", "author_id"]:
+                if key in task.context:
+                    dispatch_context[key] = task.context[key]
+            channel_id = task.context.get("channel_id")
+        if not channel_id:
+            channel_id = self.startup_channel_id
+            if not channel_id:
+                logger.error(
+                    f"No channel_id found for thought {thought.thought_id} and no startup_channel_id set. This may cause downstream errors."
+                )
+                channel_id = "CLI" if dispatch_context["origin_service"] == "CLI" else "default"
+        dispatch_context["channel_id"] = str(channel_id)
+        return dispatch_context
 
     @property
     def action_dispatcher(self) -> "ActionDispatcher":
@@ -270,7 +292,9 @@ class AgentProcessor:
             if result:
                 # Get the task for context
                 task = persistence.get_task_by_id(thought.source_task_id)
-                dispatch_context = build_dispatch_context(item, thought, task)
+                dispatch_context = self._build_dispatch_context(thought, task)
+                if hasattr(self, "discord_service"):
+                    dispatch_context["discord_service"] = self.discord_service
                 
                 await self.action_dispatcher.dispatch(
                     action_selection_result=result,

--- a/ciris_engine/processor/work_processor.py
+++ b/ciris_engine/processor/work_processor.py
@@ -175,6 +175,8 @@ class WorkProcessor(BaseProcessor):
         # Get the task object for context
         task = persistence.get_task_by_id(item.source_task_id)
         dispatch_context = build_dispatch_context(item, thought_obj, task)
+        if hasattr(self, "discord_service"):
+            dispatch_context["discord_service"] = self.discord_service
         
         try:
             await self.dispatch_action(result, thought_obj, dispatch_context)

--- a/ciris_engine/runtime/discord_runtime.py
+++ b/ciris_engine/runtime/discord_runtime.py
@@ -104,6 +104,15 @@ class DiscordRuntime(CIRISRuntime):
         register_discord_tools(tool_registry, self.discord_adapter.client)
         ToolHandler.set_tool_registry(tool_registry)
 
+        # Expose the discord client/service to processors for active observation
+        if self.agent_processor:
+            for proc in [self.agent_processor,
+                         self.agent_processor.wakeup_processor,
+                         self.agent_processor.work_processor,
+                         self.agent_processor.play_processor,
+                         self.agent_processor.solitude_processor]:
+                setattr(proc, "discord_service", self.client)
+
         # --- Ensure dispatcher is rebuilt with the correct sinks BEFORE starting observer ---
         if not self.action_sink:
             logger.error("DiscordRuntime: action_sink is not set before dispatcher rebuild attempt!")

--- a/tests/ciris_engine/processor/test_dispatch_context_services.py
+++ b/tests/ciris_engine/processor/test_dispatch_context_services.py
@@ -1,0 +1,68 @@
+import pytest
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from ciris_engine.processor.work_processor import WorkProcessor
+from ciris_engine.processor.main_processor import AgentProcessor
+from ciris_engine.schemas.config_schemas_v1 import AppConfig
+from ciris_engine.processor.processing_queue import ProcessingQueueItem
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus
+
+
+def make_thought():
+    return Thought(
+        thought_id="th1",
+        source_task_id="task1",
+        thought_type="test",
+        status=ThoughtStatus.PENDING,
+        created_at="now",
+        updated_at="now",
+        round_number=1,
+        content="content",
+        context={},
+        ponder_count=0,
+        ponder_notes=None,
+        parent_thought_id=None,
+        final_action={},
+        priority=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_work_processor_injects_discord_service(monkeypatch):
+    proc = WorkProcessor(app_config=AppConfig(), thought_processor=AsyncMock(), action_dispatcher=AsyncMock(), services={})
+    proc.discord_service = "DS"
+    thought = make_thought()
+    item = ProcessingQueueItem.from_thought(thought)
+    result = MagicMock(selected_action="OBSERVE")
+    monkeypatch.setattr("ciris_engine.processor.work_processor.persistence.get_thought_by_id", lambda x: thought)
+    monkeypatch.setattr("ciris_engine.processor.work_processor.persistence.get_task_by_id", lambda x: None)
+    dispatch_action = AsyncMock()
+    proc.dispatch_action = dispatch_action
+    await proc._dispatch_thought_result(item, result)
+    assert dispatch_action.call_args.args[2]["discord_service"] == "DS"
+
+
+@pytest.mark.asyncio
+async def test_agent_processor_injects_discord_service(monkeypatch):
+    app_config = AppConfig()
+    dispatcher = AsyncMock()
+    processor = AgentProcessor(
+        app_config=app_config,
+        thought_processor=AsyncMock(),
+        action_dispatcher=dispatcher,
+        services={},
+        startup_channel_id=None,
+    )
+    processor.discord_service = "DS"
+    thought = make_thought()
+    item = ProcessingQueueItem.from_thought(thought)
+    monkeypatch.setattr("ciris_engine.processor.main_processor.persistence.get_task_by_id", lambda x: None)
+    sub_proc = MagicMock()
+    sub_proc.process_thought_item = AsyncMock(return_value=MagicMock())
+    processor.state_processors[processor.state_manager.get_state()] = sub_proc
+    dispatcher.dispatch = AsyncMock()
+    await processor._process_single_thought(thought)
+    assert dispatcher.dispatch.call_args.kwargs["dispatch_context"]["discord_service"] == "DS"
+


### PR DESCRIPTION
## Summary
- inject discord_service into processors via services or runtime
- include discord_service in dispatch context for main and work processors
- initialize DB in CLI adapter
- add tests covering discord service injection

## Testing
- `pytest -q`