### PR TITLE
Update memory and ponder handlers

### DIFF
--- a/tests/ciris_engine/action_handlers/test_followup_thoughts.py
+++ b/tests/ciris_engine/action_handlers/test_followup_thoughts.py
@@ -48,7 +48,7 @@ async def test_recall_handler_creates_followup():
     thought = Thought(thought_id="t2", source_task_id="parent2", content="test content", context={}, status="PENDING", created_at="now", updated_at="now", round_number=1)
     params = RecallParams(query="q", scope="identity")
     result = ActionSelectionResult(selected_action=HandlerActionType.RECALL, action_parameters=params, rationale="r")
-    await handler.handle(result, thought, {})
+    await handler.handle(result, thought, {"wa_authorized": True})
     follow_up = deps.persistence.add_thought.call_args[0][0]
     assert follow_up.parent_thought_id == thought.thought_id
     assert follow_up.context["action_performed"] == "RECALL" or "RECALL" in follow_up.content
@@ -69,7 +69,7 @@ async def test_forget_handler_creates_followup():
     thought = Thought(thought_id="t3", source_task_id="parent3", content="test content", context={}, status="PENDING", created_at="now", updated_at="now", round_number=1)
     params = ForgetParams(key="k", scope="identity", reason="r")
     result = ActionSelectionResult(selected_action=HandlerActionType.FORGET, action_parameters=params, rationale="r")
-    await handler.handle(result, thought, {})
+    await handler.handle(result, thought, {"wa_authorized": True})
     follow_up = deps.persistence.add_thought.call_args[0][0]
     assert follow_up.parent_thought_id == thought.thought_id
     assert follow_up.context["action_performed"] == "FORGET"
@@ -93,7 +93,7 @@ def test_memorize_handler_creates_followup(monkeypatch):
     thought = Thought(thought_id="t4", source_task_id="parent4", content="test content", context={}, status="PENDING", created_at="now", updated_at="now", round_number=1)
     params = MemorizeParams(key="k", value="v", scope="identity")
     result = ActionSelectionResult(selected_action=HandlerActionType.MEMORIZE, action_parameters=params, rationale="r")
-    import asyncio; asyncio.run(handler.handle(result, thought, {}))
+    import asyncio; asyncio.run(handler.handle(result, thought, {"wa_authorized": True}))
     follow_up = add_thought_mock.call_args[0][0]
     assert follow_up.parent_thought_id == thought.thought_id
     # Only require that follow_up.content is a non-empty string

--- a/tests/ciris_engine/action_handlers/test_handler_followup_persistence.py
+++ b/tests/ciris_engine/action_handlers/test_handler_followup_persistence.py
@@ -92,7 +92,7 @@ async def test_handler_creates_followup_persistence(handler_cls, params, result_
                  patch.object(handler_mod.persistence, 'update_thought_status', side_effect=lambda **kwargs: None):
                 handler = handler_cls(deps)
                 result = ActionSelectionResult(selected_action=result_action, action_parameters=params, rationale="r")
-                dispatch_context = {"channel_id": "c1"}
+                dispatch_context = {"channel_id": "c1", "wa_authorized": True}
                 if extra_setup:
                     extra_setup(deps, thought, db_path)
                 await handler.handle(result, thought, dispatch_context)
@@ -102,7 +102,7 @@ async def test_handler_creates_followup_persistence(handler_cls, params, result_
             deps.persistence.update_thought_status = lambda **kwargs: None
             handler = handler_cls(deps)
             result = ActionSelectionResult(selected_action=result_action, action_parameters=params, rationale="r")
-            dispatch_context = {"channel_id": "c1"}
+            dispatch_context = {"channel_id": "c1", "wa_authorized": True}
             if extra_setup:
                 extra_setup(deps, thought, db_path)
             await handler.handle(result, thought, dispatch_context)


### PR DESCRIPTION
## Summary
- enforce WA checks and GraphScope usage for memory handlers
- handle MemoryService results
- enforce config max_ponder_rounds and requeue via action sink
- update tests for new WA requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a45397efc832bac9b4817ddbc95e4