### PR TITLE
Refactor DMAs to use service registry

### DIFF
--- a/ciris_engine/dma/factory.py
+++ b/ciris_engine/dma/factory.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Dict, Optional, Type
 
-from openai import AsyncOpenAI
+from ciris_engine.registries.base import ServiceRegistry
 
 from .dsdma_base import BaseDSDMA
 from ciris_engine.schemas.config_schemas_v1 import AgentProfile
@@ -19,7 +19,7 @@ DEFAULT_PROFILE_PATH = Path("ciris_profiles/default.yaml")
 
 async def create_dsdma_from_profile(
     profile: Optional[AgentProfile],
-    aclient: AsyncOpenAI,
+    service_registry: ServiceRegistry,
     *,
     model_name: Optional[str] = None,
     default_profile_path: Path = DEFAULT_PROFILE_PATH,
@@ -50,7 +50,7 @@ async def create_dsdma_from_profile(
 
     return dsdma_cls(
         domain_name=profile.name,
-        aclient=aclient,
+        service_registry=service_registry,
         model_name=model_name,
         domain_specific_knowledge=domain_knowledge,
         prompt_template=prompt_template,

--- a/tests/ciris_engine/dma/test_csdma.py
+++ b/tests/ciris_engine/dma/test_csdma.py
@@ -1,23 +1,29 @@
 from unittest.mock import MagicMock, AsyncMock
+from types import SimpleNamespace
 from ciris_engine.dma.csdma import CSDMAEvaluator
 from ciris_engine.schemas.dma_results_v1 import CSDMAResult
 from ciris_engine.processor.processing_queue import ProcessingQueueItem
-from openai import AsyncOpenAI
+from ciris_engine.registries.base import ServiceRegistry, Priority
 
 def test_csdma_init_and_patch(monkeypatch):
-    aclient = MagicMock(spec=AsyncOpenAI)
+    service_registry = ServiceRegistry()
+    dummy_client = SimpleNamespace(client=MagicMock())
+    dummy_service = SimpleNamespace(get_client=lambda: dummy_client)
+    service_registry.register_global("llm", dummy_service, priority=Priority.HIGH)
     monkeypatch.setattr("instructor.patch", lambda c, mode: c)
-    evaluator = CSDMAEvaluator(aclient=aclient, model_name="m", prompt_overrides={"csdma_system_prompt": "PROMPT"})
+    evaluator = CSDMAEvaluator(service_registry=service_registry, model_name="m", prompt_overrides={"csdma_system_prompt": "PROMPT"})
     assert evaluator.model_name == "m"
     assert evaluator.prompt_overrides["csdma_system_prompt"] == "PROMPT"
-    assert evaluator.aclient is aclient
 
 async def test_csdma_evaluate_thought(monkeypatch):
-    aclient = MagicMock()
-    evaluator = CSDMAEvaluator(aclient=aclient, model_name="m")
-    # Use a real CSDMAResult for the mock return value
+    service_registry = ServiceRegistry()
+    dummy_client = SimpleNamespace(client=MagicMock())
+    dummy_service = SimpleNamespace(get_client=lambda: dummy_client)
+    service_registry.register_global("llm", dummy_service, priority=Priority.HIGH)
+    evaluator = CSDMAEvaluator(service_registry=service_registry, model_name="m")
     mock_result = CSDMAResult(plausibility_score=0.8, flags=["f1"], reasoning="r")
-    evaluator.aclient.chat.completions.create = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr("instructor.patch", lambda c, mode: c)
+    dummy_client.client.chat.completions.create = AsyncMock(return_value=mock_result)
     item = ProcessingQueueItem(
         thought_id="t1",
         source_task_id="s1",

--- a/tests/ciris_engine/dma/test_dsdma_base.py
+++ b/tests/ciris_engine/dma/test_dsdma_base.py
@@ -1,16 +1,21 @@
 import pytest
 from unittest.mock import MagicMock
+from types import SimpleNamespace
 from ciris_engine.dma.dsdma_base import BaseDSDMA
 from ciris_engine.schemas.dma_results_v1 import DSDMAResult
 from ciris_engine.processor.processing_queue import ProcessingQueueItem
+from ciris_engine.registries.base import ServiceRegistry, Priority
 
 class DummyDSDMA(BaseDSDMA):
     async def evaluate_thought(self, thought_item, current_context):
         return DSDMAResult(domain="d", alignment_score=1.0, recommended_action="a", flags=["f"], reasoning="r")
 
 def test_dsdma_init(monkeypatch):
+    service_registry = ServiceRegistry()
+    dummy_service = SimpleNamespace(get_client=lambda: None)
+    service_registry.register_global("llm", dummy_service, priority=Priority.HIGH)
     monkeypatch.setattr("instructor.patch", lambda c, mode: c)
-    dsdma = DummyDSDMA(domain_name="d", aclient=MagicMock(), model_name="m", domain_specific_knowledge={"rules_summary": "r"}, prompt_template="t")
+    dsdma = DummyDSDMA(domain_name="d", service_registry=service_registry, model_name="m", domain_specific_knowledge={"rules_summary": "r"}, prompt_template="t")
     assert dsdma.domain_name == "d"
     assert dsdma.model_name == "m"
     assert dsdma.domain_specific_knowledge["rules_summary"] == "r"


### PR DESCRIPTION
## Summary
- integrate service registry with all DMA evaluators
- register LLM service globally in `CIRISRuntime`
- update runtime to construct DMAs using the registry
- adjust DMA factory and tests for new signatures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a37796ccc832bb343de0711bcfd66