### PR TITLE
Improve handler flows

### DIFF
--- a/ciris_engine/action_handlers/recall_handler.py
+++ b/ciris_engine/action_handlers/recall_handler.py
@@ -58,18 +58,6 @@ class RecallHandler(BaseActionHandler):
             return
 
         scope = GraphScope(params.scope)
-        if scope in (GraphScope.IDENTITY, GraphScope.ENVIRONMENT) and not dispatch_context.get("wa_authorized"):
-            follow_up = create_follow_up_thought(
-                parent=thought,
-                content="RECALL action denied: WA authorization required"
-            )
-            self.dependencies.persistence.add_thought(follow_up)
-            await self._audit_log(
-                HandlerActionType.RECALL,
-                {**dispatch_context, "thought_id": thought_id},
-                outcome="wa_denied",
-            )
-            return
 
         node = GraphNode(
             id=params.query,

--- a/ciris_engine/action_handlers/reject_handler.py
+++ b/ciris_engine/action_handlers/reject_handler.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 # Updated imports for v1 schemas
 from ciris_engine.schemas.agent_core_schemas_v1 import Thought
 from ciris_engine.schemas.action_params_v1 import RejectParams
-from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus, HandlerActionType
+from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus, TaskStatus, HandlerActionType
 from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
 from ciris_engine import persistence
 from .base_handler import BaseActionHandler, ActionHandlerDependencies
@@ -25,6 +25,7 @@ class RejectHandler(BaseActionHandler):
     ) -> None:
         params = result.action_parameters
         thought_id = thought.thought_id
+        parent_task_id = thought.source_task_id
         await self._audit_log(HandlerActionType.REJECT, {**dispatch_context, "thought_id": thought_id}, outcome="start")
         original_event_channel_id = dispatch_context.get("channel_id")
 
@@ -43,9 +44,15 @@ class RejectHandler(BaseActionHandler):
                         parent=thought,
                         content=follow_up_text,
                     )
-                    context_for_follow_up = {"action_performed": HandlerActionType.REJECT.value}
-                    context_for_follow_up["error_details"] = follow_up_content_key_info
-                    action_params_dump = params if params is None else (params.model_dump(mode="json") if hasattr(params, "model_dump") else params)
+                    context_for_follow_up = {
+                        "action_performed": HandlerActionType.REJECT.value,
+                        "parent_task_id": parent_task_id,
+                        "is_follow_up": True,
+                        "error_details": follow_up_content_key_info,
+                    }
+                    action_params_dump = params if params is None else (
+                        params.model_dump(mode="json") if hasattr(params, "model_dump") else params
+                    )
                     context_for_follow_up["action_params"] = action_params_dump
                     new_follow_up.context = context_for_follow_up
                     persistence.add_thought(new_follow_up)
@@ -79,12 +86,18 @@ class RejectHandler(BaseActionHandler):
         else:
             follow_up_content_key_info = f"Rejected thought {thought_id}. Reason: {params.reason}"
             # Optionally, send a message to the original channel
-            if self.dependencies.action_sink and original_event_channel_id and params.reason:
-                try:
-                    await self.dependencies.action_sink.send_message(original_event_channel_id, f"Unable to proceed: {params.reason}")
-                    # Not marking action_performed_successfully = True, as REJECT is a failure state.
-                except Exception as e:
-                    self.logger.error(f"Failed to send REJECT notification to channel {original_event_channel_id} for thought {thought_id}: {e}")
+            if original_event_channel_id and params.reason:
+                comm_service = await self.get_communication_service()
+                if comm_service:
+                    try:
+                        await comm_service.send_message(original_event_channel_id, f"Unable to proceed: {params.reason}")
+                    except Exception as e:
+                        self.logger.error(f"Failed to send REJECT notification via communication service for thought {thought_id}: {e}")
+                elif self.dependencies.action_sink:
+                    try:
+                        await self.dependencies.action_sink.send_message(original_event_channel_id, f"Unable to proceed: {params.reason}")
+                    except Exception as e:
+                        self.logger.error(f"Failed to send REJECT notification to channel {original_event_channel_id} for thought {thought_id}: {e}")
         # v1 uses 'final_action' instead of 'final_action_result'
         result_data = result.model_dump() if hasattr(result, 'model_dump') else result
         persistence.update_thought_status(
@@ -92,6 +105,8 @@ class RejectHandler(BaseActionHandler):
             status=final_thought_status,  # FAILED
             final_action=result_data,  # v1 field
         )
+        if parent_task_id:
+            persistence.update_task_status(parent_task_id, TaskStatus.FAILED)
         self.logger.info(f"Updated original thought {thought_id} to status {final_thought_status.value} for REJECT action. Info: {follow_up_content_key_info}")
 
         # Create a follow-up thought indicating failure and reason
@@ -103,8 +118,12 @@ class RejectHandler(BaseActionHandler):
             )
 
             # v1 uses 'context' instead of 'processing_context'
-            context_for_follow_up = {"action_performed": HandlerActionType.REJECT.value}
-            context_for_follow_up["error_details"] = follow_up_content_key_info
+            context_for_follow_up = {
+                "action_performed": HandlerActionType.REJECT.value,
+                "parent_task_id": parent_task_id,
+                "is_follow_up": True,
+                "error_details": follow_up_content_key_info,
+            }
 
             # When serializing for follow-up, convert to dict
             action_params_dump = params.model_dump(mode="json") if hasattr(params, "model_dump") else params

--- a/ciris_engine/action_handlers/task_complete_handler.py
+++ b/ciris_engine/action_handlers/task_complete_handler.py
@@ -60,21 +60,33 @@ class TaskCompleteHandler(BaseActionHandler):
                     self.logger.info(f"Marked parent task {parent_task_id} as COMPLETED due to TASK_COMPLETE action on thought {thought_id}.")
                     print(f"[TASK_COMPLETE_HANDLER] ✓ Task {parent_task_id} marked as COMPLETED")
                     
-                    # Optionally, send a notification if an action_sink is available
-                    if self.dependencies.action_sink:
-                        original_event_channel_id = dispatch_context.get("channel_id")
-                        if original_event_channel_id:
+                    # Optionally, send a notification if communication service is available
+                    original_event_channel_id = dispatch_context.get("channel_id")
+                    if original_event_channel_id:
+                        parent_task_obj = persistence.get_task_by_id(parent_task_id)
+                        task_desc = parent_task_obj.description if parent_task_obj else "Unknown task"
+                        message = f"Task '{task_desc[:50]}...' (ID: {parent_task_id}) has been marked as complete by the agent."
+                        comm_service = await self.get_communication_service()
+                        if comm_service:
                             try:
-                                parent_task_obj = persistence.get_task_by_id(parent_task_id)
-                                task_desc = parent_task_obj.description if parent_task_obj else "Unknown task"
-                                await self.dependencies.action_sink.send_message(
-                                    original_event_channel_id,
-                                    f"Task '{task_desc[:50]}...' (ID: {parent_task_id}) has been marked as complete by the agent."
-                                )
+                                await comm_service.send_message(original_event_channel_id, message)
+                                print(f"[TASK_COMPLETE_HANDLER] ✓ Notification sent for completed task {parent_task_id}")
+                            except Exception as e:
+                                self.logger.error(f"Failed to send TASK_COMPLETE notification via communication service for task {parent_task_id}: {e}")
+                        elif self.dependencies.action_sink:
+                            try:
+                                await self.dependencies.action_sink.send_message(original_event_channel_id, message)
                                 print(f"[TASK_COMPLETE_HANDLER] ✓ Notification sent for completed task {parent_task_id}")
                             except Exception as e:
                                 self.logger.error(f"Failed to send TASK_COMPLETE notification for task {parent_task_id}: {e}")
                                 print(f"[TASK_COMPLETE_HANDLER] ✗ Failed to send notification: {e}")
+
+                    # Clean up any pending thoughts/resources for this task
+                    pending = persistence.get_thoughts_by_task_id(parent_task_id)
+                    to_delete = [t.thought_id for t in pending if getattr(t, 'status', None) in {ThoughtStatus.PENDING, ThoughtStatus.PROCESSING}]
+                    if to_delete:
+                        persistence.delete_thoughts_by_ids(to_delete)
+                        self.logger.debug(f"Cleaned up {len(to_delete)} pending thoughts for task {parent_task_id}")
                 else: # This else corresponds to "if task_updated:"
                     self.logger.error(f"Failed to update status for parent task {parent_task_id} to COMPLETED.")
                     print(f"[TASK_COMPLETE_HANDLER] ✗ Failed to update task {parent_task_id} status")


### PR DESCRIPTION
## Summary
- remove WA requirement for identity/environment recall
- send reject notifications via communication service and mark task failed
- notify on task completion using communication service and clean up pending thoughts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a47e68e50832ba38124f8eef36ef6