### PR TITLE
Update CLI observer, tool service, and deferral handling

### DIFF
--- a/ciris_engine/action_handlers/base_handler.py
+++ b/ciris_engine/action_handlers/base_handler.py
@@ -111,6 +111,14 @@ class BaseActionHandler(ABC):
             required_capabilities=["observe_messages"],
         )
 
+    async def get_tool_service(self) -> Optional[Any]:
+        """Get best available tool service"""
+        return await self.dependencies.get_service(
+            self.__class__.__name__,
+            "tool",
+            required_capabilities=["execute_tool"]
+        )
+
 
     @abstractmethod
     async def handle(

--- a/ciris_engine/action_handlers/observe_handler.py
+++ b/ciris_engine/action_handlers/observe_handler.py
@@ -111,6 +111,8 @@ class ObserveHandler(BaseActionHandler):
                 messages = await comm_service.fetch_messages(
                     str(channel_id).lstrip("#"), getattr(params, "limit", 10)
                 )
+                if not messages and observer_service and hasattr(observer_service, "get_recent_messages"):
+                    messages = await observer_service.get_recent_messages(getattr(params, "limit", 10))
                 await self._recall_from_messages(memory_service, channel_id, messages)
                 action_performed = True
                 follow_up_info = f"Fetched {len(messages)} messages from {channel_id}"

--- a/ciris_engine/action_handlers/tool_handler.py
+++ b/ciris_engine/action_handlers/tool_handler.py
@@ -13,9 +13,6 @@ from .base_handler import BaseActionHandler, ActionHandlerDependencies
 from .helpers import create_follow_up_thought
 from .exceptions import FollowUpCreationError
 from ciris_engine.schemas.tool_schemas_v1 import ToolResult, ToolExecutionStatus
-from ciris_engine.adapters import ToolRegistry
-from ciris_engine.adapters.discord.discord_tools import register_discord_tools
-import discord
 import asyncio
 import uuid
 
@@ -23,17 +20,6 @@ logger = logging.getLogger(__name__)
 
 class ToolHandler(BaseActionHandler):
     TOOL_RESULT_TIMEOUT = 30  # seconds
-    _pending_results: Dict[str, asyncio.Future] = {}
-    _tool_registry: ToolRegistry = ToolRegistry()
-
-    @classmethod
-    def set_tool_registry(cls, registry: ToolRegistry):
-        cls._tool_registry = registry
-
-    async def register_tool_result(self, correlation_id: str, result: ToolResult) -> None:
-        fut = self._pending_results.get(correlation_id)
-        if fut and not fut.done():
-            fut.set_result(result)
 
     async def handle(
         self,
@@ -59,48 +45,44 @@ class ToolHandler(BaseActionHandler):
                 follow_up_content_key_info = f"TOOL action failed: Invalid parameters dict for thought {thought_id}. Error: {e}"
                 params = None
 
-        # Tool registry validation
-        if not isinstance(params, ToolParams):  # v1 uses ToolParams
-            self.logger.error(f"TOOL action params are not ToolParams model. Type: {type(params)}. Thought ID: {thought_id}")
+        # Tool service validation and execution
+        tool_service = await self.get_tool_service()
+        if not isinstance(params, ToolParams):
+            self.logger.error(
+                f"TOOL action params are not ToolParams model. Type: {type(params)}. Thought ID: {thought_id}")
             final_thought_status = ThoughtStatus.FAILED
-            follow_up_content_key_info = f"TOOL action failed: Invalid parameters type ({type(params)}) for thought {thought_id}."
-        elif not self.dependencies.action_sink or not hasattr(self.dependencies.action_sink, 'run_tool'):
-            self.logger.error(f"ActionSink or run_tool method not available. Cannot execute TOOL for thought {thought_id}")
+            follow_up_content_key_info = (
+                f"TOOL action failed: Invalid parameters type ({type(params)}) for thought {thought_id}.")
+        elif not tool_service:
+            self.logger.error("No ToolService available")
             final_thought_status = ThoughtStatus.FAILED
-            follow_up_content_key_info = f"TOOL action failed: ActionSink or run_tool unavailable for thought {thought_id}."
-        elif not self._tool_registry.get_tool_schema(params.name):
-            self.logger.error(f"Tool '{params.name}' not found in registry. Thought ID: {thought_id}")
-            final_thought_status = ThoughtStatus.FAILED
-            follow_up_content_key_info = f"TOOL action failed: Tool '{params.name}' not registered."
-        elif not self._tool_registry.validate_arguments(params.name, params.args):
-            self.logger.error(f"Arguments for tool '{params.name}' failed validation. Thought ID: {thought_id}")
+            follow_up_content_key_info = "Tool service unavailable"
+        elif not await tool_service.validate_parameters(params.name, params.args):
+            self.logger.error(
+                f"Arguments for tool '{params.name}' failed validation. Thought ID: {thought_id}")
             final_thought_status = ThoughtStatus.FAILED
             follow_up_content_key_info = f"TOOL action failed: Arguments for tool '{params.name}' invalid."
         else:
             correlation_id = str(uuid.uuid4())
-            fut = asyncio.get_event_loop().create_future()
-            self._pending_results[correlation_id] = fut
             try:
-                # The run_tool method on ActionSink is expected to be async if it involves I/O
-                # v1 ToolParams has 'name' and 'args' fields instead of 'tool_name' and 'arguments'
-                await self.dependencies.action_sink.run_tool(params.name, {**params.args, "correlation_id": correlation_id})
-                try:
-                    tool_result: ToolResult = await asyncio.wait_for(fut, timeout=self.TOOL_RESULT_TIMEOUT)
-                    if tool_result.execution_status == ToolExecutionStatus.SUCCESS:
-                        action_performed_successfully = True
-                        follow_up_content_key_info = f"Tool '{params.name}' executed successfully. Result: {tool_result.result_data}"
-                    else:
-                        final_thought_status = ThoughtStatus.FAILED
-                        follow_up_content_key_info = f"Tool '{params.name}' failed: {tool_result.error_message}"
-                except asyncio.TimeoutError:
+                await tool_service.execute_tool(params.name, {**params.args, "correlation_id": correlation_id})
+                tool_result = await tool_service.get_tool_result(
+                    correlation_id, timeout=self.TOOL_RESULT_TIMEOUT
+                )
+                if tool_result and tool_result.get("error") is None:
+                    action_performed_successfully = True
+                    follow_up_content_key_info = (
+                        f"Tool '{params.name}' executed successfully. Result: {tool_result}"
+                    )
+                else:
                     final_thought_status = ThoughtStatus.FAILED
-                    follow_up_content_key_info = f"TOOL action timed out waiting for result from '{params.name}'."
+                    err = tool_result.get("error") if tool_result else "timeout"
+                    follow_up_content_key_info = f"Tool '{params.name}' failed: {err}"
             except Exception as e_tool:
-                self.logger.exception(f"Error executing TOOL {params.name} for thought {thought_id}: {e_tool}")
+                self.logger.exception(
+                    f"Error executing TOOL {params.name} for thought {thought_id}: {e_tool}")
                 final_thought_status = ThoughtStatus.FAILED
                 follow_up_content_key_info = f"TOOL {params.name} execution failed: {str(e_tool)}"
-            finally:
-                self._pending_results.pop(correlation_id, None)
 
         # v1 uses 'final_action' instead of 'final_action_result'
         result_data = result.model_dump() if hasattr(result, 'model_dump') else result
@@ -140,9 +122,3 @@ class ToolHandler(BaseActionHandler):
             )
             await self._audit_log(HandlerActionType.TOOL, {**dispatch_context, "thought_id": thought_id}, outcome="failed_followup")
             raise FollowUpCreationError from e
-
-# Set up the global ToolRegistry and register Discord tools if not already set
-_tool_registry = ToolRegistry()
-# Discord bot instance will be set at runtime; placeholder for registration
-# register_discord_tools(_tool_registry, bot)
-ToolHandler.set_tool_registry(_tool_registry)

--- a/ciris_engine/adapters/cli/README.md
+++ b/ciris_engine/adapters/cli/README.md
@@ -1,0 +1,5 @@
+# CLI Adapters
+
+This package provides CLI-based services for the agent. It includes a simple
+communication adapter, observation utilities and a minimal `ToolService`
+implementation for browsing the local filesystem.

--- a/ciris_engine/adapters/cli/__init__.py
+++ b/ciris_engine/adapters/cli/__init__.py
@@ -1,2 +1,3 @@
 from .cli_adapter import CLIAdapter
 from .cli_observer import CLIObserver
+from .cli_tools import CLIToolService

--- a/ciris_engine/adapters/cli/cli_runtime.py
+++ b/ciris_engine/adapters/cli/cli_runtime.py
@@ -9,6 +9,7 @@ from ciris_engine.registries.base import Priority
 from .cli_event_queues import CLIEventQueue
 from .cli_adapter import CLIAdapter
 from .cli_observer import CLIObserver
+from .cli_tools import CLIToolService
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,14 @@ class CLIRuntime(CIRISRuntime):
                 priority=Priority.NORMAL,
                 capabilities=["send_message"],
             )
+        tool_service = CLIToolService()
+        self.service_registry.register(
+            handler="ToolHandler",
+            service_type="tool",
+            provider=tool_service,
+            priority=Priority.NORMAL,
+            capabilities=["execute_tool", "get_tool_result"],
+        )
 
     async def _build_action_dispatcher(self, dependencies):
         return build_action_dispatcher(

--- a/ciris_engine/adapters/cli/cli_tools.py
+++ b/ciris_engine/adapters/cli/cli_tools.py
@@ -1,0 +1,42 @@
+import os
+import asyncio
+from typing import Dict, Any, List, Optional
+
+from ciris_engine.protocols.services import ToolService
+
+class CLIToolService(ToolService):
+    """Simple ToolService providing local filesystem browsing."""
+
+    def __init__(self):
+        self._results: Dict[str, Dict[str, Any]] = {}
+
+    async def execute_tool(self, tool_name: str, parameters: Dict[str, Any]) -> Dict[str, Any]:
+        correlation_id = parameters.get("correlation_id")
+        result: Dict[str, Any]
+        if tool_name == "list_files":
+            path = parameters.get("path", ".")
+            try:
+                files = sorted(os.listdir(path))
+                result = {"files": files, "path": path}
+            except Exception as e:
+                result = {"error": str(e)}
+        else:
+            result = {"error": f"unknown tool {tool_name}"}
+        if correlation_id:
+            self._results[correlation_id] = result
+        return result
+
+    async def get_available_tools(self) -> List[str]:
+        return ["list_files"]
+
+    async def get_tool_result(self, correlation_id: str, timeout: float = 30.0) -> Optional[Dict[str, Any]]:
+        for _ in range(int(timeout * 10)):
+            if correlation_id in self._results:
+                return self._results.pop(correlation_id)
+            await asyncio.sleep(0.1)
+        return None
+
+    async def validate_parameters(self, tool_name: str, parameters: Dict[str, Any]) -> bool:
+        if tool_name == "list_files":
+            return True
+        return False

--- a/tests/ciris_engine/action_handlers/test_defer_handler.py
+++ b/tests/ciris_engine/action_handlers/test_defer_handler.py
@@ -10,10 +10,8 @@ from ciris_engine.action_handlers.base_handler import ActionHandlerDependencies
 
 @pytest.mark.asyncio
 async def test_defer_handler_schema_driven(monkeypatch):
-    action_sink = AsyncMock()
     deferral_sink = AsyncMock()
     deps = ActionHandlerDependencies(
-        action_sink=action_sink,
         deferral_sink=deferral_sink,
         memory_service=MagicMock(),
     )
@@ -47,8 +45,8 @@ async def test_defer_handler_schema_driven(monkeypatch):
 
     await handler.handle(action_result, thought, {"channel_id": "chan1", "source_task_id": "s1"})
 
-    action_sink.send_message.assert_awaited_with("chan1", "Action Deferred: Need WA")
     deferral_sink.send_deferral.assert_awaited()
+    assert "deferral_package" in deferral_sink.send_deferral.call_args.args[3]
     update_thought.assert_called_once()
     assert update_thought.call_args.kwargs["status"] == ThoughtStatus.DEFERRED
     update_task.assert_called_once()

--- a/tests/ciris_engine/adapters/cli/test_cli_adapter.py
+++ b/tests/ciris_engine/adapters/cli/test_cli_adapter.py
@@ -25,3 +25,18 @@ async def test_cli_observer_handle_message():
     msg = IncomingMessage(message_id="1", content="hi", author_id="u", author_name="User", channel_id="cli")
     await observer.handle_incoming_message(msg)
     assert observed and observed[0]["content"] == "hi"
+
+@pytest.mark.asyncio
+async def test_cli_observer_get_recent_messages():
+    from ciris_engine.adapters.cli.cli_observer import CLIObserver
+
+    queue = CLIEventQueue()
+    async def noop(_):
+        pass
+    observer = CLIObserver(noop, queue)
+    msg1 = IncomingMessage(message_id="1", content="a", author_id="u", author_name="User", channel_id="cli")
+    msg2 = IncomingMessage(message_id="2", content="b", author_id="u", author_name="User", channel_id="cli")
+    await observer.handle_incoming_message(msg1)
+    await observer.handle_incoming_message(msg2)
+    recent = await observer.get_recent_messages(limit=1)
+    assert recent and recent[0]["id"] == "2"


### PR DESCRIPTION
## Summary
- add history tracking and active fetch to CLIObserver
- expose CLIToolService and register in CLI runtime
- allow action handlers to retrieve tool services
- update ToolHandler to rely on ToolService
- package deferrals with context in DeferHandler
- add CLI observer tests and adjust tool/defer handler tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a42e56260832b8062c6d6214f1efc