### PR TITLE
Integrate covenant preamble and remove legacy hooks

### DIFF
--- a/ciris_engine/adapters/discord/discord_deferral_sink.py
+++ b/ciris_engine/adapters/discord/discord_deferral_sink.py
@@ -1,4 +1,0 @@
-# This file is deprecated. Use ciris_engine.sinks.deferral_sink.MultiServiceDeferralSink instead.
-# If you need Discord-specific deferral logic, implement it as a utility or adapter, not as a sink.
-
-# from ciris_engine.sinks.deferral_sink import MultiServiceDeferralSink

--- a/ciris_engine/dma/action_selection_pdma.py
+++ b/ciris_engine/dma/action_selection_pdma.py
@@ -29,6 +29,7 @@ from ciris_engine.schemas.config_schemas_v1 import DEFAULT_OPENAI_MODEL_NAME
 from ciris_engine.registries.base import ServiceRegistry
 from instructor.exceptions import InstructorRetryException
 from ciris_engine.utils import DEFAULT_WA, ENGINE_OVERVIEW_TEMPLATE
+from ciris_engine.utils import COVENANT_TEXT
 from ciris_engine.formatters import (
     format_system_snapshot,
     format_user_profiles,
@@ -485,6 +486,7 @@ Adhere strictly to the schema for your JSON output.
         )
 
         messages = [
+            {"role": "system", "content": COVENANT_TEXT},
             {"role": "system", "content": system_message},
             {"role": "user", "content": main_user_content},
         ]

--- a/ciris_engine/dma/csdma.py
+++ b/ciris_engine/dma/csdma.py
@@ -15,6 +15,7 @@ from ciris_engine.formatters import (
     format_user_prompt_blocks,
 )
 from instructor.exceptions import InstructorRetryException
+from ciris_engine.utils import COVENANT_TEXT
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +104,7 @@ class CSDMAEvaluator:
         )
 
         return [
+            {"role": "system", "content": COVENANT_TEXT},
             {"role": "system", "content": system_message},
             {"role": "user", "content": user_message},
         ]

--- a/ciris_engine/dma/dsdma_base.py
+++ b/ciris_engine/dma/dsdma_base.py
@@ -9,11 +9,12 @@ from ciris_engine.processor.processing_queue import ProcessingQueueItem
 from ciris_engine.schemas.dma_results_v1 import DSDMAResult
 from ciris_engine.registries.base import ServiceRegistry
 from ciris_engine.formatters import (
-    format_user_profiles, 
+    format_user_profiles,
     format_system_snapshot,
     format_system_prompt_blocks,
     get_escalation_guidance
 )
+from ciris_engine.utils import COVENANT_TEXT
 from pydantic import BaseModel, Field
 from instructor.exceptions import InstructorRetryException
 from ciris_engine.config.config_manager import get_config # To access global config
@@ -166,6 +167,7 @@ class BaseDSDMA(ABC):
         logger.debug(f"DSDMA '{self.domain_name}' input to LLM for thought {thought_item.thought_id}:\nSystem: {system_message_content}\nUser: {user_message_content}")
 
         messages = [
+            {"role": "system", "content": COVENANT_TEXT},
             {"role": "system", "content": system_message_content},
             {"role": "user", "content": user_message_content}
         ]

--- a/ciris_engine/dma/pdma.py
+++ b/ciris_engine/dma/pdma.py
@@ -7,6 +7,7 @@ from ciris_engine.processor.processing_queue import ProcessingQueueItem
 from ciris_engine.registries.base import ServiceRegistry
 from ciris_engine.schemas.dma_results_v1 import EthicalDMAResult
 from ciris_engine.formatters import format_user_profiles, format_system_snapshot
+from ciris_engine.utils import COVENANT_TEXT
 DEFAULT_OPENAI_MODEL_NAME = "gpt-4o"
 
 logger = logging.getLogger(__name__)
@@ -91,6 +92,7 @@ Do not include extra fields or PDMA step names.""",
                 model=self.model_name,
                 response_model=EthicalDMAResult,
                 messages=[
+                    {"role": "system", "content": COVENANT_TEXT},
                     {"role": "system", "content": self.prompt_template["system_guidance_header"]},
                     {"role": "user", "content": user_message_with_context}
                 ],

--- a/ciris_engine/processor/work_processor.py
+++ b/ciris_engine/processor/work_processor.py
@@ -188,8 +188,6 @@ class WorkProcessor(BaseProcessor):
             # Add specific service references for convenience
             if "discord_service" in self.services:
                 dispatch_context["discord_service"] = self.services["discord_service"]
-            if "discord_client" in self.services:
-                dispatch_context["discord_service"] = self.services["discord_client"]  # Alternative key
         
         # Add discord_service directly if available
         if hasattr(self, 'discord_service'):

--- a/ciris_engine/runtime/discord_runtime.py
+++ b/ciris_engine/runtime/discord_runtime.py
@@ -100,7 +100,6 @@ class DiscordRuntime(CIRISRuntime):
         if self.agent_processor:
             # Update the main services dict
             self.agent_processor.services["discord_service"] = self.client
-            self.agent_processor.services["discord_client"] = self.client  # Alternative key
             
             # Set discord_service on all processors for context passing
             processors = [
@@ -184,18 +183,7 @@ class DiscordRuntime(CIRISRuntime):
                 }
             )
             
-            # Register Discord client as a raw Discord service (for legacy compatibility)
-            if self.client:
-                await self.service_registry.register(
-                    service_instance=self.client,
-                    service_type='discord_client',
-                    priority=1,
-                    capabilities=['raw_discord_access'],
-                    metadata={
-                        'type': 'discord.Client',
-                        'ready': not self.client.is_closed() if hasattr(self.client, 'is_closed') else True
-                    }
-                )
+
             
             # Register Discord observer if it exists
             if self.discord_observer:

--- a/ciris_engine/utils/__init__.py
+++ b/ciris_engine/utils/__init__.py
@@ -2,7 +2,7 @@
 import logging
 
 logger = logging.getLogger(__name__)
-from .constants import DEFAULT_WA, ENGINE_OVERVIEW_TEMPLATE  # noqa:F401
+from .constants import DEFAULT_WA, ENGINE_OVERVIEW_TEMPLATE, COVENANT_TEXT  # noqa:F401
 from .graphql_context_provider import GraphQLContextProvider, GraphQLClient  # noqa:F401
 from .user_utils import extract_user_nick  # noqa:F401
 

--- a/ciris_engine/utils/constants.py
+++ b/ciris_engine/utils/constants.py
@@ -1,10 +1,20 @@
 import os
 import logging
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_WA = os.getenv("WA_DISCORD_USER", "somecomputerguy")
 WA_USER_ID = os.getenv("WA_USER_ID")
+
+# Load the CIRIS Covenant text for inclusion in prompts
+_COVENANT_PATH = Path(__file__).resolve().parents[2] / "covenant_1.0b.txt"
+try:
+    with open(_COVENANT_PATH, "r", encoding="utf-8") as f:
+        COVENANT_TEXT = f.read()
+except Exception as exc:  # noqa: BLE001
+    logger.warning("Could not load covenant text from %s: %s", _COVENANT_PATH, exc)
+    COVENANT_TEXT = ""
 
 # Flag indicating that a memory meta-thought should be generated for the
 # originating context. It is toggled by the ActionDispatcher when


### PR DESCRIPTION
## Summary
- load covenant text as a constant
- prepend covenant text to all DMA prompts
- drop deprecated discord_deferral_sink
- remove direct `discord_client` service usage
- simplify SpeakHandler and enforce schema parameters
- update tests for ServiceRegistry communication

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a4a270ef8832b85b872440390f65f