### PR TITLE
Implement DRY utilities and unify handler errors

### DIFF
--- a/ciris_engine/action_handlers/reject_handler.py
+++ b/ciris_engine/action_handlers/reject_handler.py
@@ -29,52 +29,38 @@ class RejectHandler(BaseActionHandler):
         await self._audit_log(HandlerActionType.REJECT, {**dispatch_context, "thought_id": thought_id}, outcome="start")
         original_event_channel_id = dispatch_context.get("channel_id")
 
-        # Always use schema internally
-        if isinstance(params, dict):
+        try:
+            params = await self._validate_and_convert_params(params, RejectParams)
+        except Exception as e:
+            await self._handle_error(HandlerActionType.REJECT, dispatch_context, thought_id, e)
+            follow_up_content_key_info = f"REJECT action failed: {e}"
+            final_thought_status = ThoughtStatus.FAILED
+            follow_up_text = f"REJECT action failed for thought {thought_id}. Reason: {follow_up_content_key_info}. This path of reasoning is terminated. Review and determine if a new approach or task is needed."
             try:
-                params = RejectParams(**params)
-            except Exception as e:
-                self.logger.error(f"REJECT action params dict could not be parsed: {e}. Thought ID: {thought_id}")
-                follow_up_content_key_info = f"REJECT action failed: Invalid parameters dict for thought {thought_id}. Error: {e}"
-                final_thought_status = ThoughtStatus.FAILED
-                # Always create a follow-up thought on error
-                follow_up_text = f"REJECT action failed for thought {thought_id}. Reason: {follow_up_content_key_info}. This path of reasoning is terminated. Review and determine if a new approach or task is needed."
-                try:
-                    new_follow_up = create_follow_up_thought(
-                        parent=thought,
-                        content=follow_up_text,
-                    )
-                    context_for_follow_up = {
-                        "action_performed": HandlerActionType.REJECT.value,
-                        "parent_task_id": parent_task_id,
-                        "is_follow_up": True,
-                        "error_details": follow_up_content_key_info,
-                    }
-                    action_params_dump = params if params is None else (
-                        params.model_dump(mode="json") if hasattr(params, "model_dump") else params
-                    )
-                    context_for_follow_up["action_params"] = action_params_dump
-                    new_follow_up.context = context_for_follow_up
-                    persistence.add_thought(new_follow_up)
-                    self.logger.info(
-                        f"Created follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after REJECT action."
-                    )
-                    await self._audit_log(HandlerActionType.REJECT, {**dispatch_context, "thought_id": thought_id}, outcome="failed")
-                except Exception as e:
-                    self.logger.critical(
-                        f"Failed to create follow-up thought for {thought_id}: {e}",
-                        exc_info=e,
-                    )
-                    await self._audit_log(HandlerActionType.REJECT, {**dispatch_context, "thought_id": thought_id}, outcome="failed_followup")
-                    raise FollowUpCreationError from e
-                # Also update thought status
-                result_data = result.model_dump() if hasattr(result, 'model_dump') else result
-                persistence.update_thought_status(
-                    thought_id=thought_id,
-                    status=final_thought_status,  # FAILED
-                    final_action=result_data,  # v1 field
+                new_follow_up = create_follow_up_thought(
+                    parent=thought,
+                    content=follow_up_text,
                 )
-                return
+                context_for_follow_up = {
+                    "action_performed": HandlerActionType.REJECT.value,
+                    "parent_task_id": parent_task_id,
+                    "is_follow_up": True,
+                    "error_details": follow_up_content_key_info,
+                }
+                context_for_follow_up["action_params"] = params if isinstance(params, dict) else str(params)
+                new_follow_up.context = context_for_follow_up
+                persistence.add_thought(new_follow_up)
+                await self._audit_log(HandlerActionType.REJECT, {**dispatch_context, "thought_id": thought_id}, outcome="failed")
+            except Exception as e2:
+                await self._handle_error(HandlerActionType.REJECT, dispatch_context, thought_id, e2)
+                raise FollowUpCreationError from e2
+            result_data = result.model_dump() if hasattr(result, 'model_dump') else result
+            persistence.update_thought_status(
+                thought_id=thought_id,
+                status=final_thought_status,
+                final_action=result_data,
+            )
+            return
         # REJECT actions usually mean the thought processing has failed for a stated reason.
         final_thought_status = ThoughtStatus.FAILED 
         action_performed_successfully = False  # The agent couldn't proceed.
@@ -137,9 +123,5 @@ class RejectHandler(BaseActionHandler):
             )
             await self._audit_log(HandlerActionType.REJECT, {**dispatch_context, "thought_id": thought_id}, outcome="success")
         except Exception as e:
-            self.logger.critical(
-                f"Failed to create follow-up thought for {thought_id}: {e}",
-                exc_info=e,
-            )
-            await self._audit_log(HandlerActionType.REJECT, {**dispatch_context, "thought_id": thought_id}, outcome="failed_followup")
+            await self._handle_error(HandlerActionType.REJECT, dispatch_context, thought_id, e)
             raise FollowUpCreationError from e

--- a/ciris_engine/action_handlers/speak_handler.py
+++ b/ciris_engine/action_handlers/speak_handler.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, Any
 
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 # Updated imports for v1 schemas
 from ciris_engine.schemas.agent_core_schemas_v1 import Thought
@@ -27,181 +27,86 @@ class SpeakHandler(BaseActionHandler):
         thought: Thought,
         dispatch_context: Dict[str, Any]
     ) -> None:
-        params = result.action_parameters
         thought_id = thought.thought_id
-        # channel_id from the original event context or thought context
-        original_event_channel_id = dispatch_context.get("channel_id")
-        if not original_event_channel_id and getattr(thought, "context", None):
-            original_event_channel_id = thought.context.get("channel_id")
 
-        final_thought_status = ThoughtStatus.COMPLETED
-        action_performed_successfully = False
-        follow_up_content_key_info = f"Failed SPEAK for thought {thought_id}"  # Default for errors
-
-        speak_content: str = None
-        channel_id_from_params: str = None
-
-        # Ensure params is a SpeakParams instance
-        if isinstance(params, dict):
+        try:
+            params = await self._validate_and_convert_params(result.action_parameters, SpeakParams)
+        except Exception as e:
+            await self._handle_error(HandlerActionType.SPEAK, dispatch_context, thought_id, e)
+            result_data = result.model_dump(mode="json") if hasattr(result, "model_dump") else result
+            persistence.update_thought_status(
+                thought_id=thought_id,
+                status=ThoughtStatus.FAILED,
+                final_action=result_data,
+            )
+            follow_up_text = f"SPEAK action failed for thought {thought_id}. Reason: {e}"
             try:
-                params = SpeakParams(**params)
-            except ValidationError as ve:
-                self.logger.error(
-                    f"Invalid SpeakParams provided for thought {thought_id}: {ve}"
-                )
-                final_thought_status = ThoughtStatus.FAILED
-                follow_up_content_key_info = f"SPEAK action failed: {ve}"
-                params = None
-            else:
-                result.action_parameters = params
-        if isinstance(params, SpeakParams) and not params.channel_id:
-            params.channel_id = original_event_channel_id
-        # --- Ensure event_summary is set for audit log ---
-        event_summary = None
-        if isinstance(params, SpeakParams):
-            event_summary = params.content
-        elif isinstance(params, dict):
-            event_summary = params.get("content")
+                fu = create_follow_up_thought(parent=thought, content=follow_up_text)
+                fu.context = {
+                    "action_performed": HandlerActionType.SPEAK.value,
+                    "error_details": str(e),
+                    "action_params": result_data.get("action_parameters") if isinstance(result_data, dict) else str(result_data),
+                }
+                persistence.add_thought(fu)
+            except Exception as fe:
+                await self._handle_error(HandlerActionType.SPEAK, dispatch_context, thought_id, fe)
+                raise FollowUpCreationError from fe
+            return
 
+        if not params.channel_id:
+            params.channel_id = await self._get_channel_id(thought, dispatch_context) or self.snore_channel_id
+
+        event_summary = params.content
         await self._audit_log(
             HandlerActionType.SPEAK,
             {**dispatch_context, "thought_id": thought_id, "event_summary": event_summary},
-            outcome="start"
+            outcome="start",
         )
 
-        if isinstance(params, SpeakParams):
-            speak_content = params.content
-            channel_id_from_params = params.channel_id
-        else:
-            self.logger.error(
-                f"SPEAK action parameters must be SpeakParams. Got {type(params)} for thought {thought_id}"
-            )
-            final_thought_status = ThoughtStatus.FAILED
-            follow_up_content_key_info = f"SPEAK action failed: Invalid parameters type ({type(params)}) for thought {thought_id}."
-            # No action_performed_successfully update here, it's already False
+        success = await self._send_notification(params.channel_id, params.content)
 
-        if final_thought_status != ThoughtStatus.FAILED:
-            final_channel_id_to_speak = channel_id_from_params or original_event_channel_id
-            
-            if not final_channel_id_to_speak and self.snore_channel_id:
-                self.logger.info(f"No channel_id in params or event_channel_id. Using SNORE_CHANNEL_ID: {self.snore_channel_id}. Thought ID: {thought_id}")
-                final_channel_id_to_speak = self.snore_channel_id
+        final_thought_status = ThoughtStatus.COMPLETED if success else ThoughtStatus.FAILED
+        follow_up_content_key_info = (
+            f"Spoke: '{params.content[:50]}...' in channel #{params.channel_id}"
+            if success
+            else f"Failed to send message to {params.channel_id}"
+        )
 
-            if speak_content and final_channel_id_to_speak:
-                # New way with automatic fallback via service registry
-                comm_service = await self.get_communication_service()
-                if comm_service:
-                    try:
-                        numeric_channel_id_str = str(final_channel_id_to_speak).lstrip('#')
-                        success = await comm_service.send_message(numeric_channel_id_str, speak_content)
-                        if success:
-                            action_performed_successfully = True
-                            follow_up_content_key_info = f"Spoke: '{str(speak_content)[:50]}...' in channel #{numeric_channel_id_str}"
-                            logger.info(f"Message sent via service registry to channel {numeric_channel_id_str}")
-                        else:
-                            logger.warning(
-                                f"Communication service failed to send message to channel {numeric_channel_id_str}"
-                            )
-                            final_thought_status = ThoughtStatus.FAILED
-                            follow_up_content_key_info = (
-                                f"Communication service failed for channel {final_channel_id_to_speak}"
-                            )
-                    except Exception as send_ex:
-                        logger.exception(
-                            f"Error with communication service for thought {thought_id}: {send_ex}"
-                        )
-                        final_thought_status = ThoughtStatus.FAILED
-                        follow_up_content_key_info = f"SPEAK action failed: {send_ex}"
-                else:
-                    logger.error(
-                        f"No communication services available. Cannot send SPEAK message for thought {thought_id}"
-                    )
-                    final_thought_status = ThoughtStatus.FAILED
-                    follow_up_content_key_info = (
-                        f"SPEAK action failed: No communication service for thought {thought_id}"
-                    )
-            else:
-                err_msg = "SPEAK action failed: "
-                if not speak_content: err_msg += "Missing content. "
-                if not final_channel_id_to_speak: err_msg += "Missing channel."
-                self.logger.error(f"{err_msg} Thought ID: {thought_id}")
-                final_thought_status = ThoughtStatus.FAILED
-                follow_up_content_key_info = err_msg.strip()
-
-        # Update original thought status
-        # v1 uses 'status' instead of 'new_status'
-        # Ensure final_action is always a dict for persistence (avoid Pydantic serialization warning)
-        final_action_dump = {}
-        if hasattr(result, 'model_dump'):
-            final_action_dump = result.model_dump(mode="json")
-        elif isinstance(result, dict):
-            final_action_dump = result
-        else:
-            final_action_dump = {"result": str(result)}
-            
+        result_data = result.model_dump(mode="json") if hasattr(result, "model_dump") else result
         persistence.update_thought_status(
             thought_id=thought_id,
             status=final_thought_status,
-            final_action=final_action_dump,  # v1 field
+            final_action=result_data,
         )
-        logger.info(f"[SPEAK_HANDLER] Updated thought {thought_id} to status {final_thought_status.value} after SPEAK attempt.")
-        print(f"[SPEAK_HANDLER] Updated thought {thought_id} to status {final_thought_status.value} after SPEAK attempt.")
 
-        # Create follow-up thought
-        follow_up_text = ""
-        if action_performed_successfully:
-            follow_up_text = f"Successfully spoke: '{speak_content[:70]}...'. The original user request may now be addressed. Consider if any further memory operations or actions are needed. If the task is complete, the next action should be TASK_COMPLETE."
-        else:  # Failed
-            follow_up_text = f"SPEAK action failed for thought {thought_id}. Reason: {follow_up_content_key_info}. Review and determine next steps."
+        follow_up_text = (
+            f"Successfully spoke: '{params.content[:70]}...'"
+            if success
+            else f"SPEAK action failed for thought {thought_id}. Reason: {follow_up_content_key_info}."
+        )
 
         try:
-            new_follow_up = create_follow_up_thought(
-                parent=thought,
-                content=follow_up_text,
-            )
-            
-            # v1 uses 'context' instead of 'processing_context'
-            context_for_follow_up = {"action_performed": HandlerActionType.SPEAK.value}
-            if final_thought_status == ThoughtStatus.FAILED:
-                context_for_follow_up["error_details"] = follow_up_content_key_info
-
-            action_params_dump = result.action_parameters
-            if hasattr(action_params_dump, 'model_dump'):
-                action_params_dump = action_params_dump.model_dump(mode="json")
-            elif not isinstance(action_params_dump, (dict, list, str, int, float, bool, type(None))):
-                action_params_dump = str(action_params_dump)
-            context_for_follow_up["action_params"] = action_params_dump
-
-            new_follow_up.context = context_for_follow_up  # v1 uses 'context'
+            new_follow_up = create_follow_up_thought(parent=thought, content=follow_up_text)
+            ctx = {
+                "action_performed": HandlerActionType.SPEAK.value,
+                "action_params": params.model_dump(mode="json"),
+            }
+            if not success:
+                ctx["error_details"] = follow_up_content_key_info
+            new_follow_up.context = ctx
             persistence.add_thought(new_follow_up)
-            
-            # Follow-up thoughts are automatically picked up by the main processing loop
-            # as PENDING thoughts, so no manual queueing is needed
-            
-            self.logger.info(
-                f"Created follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after SPEAK action."
-            )
-            print(f"[SPEAK_HANDLER] Created follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after SPEAK action.")
             await self._audit_log(
                 HandlerActionType.SPEAK,
                 {**dispatch_context, "thought_id": thought_id, "event_summary": event_summary},
-                outcome="success" if action_performed_successfully else "failed"
+                outcome="success" if success else "failed",
             )
         except Exception as e:
-            self.logger.critical(
-                f"Failed to create follow-up thought for {thought_id}: {e}",
-                exc_info=e,
-            )
-            await self._audit_log(
-                HandlerActionType.SPEAK,
-                {**dispatch_context, "thought_id": thought_id, "event_summary": event_summary},
-                outcome="failed_followup"
-            )
+            await self._handle_error(HandlerActionType.SPEAK, dispatch_context, thought_id, e)
             raise FollowUpCreationError from e
 
-        # Ensure channel_id is set in the thought context for downstream consumers (e.g., guardrails)
         if hasattr(thought, "context"):
             if not thought.context:
                 thought.context = {}
-            if "channel_id" not in thought.context or not thought.context["channel_id"]:
-                thought.context["channel_id"] = channel_id_from_params or original_event_channel_id or self.snore_channel_id
+            if not thought.context.get("channel_id"):
+                thought.context["channel_id"] = params.channel_id
+

--- a/ciris_engine/action_handlers/task_complete_handler.py
+++ b/ciris_engine/action_handlers/task_complete_handler.py
@@ -72,14 +72,13 @@ class TaskCompleteHandler(BaseActionHandler):
                                 await comm_service.send_message(original_event_channel_id, message)
                                 print(f"[TASK_COMPLETE_HANDLER] ✓ Notification sent for completed task {parent_task_id}")
                             except Exception as e:
-                                self.logger.error(f"Failed to send TASK_COMPLETE notification via communication service for task {parent_task_id}: {e}")
+                                await self._handle_error(HandlerActionType.TASK_COMPLETE, dispatch_context, thought_id, e)
                         elif self.dependencies.action_sink:
                             try:
                                 await self.dependencies.action_sink.send_message(original_event_channel_id, message)
                                 print(f"[TASK_COMPLETE_HANDLER] ✓ Notification sent for completed task {parent_task_id}")
                             except Exception as e:
-                                self.logger.error(f"Failed to send TASK_COMPLETE notification for task {parent_task_id}: {e}")
-                                print(f"[TASK_COMPLETE_HANDLER] ✗ Failed to send notification: {e}")
+                                await self._handle_error(HandlerActionType.TASK_COMPLETE, dispatch_context, thought_id, e)
 
                     # Clean up any pending thoughts/resources for this task
                     pending = persistence.get_thoughts_by_task_id(parent_task_id)


### PR DESCRIPTION
## Summary
- centralize channel lookup, notifications and parameter validation in BaseActionHandler
- use new helper methods in SpeakHandler
- update Memorize, Recall, Reject, Tool and TaskComplete handlers to use `_handle_error`
- preserve old MEMORIZE schema fallback
- ensure tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a4fd4a608832b9abbe07fb421d528