### PR TITLE
Update handlers with registry services

### DIFF
--- a/ciris_engine/action_handlers/base_handler.py
+++ b/ciris_engine/action_handlers/base_handler.py
@@ -103,6 +103,15 @@ class BaseActionHandler(ABC):
             "llm"
         )
 
+    async def get_observer_service(self) -> Optional[Any]:
+        """Get best available observer service"""
+        return await self.dependencies.get_service(
+            self.__class__.__name__,
+            "observer",
+            required_capabilities=["observe_messages"],
+        )
+
+
     @abstractmethod
     async def handle(
         self,

--- a/ciris_engine/action_handlers/observe_handler.py
+++ b/ciris_engine/action_handlers/observe_handler.py
@@ -1,244 +1,178 @@
 import logging
-import os
-from typing import Dict, Any
+from typing import Dict, Any, List, Optional
+
+from pydantic import ValidationError
+
 from ciris_engine.schemas.agent_core_schemas_v1 import Thought
 from ciris_engine.schemas.action_params_v1 import ObserveParams
-from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus, HandlerActionType
 from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
+from ciris_engine.schemas.foundational_schemas_v1 import (
+    ThoughtStatus,
+    HandlerActionType,
+    IncomingMessage,
+)
+from ciris_engine.schemas.graph_schemas_v1 import GraphScope
 from ciris_engine import persistence
 from .base_handler import BaseActionHandler, ActionHandlerDependencies
 from .helpers import create_follow_up_thought
 from .exceptions import FollowUpCreationError
-from .discord_observe_handler import handle_discord_observe_event
-from ciris_engine.schemas.service_actions_v1 import FetchMessagesAction
-from ciris_engine.sinks.multi_service_sink import MultiServiceActionSink
-from pydantic import BaseModel, ValidationError
 
 logger = logging.getLogger(__name__)
 
 
 class ObserveHandler(BaseActionHandler):
+    async def _recall_from_messages(
+        self,
+        memory_service: Optional[Any],
+        channel_id: Optional[str],
+        messages: List[Dict[str, Any]],
+    ) -> None:
+        if not memory_service:
+            return
+        recall_ids = set()
+        if channel_id:
+            recall_ids.add(f"channel/{channel_id}")
+        for msg in messages or []:
+            aid = msg.get("author_id")
+            if aid:
+                recall_ids.add(f"user/{aid}")
+        for rid in recall_ids:
+            for scope in (
+                GraphScope.IDENTITY,
+                GraphScope.ENVIRONMENT,
+                GraphScope.LOCAL,
+            ):
+                try:
+                    await memory_service.recall(rid, scope)
+                except Exception:
+                    continue
+
     async def handle(
         self,
-        result: ActionSelectionResult,  # Updated to v1 result schema
+        result: ActionSelectionResult,
         thought: Thought,
-        dispatch_context: Dict[str, Any]
+        dispatch_context: Dict[str, Any],
     ) -> None:
         params = result.action_parameters
         thought_id = thought.thought_id
-        await self._audit_log(HandlerActionType.OBSERVE, {**dispatch_context, "thought_id": thought_id}, outcome="start")
-        final_thought_status = ThoughtStatus.COMPLETED
-        action_performed_successfully = False
-        follow_up_content_key_info = f"OBSERVE action for thought {thought_id}"
+        await self._audit_log(
+            HandlerActionType.OBSERVE,
+            {**dispatch_context, "thought_id": thought_id},
+            outcome="start",
+        )
+        final_status = ThoughtStatus.COMPLETED
+        action_performed = False
+        follow_up_info = f"OBSERVE action for thought {thought_id}"
 
-        # DEBUG: Log the incoming parameters
-        logger.warning(f"OBSERVE HANDLER DEBUG: thought_id={thought_id}, params type={type(params)}, params={params}")
-
-        # Always use schema internally
         if isinstance(params, dict):
             try:
                 params = ObserveParams(**params)
-                logger.warning(f"OBSERVE HANDLER DEBUG: Created ObserveParams from dict: {params}")
             except ValidationError as e:
-                self.logger.error(f"OBSERVE action params dict could not be parsed: {e}. Thought ID: {thought_id}")
-                final_thought_status = ThoughtStatus.FAILED
-                follow_up_content_key_info = f"OBSERVE action failed: Invalid parameters dict for thought {thought_id}. Error: {e}"
+                logger.error(
+                    "OBSERVE params invalid for %s: %s", thought_id, e
+                )
+                final_status = ThoughtStatus.FAILED
+                follow_up_info = str(e)
                 persistence.update_thought_status(
                     thought_id=thought_id,
-                    status=final_thought_status,
-                    final_action=None
+                    status=final_status,
+                    final_action=None,
                 )
-                raise FollowUpCreationError(f"OBSERVE action failed: Invalid parameters dict for thought {thought_id}. Error: {e}")
+                raise FollowUpCreationError from e
         elif not isinstance(params, ObserveParams):
-            self.logger.error(f"OBSERVE action params are not ObserveParams model or dict. Type: {type(params)}. Thought ID: {thought_id}")
-            final_thought_status = ThoughtStatus.FAILED
-            follow_up_content_key_info = f"OBSERVE action failed: Invalid parameters type ({type(params)}) for thought {thought_id}."
+            logger.error(
+                "OBSERVE params wrong type %s for thought %s", type(params), thought_id
+            )
+            final_status = ThoughtStatus.FAILED
+            follow_up_info = "invalid params"
             persistence.update_thought_status(
                 thought_id=thought_id,
-                status=final_thought_status,
-                final_action=result.model_dump() if hasattr(result, 'model_dump') else result,
+                status=final_status,
+                final_action=None,
             )
-            raise FollowUpCreationError(f"OBSERVE action failed: Invalid parameters type ({type(params)}) for thought {thought_id}.")
-        
-        # DEBUG: Log the processed parameters
-        logger.warning(f"OBSERVE HANDLER DEBUG: processed params: active={params.active}, channel_id={params.channel_id}")
-        
-        logger.warning(f"OBSERVE HANDLER DEBUG: Processing {params.active} observation")
-        logger.warning(f"OBSERVE HANDLER DEBUG: Channel ID: {params.channel_id}")
-        logger.warning(f"OBSERVE HANDLER DEBUG: Memory service available: {self.dependencies.memory_service is not None}")
+            raise FollowUpCreationError("Invalid params type")
 
-        if params.active:  # v1 uses 'active'
-            # Use the new MultiServiceActionSink with FETCH_MESSAGES action
-            try:
-                target_channel_id = params.channel_id or dispatch_context.get("channel_id")
-                if not target_channel_id:
-                    target_channel_id = os.getenv("DISCORD_CHANNEL_ID")
+        channel_id = (
+            params.channel_id
+            or dispatch_context.get("channel_id")
+            or getattr(thought, "context", {}).get("channel_id")
+            or getattr(self.dependencies.observer_service, "monitored_channel_id", None)
+        )
+        params.channel_id = channel_id
 
-                if not target_channel_id:
-                    raise ValueError("No channel ID available for active observation")
+        comm_service = await self.get_communication_service()
+        observer_service = await self.get_observer_service()
+        memory_service = await self.get_memory_service()
 
-                # Check if we have service registry for new action system
-                if self.dependencies.service_registry:
-                    # Use new action system with MultiServiceActionSink
-                    action_sink = MultiServiceActionSink(
-                        service_registry=self.dependencies.service_registry,
-                        fallback_channel_id=target_channel_id
-                    )
-                    
-                    # Create FETCH_MESSAGES action
-                    fetch_action = FetchMessagesAction(
-                        type=None,  # Will be set in __post_init__
-                        handler_name="ObserveHandler",
-                        metadata={
-                            "thought_id": thought_id,
-                            "observation_type": "active",
-                            "dispatch_context": dispatch_context
-                        },
-                        channel_id=target_channel_id,
-                        limit=getattr(params, 'limit', 10)
-                    )
-                    
-                    # Start action sink and enqueue action
-                    await action_sink.start()
-                    try:
-                        success = await action_sink.enqueue_action(fetch_action)
-                        if success:
-                            action_performed_successfully = True
-                            follow_up_content_key_info = f"Active message fetch queued for channel: {target_channel_id}"
-                        else:
-                            raise Exception("Failed to enqueue FETCH_MESSAGES action")
-                    finally:
-                        await action_sink.stop()
-                
-                else:
-                    # Fallback to legacy Discord observe handler
-                    logger.warning("No service registry available, falling back to legacy Discord observe handler")
-                    
-                    # Build comprehensive context for active observation
-                    observe_context = {
-                        "default_channel_id": target_channel_id or os.getenv("DISCORD_CHANNEL_ID"),
-                        "agent_id": dispatch_context.get("agent_id")
-                    }
-                    
-                    # Try multiple sources for discord_service
-                    discord_service = None
-                    
-                    # 1. From dependencies
-                    if hasattr(self.dependencies, 'io_adapter') and hasattr(self.dependencies.io_adapter, 'client'):
-                        discord_service = self.dependencies.io_adapter.client
-                        logger.debug("Got discord_service from dependencies.io_adapter.client")
-                    
-                    # 2. From dispatch_context
-                    if not discord_service:
-                        discord_service = dispatch_context.get("discord_service")
-                        if discord_service:
-                            logger.debug("Got discord_service from dispatch_context")
-                    
-                    # 3. From services dict in dispatch_context
-                    if not discord_service and "services" in dispatch_context:
-                        services = dispatch_context["services"]
-                        discord_service = services.get("discord_service") or services.get("discord_client")
-                        if discord_service:
-                            logger.debug("Got discord_service from dispatch_context.services")
-                    
-                    # 4. Try to get from global runtime state (last resort)
-                    if not discord_service:
-                        # This is a fallback - ideally context should provide it
-                        logger.warning("discord_service not found in expected locations, active observation may fail")
-                    
-                    observe_context["discord_service"] = discord_service
-
-                    await handle_discord_observe_event(
-                        payload={
-                            "channel_id": target_channel_id,
-                            "offset": params.offset if hasattr(params, 'offset') else 0,
-                            "limit": params.limit if hasattr(params, 'limit') else 10,
-                            "include_agent": True
-                        },
-                        mode="active",
-                        context=observe_context
-                    )
-                    action_performed_successfully = True
-                    follow_up_content_key_info = f"Active Discord observe handler invoked for channel: {target_channel_id}"
-            except Exception as e:
-                self.logger.exception(f"Error during active Discord observe handler for thought {thought_id}: {e}")
-                final_thought_status = ThoughtStatus.FAILED
-                follow_up_content_key_info = f"Active Discord observe handler error: {str(e)}"
-        else:  # Passive observe
-            # Use the Discord observe handler in passive mode
-            try:
-                await handle_discord_observe_event(
-                    payload={
-                        "message_id": thought.thought_id,
-                        "content": thought.content,
-                        "context": getattr(thought, "context", {}),
-                        "task_description": getattr(thought, "content", None)
-                    },
-                    mode="passive"
+        try:
+            if params.active:
+                if not comm_service or not channel_id:
+                    raise RuntimeError("No communication service or channel_id")
+                messages = await comm_service.fetch_messages(
+                    str(channel_id).lstrip("#"), getattr(params, "limit", 10)
                 )
-                action_performed_successfully = True
-                follow_up_content_key_info = "Passive Discord observe handler invoked"
-            except Exception as e:
-                self.logger.exception(f"Error during passive Discord observe handler for thought {thought_id}: {e}")
-                final_thought_status = ThoughtStatus.FAILED
-                follow_up_content_key_info = f"Passive Discord observe handler error: {str(e)}"
+                await self._recall_from_messages(memory_service, channel_id, messages)
+                action_performed = True
+                follow_up_info = f"Fetched {len(messages)} messages from {channel_id}"
+            else:
+                if not observer_service:
+                    raise RuntimeError("Observer service unavailable")
+                incoming = IncomingMessage(
+                    message_id=thought.thought_id,
+                    author_id=thought.context.get("author_id", "unknown"),
+                    author_name=thought.context.get("author_name", "unknown"),
+                    content=thought.content,
+                    channel_id=channel_id,
+                )
+                if hasattr(observer_service, "handle_incoming_message"):
+                    await observer_service.handle_incoming_message(incoming)
+                elif hasattr(observer_service, "observe"):
+                    await observer_service.observe({"message": incoming})
+                else:
+                    raise RuntimeError("Observer service missing method")
+                action_performed = True
+                follow_up_info = "Observation forwarded"
+        except Exception as e:
+            logger.exception("ObserveHandler error for %s: %s", thought_id, e)
+            final_status = ThoughtStatus.FAILED
+            follow_up_info = str(e)
 
-        # v1 uses 'final_action' instead of 'final_action_result'
-        result_data = result.model_dump() if hasattr(result, 'model_dump') else result
+        final_action_dump = (
+            result.model_dump(mode="json") if hasattr(result, "model_dump") else result
+        )
         persistence.update_thought_status(
             thought_id=thought_id,
-            status=final_thought_status,
-            final_action=result_data,  # v1 field
+            status=final_status,
+            final_action=final_action_dump,
         )
-        self.logger.debug(f"Updated original thought {thought_id} to status {final_thought_status.value} after OBSERVE attempt.")
 
-        # ALWAYS create a follow-up thought for OBSERVE actions
-        # This ensures the DMA can see the results and continue reasoning
-        should_create_standard_follow_up = True
-        
-        # DEBUG: Log the decision logic
-        logger.warning(f"OBSERVE HANDLER DEBUG: Follow-up decision logic - params={params}, params.active={params.active if params else 'None'}, action_performed_successfully={action_performed_successfully}")
-        logger.warning(f"OBSERVE HANDLER DEBUG: Always creating follow-up for OBSERVE actions")
-
-        logger.warning(f"OBSERVE HANDLER DEBUG: should_create_standard_follow_up={should_create_standard_follow_up}")
-
-        if should_create_standard_follow_up:
-            follow_up_text = ""
-            if action_performed_successfully:
-                observation_type = "active" if (params and params.active) else "passive"
-                follow_up_text = f"OBSERVE action ({observation_type}) for thought {thought_id} completed. Info: {follow_up_content_key_info}. Review if this completes the task or if further steps are needed."
-            else:  # Failed
-                follow_up_text = f"OBSERVE action failed for thought {thought_id}. Reason: {follow_up_content_key_info}. Review and determine next steps."
-
-            try:
-                new_follow_up = create_follow_up_thought(
-                    parent=thought,
-                    content=follow_up_text,
-                )
-
-                # v1 uses 'context' instead of 'processing_context'
-                context_for_follow_up = {
-                    "action_performed": HandlerActionType.OBSERVE.value
-                }
-                if final_thought_status == ThoughtStatus.FAILED:
-                    context_for_follow_up["error_details"] = follow_up_content_key_info
-
-                # When serializing for follow-up, convert to dict
-                action_params_dump = params.model_dump(mode="json") if hasattr(params, "model_dump") else params
-                context_for_follow_up["action_params"] = action_params_dump
-
-                new_follow_up.context = context_for_follow_up  # v1 uses 'context'
-
-                persistence.add_thought(new_follow_up)
-                self.logger.info(
-                    f"Created standard follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after OBSERVE action."
-                )
-                await self._audit_log(HandlerActionType.OBSERVE, {**dispatch_context, "thought_id": thought_id}, outcome="success" if action_performed_successfully else "failed")
-            except Exception as e:
-                self.logger.critical(
-                    f"Failed to create follow-up thought for {thought_id}: {e}",
-                    exc_info=e,
-                )
-                await self._audit_log(HandlerActionType.OBSERVE, {**dispatch_context, "thought_id": thought_id}, outcome="failed_followup")
-                raise FollowUpCreationError from e
-        return result
+        follow_up_text = (
+            f"OBSERVE action completed. Info: {follow_up_info}"
+            if action_performed
+            else f"OBSERVE action failed: {follow_up_info}"
+        )
+        try:
+            new_follow_up = create_follow_up_thought(parent=thought, content=follow_up_text)
+            ctx = {
+                "action_performed": HandlerActionType.OBSERVE.value,
+                "action_params": params.model_dump(mode="json"),
+            }
+            if final_status == ThoughtStatus.FAILED:
+                ctx["error_details"] = follow_up_info
+            new_follow_up.context = ctx
+            persistence.add_thought(new_follow_up)
+            await self._audit_log(
+                HandlerActionType.OBSERVE,
+                {**dispatch_context, "thought_id": thought_id},
+                outcome="success" if action_performed else "failed",
+            )
+        except Exception as e:
+            logger.critical(
+                "Failed to create follow-up for %s: %s", thought_id, e, exc_info=e
+            )
+            await self._audit_log(
+                HandlerActionType.OBSERVE,
+                {**dispatch_context, "thought_id": thought_id},
+                outcome="failed_followup",
+            )
+            raise FollowUpCreationError from e

--- a/ciris_engine/action_handlers/speak_handler.py
+++ b/ciris_engine/action_handlers/speak_handler.py
@@ -29,8 +29,10 @@ class SpeakHandler(BaseActionHandler):
     ) -> None:
         params = result.action_parameters
         thought_id = thought.thought_id
-        # channel_id from the original event context, if available
+        # channel_id from the original event context or thought context
         original_event_channel_id = dispatch_context.get("channel_id")
+        if not original_event_channel_id and getattr(thought, "context", None):
+            original_event_channel_id = thought.context.get("channel_id")
 
         final_thought_status = ThoughtStatus.COMPLETED
         action_performed_successfully = False

--- a/tests/ciris_engine/action_handlers/test_remaining_handlers.py
+++ b/tests/ciris_engine/action_handlers/test_remaining_handlers.py
@@ -101,17 +101,16 @@ async def test_recall_handler_schema_driven(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_observe_handler_passive(monkeypatch):
-    handle_event = AsyncMock()
-    monkeypatch.setattr(
-        "ciris_engine.action_handlers.observe_handler.handle_discord_observe_event",
-        handle_event,
-    )
     update_status = MagicMock()
     add_thought = MagicMock()
     monkeypatch.setattr("ciris_engine.persistence.update_thought_status", update_status)
     monkeypatch.setattr("ciris_engine.persistence.add_thought", add_thought)
 
+    mock_observer = AsyncMock()
+    mock_observer.handle_incoming_message = AsyncMock()
+
     deps = ActionHandlerDependencies()
+    deps.get_service = AsyncMock(return_value=mock_observer)
     handler = ObserveHandler(deps)
 
     params = ObserveParams(active=False, context={})
@@ -124,7 +123,7 @@ async def test_observe_handler_passive(monkeypatch):
 
     await handler.handle(action_result, thought, {})
 
-    handle_event.assert_awaited()
+    mock_observer.handle_incoming_message.assert_awaited()
     update_status.assert_called_once()
     add_thought.assert_called_once()
 


### PR DESCRIPTION
## Summary
- add `get_observer_service` helper to `BaseActionHandler`
- extract channel info from thought context in `SpeakHandler`
- rewrite `ObserveHandler` to use registry observer & communication services
- update tests for new observe handler behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a406c21fc832b91eaa18d355b10ec