### PR TITLE
Refactor guardrails architecture

### DIFF
--- a/ciris_engine/dma/__init__.py
+++ b/ciris_engine/dma/__init__.py
@@ -3,4 +3,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-__all__: list[str] = []
+from .base_dma import BaseDMA
+
+__all__: list[str] = ["BaseDMA"]

--- a/ciris_engine/dma/action_selection_pdma.py
+++ b/ciris_engine/dma/action_selection_pdma.py
@@ -27,6 +27,7 @@ from ciris_engine.schemas.action_params_v1 import ToolParams
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, CIRISSchemaVersion
 from ciris_engine.schemas.config_schemas_v1 import DEFAULT_OPENAI_MODEL_NAME
 from ciris_engine.registries.base import ServiceRegistry
+from .base_dma import BaseDMA
 from instructor.exceptions import InstructorRetryException
 from ciris_engine.utils import DEFAULT_WA, ENGINE_OVERVIEW_TEMPLATE
 from ciris_engine.utils import COVENANT_TEXT
@@ -45,7 +46,7 @@ DEFAULT_TEMPLATE = """{system_header}
 
 {closing_reminder}"""
 
-class ActionSelectionPDMAEvaluator:
+class ActionSelectionPDMAEvaluator(BaseDMA):
     """
     The second PDMA in the sequence. It takes the original thought and the outputs
     of the Ethical PDMA, CSDMA, and DSDMA, then performs a PDMA process
@@ -190,11 +191,13 @@ class ActionSelectionPDMAEvaluator:
             prompt_overrides: Optional prompt overrides dict.
             instructor_mode: instructor.Mode (must be passed as keyword argument).
         """
-        self.service_registry = service_registry
-        self.model_name = model_name
-        self.max_retries = max_retries  # Store max_retries
+        super().__init__(
+            service_registry=service_registry,
+            model_name=model_name,
+            max_retries=max_retries,
+            instructor_mode=instructor_mode,
+        )
         self.prompt = {**self.DEFAULT_PROMPT, **(prompt_overrides or {})}
-        self.instructor_mode = instructor_mode  # Store for reference if needed
 
     def _get_profile_specific_prompt(self, base_key: str, agent_profile_name: Optional[str]) -> str:
         if agent_profile_name:
@@ -423,12 +426,7 @@ Adhere strictly to the schema for your JSON output.
         original_thought: Thought = triaged_inputs['original_thought'] # For logging & post-processing
         processing_context_data = triaged_inputs.get('processing_context') # Define this at the start of the method
 
-        llm_service = None
-        if self.service_registry:
-            llm_service = await self.service_registry.get_service(
-                handler=self.__class__.__name__,
-                service_type="llm"
-            )
+        llm_service = await self.get_llm_service()
         if not llm_service:
             raise RuntimeError("LLM service unavailable for ActionSelectionPDMA")
 

--- a/ciris_engine/dma/base_dma.py
+++ b/ciris_engine/dma/base_dma.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import instructor
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from pydantic import BaseModel
+
+from ciris_engine.registries.base import ServiceRegistry
+from ciris_engine.protocols.services import LLMService
+
+
+class BaseDMA(ABC):
+    """Abstract base class for Decision Making Algorithms."""
+
+    def __init__(
+        self,
+        service_registry: ServiceRegistry,
+        model_name: Optional[str] = None,
+        max_retries: int = 3,
+        *,
+        instructor_mode: instructor.Mode = instructor.Mode.JSON,
+    ) -> None:
+        self.service_registry = service_registry
+        self.model_name = model_name
+        self.max_retries = max_retries
+        self.instructor_mode = instructor_mode
+
+    async def get_llm_service(self) -> LLMService:
+        """Return the LLM service for this DMA from the service registry."""
+        return await self.service_registry.get_service(
+            handler=self.__class__.__name__,
+            service_type="llm",
+        )
+
+    @abstractmethod
+    async def evaluate(self, *args, **kwargs) -> BaseModel:
+        """Execute DMA evaluation and return a pydantic model."""
+        raise NotImplementedError

--- a/ciris_engine/guardrails/__init__.py
+++ b/ciris_engine/guardrails/__init__.py
@@ -1,137 +1,19 @@
-import logging
-from typing import Tuple, Dict, Any, Optional, List
+"""Guardrail components."""
 
-import instructor
-from openai import AsyncOpenAI # For type hinting aclient if it's not already instructor.Instructor
-
-# Corrected import for config schemas
-from ciris_engine.schemas.config_schemas_v1 import GuardrailsConfig, DEFAULT_OPENAI_MODEL_NAME 
-# Import schemas used by the guardrail
-from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
-from ciris_engine.schemas.feedback_schemas_v1 import OptimizationVetoResult, EpistemicHumilityResult
-from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
-from pydantic import BaseModel, Field
-
-from ciris_engine.faculties.epistemic import calculate_epistemic_values, evaluate_optimization_veto, evaluate_epistemic_humility
-
-logger = logging.getLogger(__name__)
-
-
-class EthicalGuardrails:
-    """
-    Applies ethical guardrails to the final proposed action from the ActionSelectionPDMA.
-    Primarily focuses on epistemic checks (entropy, coherence) of communicative actions.
-    """
-
-    def __init__(self, 
-                 aclient: instructor.Instructor, # Expect an instructor-patched client
-                 guardrails_config: GuardrailsConfig,
-                 model_name: str = DEFAULT_OPENAI_MODEL_NAME
-                 ):
-        self.aclient = aclient
-        self.model_name = model_name
-        self.guardrails_config = guardrails_config # Store the config object
-        self.entropy_threshold = guardrails_config.entropy_threshold
-        self.coherence_threshold = guardrails_config.coherence_threshold
-        self.optimization_veto_ratio = guardrails_config.optimization_veto_ratio
-        logger.info(
-            f"EthicalGuardrails initialized with model: {self.model_name}, "
-            f"entropy_threshold: {self.entropy_threshold}, "
-            f"coherence_threshold: {self.coherence_threshold}, "
-            f"optimization_veto_ratio: {self.optimization_veto_ratio}"
-        )
-
-    async def _evaluate_optimization_veto(self, action_result: ActionSelectionResult):
-        """Run the optimization veto check via LLM."""
-        return await evaluate_optimization_veto(action_result, self.aclient, self.model_name)
-
-    async def _evaluate_epistemic_humility(self, action_result: ActionSelectionResult):
-        """Run the epistemic humility check via LLM."""
-        return await evaluate_epistemic_humility(action_result, self.aclient, self.model_name)
-
-    async def check_action_output_safety(self, proposed_action_result: ActionSelectionResult) -> Tuple[bool, Optional[str], Optional[Dict[str, Any]]]:
-        """
-        Checks the safety and appropriateness of the proposed action's output,
-        especially for communicative actions like 'Speak'.
-
-        Args:
-            proposed_action_result: The result from the ActionSelectionPDMA.
-
-        Returns:
-            A tuple: (passes_guardrail: bool, reason: Optional[str], epistemic_data: Optional[Dict[str, Any]])
-        """
-        action_type = proposed_action_result.selected_action # Corrected field name
-        action_params = proposed_action_result.action_parameters
-
-        epistemic_data: Dict[str, Any] = {}
-
-        if action_type == HandlerActionType.SPEAK:
-            # Ensure action_params is a dict or has .get method
-            message_to_speak = ""
-            if isinstance(action_params, dict):
-                message_to_speak = action_params.get("content", "") # Assuming SpeakParams structure
-            elif hasattr(action_params, "content"): # For Pydantic model SpeakParams
-                 message_to_speak = getattr(action_params, "content", "")
-
-            if not message_to_speak:
-                logging.warning("Guardrail check: Speak action has no message content.")
-                return True, "Speak action has no message; passing guardrail by default.", None
-
-            logging.info(f"Guardrail: Async epistemic check on message: '{message_to_speak[:100]}...'")
-            epistemic_data = await calculate_epistemic_values(message_to_speak, self.aclient, self.model_name)
-            
-            entropy = epistemic_data.get("entropy", 1.0) 
-            coherence = epistemic_data.get("coherence", 0.0)
-
-            logging.info(f"Guardrail - Epistemic Values => entropy={entropy:.2f} coherence={coherence:.2f}")
-
-            if epistemic_data.get("error"):
-                reason = f"Epistemic check failed due to LLM error(s): {epistemic_data['error']}"
-                logging.error(f"Guardrail: {reason}")
-                return False, reason, epistemic_data
-            
-            if entropy > self.entropy_threshold:
-                reason = f"Output failed guardrail: Entropy ({entropy:.2f}) > threshold ({self.entropy_threshold:.2f}). Potential for being too chaotic/surprising."
-                logging.info(f"Guardrail: {reason}")
-                return False, reason, epistemic_data
-
-            if coherence < self.coherence_threshold:
-                reason = f"Output failed guardrail: Coherence ({coherence:.2f}) < threshold ({self.coherence_threshold:.2f}). Potential for misalignment with CIRIS voice/values."
-                logging.info(f"Guardrail: {reason}")
-                return False, reason, epistemic_data
-
-        optimization_result = await self._evaluate_optimization_veto(proposed_action_result)
-        epistemic_data["optimization_veto"] = optimization_result.model_dump()
-
-        if (
-            optimization_result.entropy_reduction_ratio >= self.optimization_veto_ratio
-            or optimization_result.decision in {"abort", "defer"}
-        ):
-            reason = f"Optimization veto triggered: {optimization_result.justification}"
-            logging.info(f"Guardrail: {reason}")
-            return False, reason, epistemic_data
-
-        humility_result = await self._evaluate_epistemic_humility(proposed_action_result)
-        epistemic_data["epistemic_humility"] = humility_result.model_dump()
-
-        if humility_result.recommended_action in {"abort", "defer", "ponder"}:
-            reason = f"Epistemic humility check requested {humility_result.recommended_action}: {humility_result.reflective_justification}"
-            logging.info(f"Guardrail: {reason}")
-            return False, reason, epistemic_data
-
-        if action_type == HandlerActionType.SPEAK:
-            return True, "Epistemic checks passed for Speak action.", epistemic_data
-
-        logging.info(
-            f"Guardrail: Action type '{action_type.value}' passed by default (no specific output content to check for epistemic safety)."
-        )
-        return True, f"Action type '{action_type.value}' passed guardrail by default.", epistemic_data
-
-    def __repr__(self) -> str:
-        return f"<EthicalGuardrails model='{self.model_name}' entropy_threshold={self.entropy_threshold} coherence_threshold={self.coherence_threshold}>"
+from .interface import GuardrailInterface
+from .registry import GuardrailRegistry
+from .core import (
+    EntropyGuardrail,
+    CoherenceGuardrail,
+    OptimizationVetoGuardrail,
+    EpistemicHumilityGuardrail,
+)
 
 __all__ = [
-    "EthicalGuardrails",
-    "OptimizationVetoResult",
-    "EpistemicHumilityResult",
+    "GuardrailInterface",
+    "GuardrailRegistry",
+    "EntropyGuardrail",
+    "CoherenceGuardrail",
+    "OptimizationVetoGuardrail",
+    "EpistemicHumilityGuardrail",
 ]

--- a/ciris_engine/guardrails/core.py
+++ b/ciris_engine/guardrails/core.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Dict, Any
+
+from ciris_engine.schemas.config_schemas_v1 import GuardrailsConfig, DEFAULT_OPENAI_MODEL_NAME
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
+from ciris_engine.schemas.guardrails_schemas_v1 import (
+    GuardrailCheckResult,
+    GuardrailStatus,
+)
+from ciris_engine.registries.base import ServiceRegistry
+from ciris_engine.faculties.epistemic import (
+    calculate_epistemic_values,
+    evaluate_optimization_veto,
+    evaluate_epistemic_humility,
+)
+from ciris_engine.protocols.services import LLMService
+
+from .interface import GuardrailInterface
+
+logger = logging.getLogger(__name__)
+
+
+class _BaseGuardrail(GuardrailInterface):
+    def __init__(
+        self,
+        service_registry: ServiceRegistry,
+        config: GuardrailsConfig,
+        model_name: str = DEFAULT_OPENAI_MODEL_NAME,
+    ) -> None:
+        self.service_registry = service_registry
+        self.config = config
+        self.model_name = model_name
+
+    async def _get_llm(self) -> LLMService | None:
+        return await self.service_registry.get_service(self.__class__.__name__, "llm")
+
+
+class EntropyGuardrail(_BaseGuardrail):
+    async def check(self, action: ActionSelectionResult, context: Dict[str, Any]) -> GuardrailCheckResult:
+        ts = datetime.now(timezone.utc).isoformat()
+        if action.selected_action != HandlerActionType.SPEAK:
+            return GuardrailCheckResult(
+                status=GuardrailStatus.PASSED,
+                passed=True,
+                check_timestamp=ts,
+            )
+        llm = await self._get_llm()
+        if not llm:
+            return GuardrailCheckResult(
+                status=GuardrailStatus.WARNING,
+                passed=True,
+                reason="LLM service unavailable",
+                check_timestamp=ts,
+            )
+        text = ""
+        params = action.action_parameters
+        if isinstance(params, dict):
+            text = params.get("content", "")
+        elif hasattr(params, "content"):
+            text = getattr(params, "content", "")
+        if not text:
+            return GuardrailCheckResult(
+                status=GuardrailStatus.PASSED,
+                passed=True,
+                reason="No content to evaluate",
+                check_timestamp=ts,
+            )
+        aclient = llm.get_client().instruct_client
+        epi = await calculate_epistemic_values(text, aclient, self.model_name)
+        entropy = epi.get("entropy", 0.0)
+        passed = entropy <= self.config.entropy_threshold
+        status = GuardrailStatus.PASSED if passed else GuardrailStatus.FAILED
+        reason = None
+        if not passed:
+            reason = (
+                f"Entropy {entropy:.2f} > threshold {self.config.entropy_threshold:.2f}"
+            )
+        return GuardrailCheckResult(
+            status=status,
+            passed=passed,
+            reason=reason,
+            epistemic_data={"entropy": entropy},
+            entropy_check={"entropy": entropy, "threshold": self.config.entropy_threshold},
+            entropy_score=entropy,
+            check_timestamp=ts,
+        )
+
+
+class CoherenceGuardrail(_BaseGuardrail):
+    async def check(self, action: ActionSelectionResult, context: Dict[str, Any]) -> GuardrailCheckResult:
+        ts = datetime.now(timezone.utc).isoformat()
+        if action.selected_action != HandlerActionType.SPEAK:
+            return GuardrailCheckResult(status=GuardrailStatus.PASSED, passed=True, check_timestamp=ts)
+        llm = await self._get_llm()
+        if not llm:
+            return GuardrailCheckResult(status=GuardrailStatus.WARNING, passed=True, reason="LLM service unavailable", check_timestamp=ts)
+        text = ""
+        params = action.action_parameters
+        if isinstance(params, dict):
+            text = params.get("content", "")
+        elif hasattr(params, "content"):
+            text = getattr(params, "content", "")
+        if not text:
+            return GuardrailCheckResult(status=GuardrailStatus.PASSED, passed=True, reason="No content to evaluate", check_timestamp=ts)
+        aclient = llm.get_client().instruct_client
+        epi = await calculate_epistemic_values(text, aclient, self.model_name)
+        coherence = epi.get("coherence", 1.0)
+        passed = coherence >= self.config.coherence_threshold
+        status = GuardrailStatus.PASSED if passed else GuardrailStatus.FAILED
+        reason = None
+        if not passed:
+            reason = (
+                f"Coherence {coherence:.2f} < threshold {self.config.coherence_threshold:.2f}"
+            )
+        return GuardrailCheckResult(
+            status=status,
+            passed=passed,
+            reason=reason,
+            epistemic_data={"coherence": coherence},
+            coherence_check={"coherence": coherence, "threshold": self.config.coherence_threshold},
+            coherence_score=coherence,
+            check_timestamp=ts,
+        )
+
+
+class OptimizationVetoGuardrail(_BaseGuardrail):
+    async def check(self, action: ActionSelectionResult, context: Dict[str, Any]) -> GuardrailCheckResult:
+        ts = datetime.now(timezone.utc).isoformat()
+        llm = await self._get_llm()
+        if not llm:
+            return GuardrailCheckResult(status=GuardrailStatus.WARNING, passed=True, reason="LLM service unavailable", check_timestamp=ts)
+        aclient = llm.get_client().instruct_client
+        result = await evaluate_optimization_veto(action, aclient, self.model_name)
+        passed = result.decision not in {"abort", "defer"} and result.entropy_reduction_ratio < self.config.optimization_veto_ratio
+        status = GuardrailStatus.PASSED if passed else GuardrailStatus.FAILED
+        reason = None
+        if not passed:
+            reason = f"Optimization veto triggered: {result.justification}"
+        return GuardrailCheckResult(
+            status=status,
+            passed=passed,
+            reason=reason,
+            epistemic_data=result.model_dump(),
+            optimization_veto_check=result.model_dump(),
+            check_timestamp=ts,
+        )
+
+
+class EpistemicHumilityGuardrail(_BaseGuardrail):
+    async def check(self, action: ActionSelectionResult, context: Dict[str, Any]) -> GuardrailCheckResult:
+        ts = datetime.now(timezone.utc).isoformat()
+        llm = await self._get_llm()
+        if not llm:
+            return GuardrailCheckResult(status=GuardrailStatus.WARNING, passed=True, reason="LLM service unavailable", check_timestamp=ts)
+        aclient = llm.get_client().instruct_client
+        result = await evaluate_epistemic_humility(action, aclient, self.model_name)
+        passed = result.recommended_action not in {"abort", "defer", "ponder"}
+        status = GuardrailStatus.PASSED if passed else GuardrailStatus.FAILED
+        reason = None
+        if not passed:
+            reason = f"Epistemic humility request: {result.recommended_action}"
+        return GuardrailCheckResult(
+            status=status,
+            passed=passed,
+            reason=reason,
+            epistemic_data=result.model_dump(),
+            epistemic_humility_check=result.model_dump(),
+            check_timestamp=ts,
+        )

--- a/ciris_engine/guardrails/interface.py
+++ b/ciris_engine/guardrails/interface.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Protocol, Dict, Any
+
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
+from ciris_engine.schemas.guardrails_schemas_v1 import GuardrailCheckResult
+
+class GuardrailInterface(Protocol):
+    """Protocol for all guardrail implementations."""
+
+    async def check(
+        self,
+        action: ActionSelectionResult,
+        context: Dict[str, Any],
+    ) -> GuardrailCheckResult:
+        """Check if action passes guardrail."""
+        ...

--- a/ciris_engine/guardrails/orchestrator.py
+++ b/ciris_engine/guardrails/orchestrator.py
@@ -1,185 +1,77 @@
-from ciris_engine.guardrails import EthicalGuardrails
-from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
-from ciris_engine.schemas.agent_core_schemas_v1 import Thought
-from ciris_engine.schemas.processing_schemas_v1 import DMAResults, GuardrailResult
-from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
-from ciris_engine.schemas.action_params_v1 import DeferParams, SpeakParams, PonderParams
-from ciris_engine.utils import DEFAULT_WA
-from ciris_engine.formatters.system_snapshot import format_system_snapshot
-from ciris_engine.formatters.user_profiles import format_user_profiles
-from ciris_engine.utils.task_formatters import format_task_context
-from ciris_engine.processor.thought_escalation import escalate_due_to_guardrail
-from pydantic import BaseModel
+from __future__ import annotations
+
 import logging
 from typing import Dict, Any
 
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.processing_schemas_v1 import GuardrailResult
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType
+from ciris_engine.schemas.action_params_v1 import PonderParams
+from ciris_engine.guardrails.registry import GuardrailRegistry
+from ciris_engine.registries.circuit_breaker import CircuitBreakerError
+
 logger = logging.getLogger(__name__)
 
+
 class GuardrailOrchestrator:
-    def __init__(self, ethical_guardrails: EthicalGuardrails):
-        self.ethical_guardrails = ethical_guardrails
-        
+    def __init__(self, registry: GuardrailRegistry) -> None:
+        self.registry = registry
+
     async def apply_guardrails(
         self,
         action_result: ActionSelectionResult,
         thought: Thought,
-        dma_results_dict: Dict[str, Any]
+        dma_results_dict: Dict[str, Any],
     ) -> GuardrailResult:
-        """Apply guardrails and handle overrides. Retries up to 3 times if guardrail fails."""
-        
-        # CRITICAL DEBUG: Check if we receive OBSERVE actions
-        if action_result and hasattr(action_result, 'selected_action'):
-            if action_result.selected_action == HandlerActionType.OBSERVE:
-                logger.warning(f"OBSERVE ACTION DEBUG: GuardrailOrchestrator received OBSERVE action for thought {thought.thought_id}")
-                logger.warning(f"OBSERVE ACTION DEBUG: action_result type: {type(action_result)}")
-                logger.warning(f"OBSERVE ACTION DEBUG: action_result.selected_action: {action_result.selected_action}")
-                logger.warning(f"OBSERVE ACTION DEBUG: action_result.action_parameters: {action_result.action_parameters}")
-        else:
-            logger.error(f"GuardrailOrchestrator: No action_result or missing selected_action for thought {thought.thought_id}")
-        
-        # Skip guardrails for TASK_COMPLETE actions - they should proceed immediately
         if action_result.selected_action == HandlerActionType.TASK_COMPLETE:
-            logger.debug(f"GuardrailOrchestrator: Skipping guardrails for TASK_COMPLETE action on thought {thought.thought_id}")
             return GuardrailResult(
                 original_action=action_result,
                 final_action=action_result,
                 overridden=False,
-                override_reason=None,
-                epistemic_data=None,
             )
-        
-        # Parse the incoming dict into DMAResults model
-        try:
-            dma_results = DMAResults(**dma_results_dict)
-        except Exception as e:
-            logger.error(f"Failed to parse dma_results_dict into DMAResults model: {e}", exc_info=True)
-            dma_results = DMAResults()
 
-        # Inject channel_id for SPEAK actions before guardrail check
-        if action_result.selected_action == HandlerActionType.SPEAK:
-            params = action_result.action_parameters
-            
-            # Try to get channel_id from multiple sources
-            channel_id = None
-            
-            # 1. From dma_results_dict processing_context
-            if isinstance(dma_results_dict, dict) and 'processing_context' in dma_results_dict:
-                proc_ctx = dma_results_dict['processing_context']
-                if isinstance(proc_ctx, dict):
-                    channel_id = proc_ctx.get('channel_id')
-                    if not channel_id:
-                        # Check system_snapshot within processing_context
-                        sys_snap = proc_ctx.get('system_snapshot', {})
-                        if isinstance(sys_snap, dict):
-                            channel_id = sys_snap.get('channel_id')
-            
-            # 2. From thought context
-            if not channel_id and hasattr(thought, 'context') and isinstance(thought.context, dict):
-                channel_id = thought.context.get('channel_id')
-            
-            # 3. From identity_context parsing
-            if not channel_id and isinstance(dma_results_dict, dict):
-                identity_ctx = dma_results_dict.get('identity_context')
-                if isinstance(identity_ctx, str) and 'channel is' in identity_ctx:
-                    import re
-                    match = re.search(r'channel is (\S+)', identity_ctx)
-                    if match:
-                        channel_id = match.group(1)
-            
-            # 4. From environment variable as last resort
-            if not channel_id:
-                import os
-                channel_id = os.getenv('DISCORD_CHANNEL_ID')
-            
-            # Inject channel_id if found
-            if channel_id:
-                if isinstance(params, dict):
-                    params['channel_id'] = channel_id
-                elif isinstance(params, SpeakParams):
-                    params.channel_id = channel_id
-                action_result.action_parameters = params
-                logger.debug(f"Injected channel_id={channel_id} into SPEAK parameters")
-            else:
-                logger.error("Failed to find channel_id from any source!")
-        
-        # Retry guardrail check up to 3 times if it fails
-        max_retries = 3
-        passes_guardrail = True
-        reason = None
-        epistemic_data = None
-        
-        for attempt in range(1, max_retries + 1):
-            passes_guardrail, reason, epistemic_data = await self.ethical_guardrails.check_action_output_safety(action_result)
-            if passes_guardrail:
-                break
-            logger.info(f"Guardrail failed attempt {attempt} for thought ID {thought.thought_id}: {reason}")
-            if attempt < max_retries:
+        context = {"thought": thought, "dma_results": dma_results_dict}
+
+        final_action = action_result
+        overridden = False
+        override_reason = None
+        epistemic_data: Dict[str, Any] = {}
+
+        for entry in self.registry.get_guardrails():
+            guardrail = entry.guardrail
+            cb = entry.circuit_breaker
+            try:
+                cb.check_and_raise()
+                result = await guardrail.check(final_action, context)
+                cb.record_success()
+            except CircuitBreakerError as e:
+                logger.warning(f"Guardrail {entry.name} unavailable: {e}")
                 continue
-            # Only proceed to override after final failed attempt
+            except Exception as e:  # noqa: BLE001
+                logger.error(f"Guardrail {entry.name} error: {e}", exc_info=True)
+                cb.record_failure()
+                continue
 
-        override_action_result = None
-        if not passes_guardrail:
-            logger.info(f"Guardrail failed for thought ID {thought.thought_id}: {reason}. Overriding action to PONDER.")
-
-            # Create ponder questions based on the guardrail failure
-            ponder_questions = [
-                f"Why did the guardrail fail with reason: {reason}?",
-                "What alternative approach would satisfy the epistemic constraints?",
-                "How can I reformulate my response to align with CIRIS values?"
-            ]
-
-            # Add specific questions based on epistemic data
-            if epistemic_data:
-                if epistemic_data.get('entropy', 0) > self.ethical_guardrails.entropy_threshold:
-                    ponder_questions.append("How can I reduce the entropy/chaos in my response?")
-                if epistemic_data.get('coherence', 1) < self.ethical_guardrails.coherence_threshold:
-                    ponder_questions.append("How can I better align my response with CIRIS principles?")
-                if 'optimization_veto' in epistemic_data:
-                    veto = epistemic_data['optimization_veto']
-                    if veto.get('decision') in ['abort', 'defer']:
-                        ponder_questions.append(f"Optimization concern: {veto.get('justification')} - How to address this?")
-                if 'epistemic_humility' in epistemic_data:
-                    humility = epistemic_data['epistemic_humility']
-                    if humility.get('recommended_action') in ['abort', 'defer']:
-                        ponder_questions.extend(humility.get('identified_uncertainties', []))
-
-            ponder_params = PonderParams(questions=ponder_questions[:5])  # Limit to 5 questions
-
-            override_action_result = ActionSelectionResult(
-                selected_action=HandlerActionType.PONDER,
-                action_parameters=ponder_params.model_dump(mode='json'),
-                rationale=f"Original action '{action_result.selected_action.value}' failed guardrails. Pondering to find aligned approach. Reason: {reason}",
-                confidence=0.3,  # Low confidence due to guardrail failure
-                raw_llm_response=action_result.raw_llm_response
-            )
-
-            logger.info(f"Guardrail triggered PONDER for thought {thought.thought_id}: {reason}")
-
-        final_action = override_action_result if override_action_result else action_result
-
-        # Normalize action_parameters for all main action types before dispatch
-        if final_action.selected_action == HandlerActionType.SPEAK:
-            params = final_action.action_parameters
-            if isinstance(params, dict):
-                final_action.action_parameters = SpeakParams(**params)
-        elif final_action.selected_action == HandlerActionType.DEFER:
-            params = final_action.action_parameters
-            if isinstance(params, dict):
-                final_action.action_parameters = DeferParams(**params)
-        elif final_action.selected_action == HandlerActionType.PONDER:
-            params = final_action.action_parameters
-            if isinstance(params, dict):
-                final_action.action_parameters = PonderParams(**params)
-
-        # CRITICAL DEBUG: Check OBSERVE actions before returning
-        if final_action.selected_action == HandlerActionType.OBSERVE:
-            logger.warning(f"OBSERVE ACTION DEBUG: GuardrailOrchestrator returning OBSERVE action for thought {thought.thought_id}")
-            logger.warning(f"OBSERVE ACTION DEBUG: final_action type: {type(final_action)}")
+            epistemic_data[entry.name] = result.epistemic_data
+            if not result.passed:
+                overridden = True
+                override_reason = result.reason
+                ponder_params = PonderParams(
+                    questions=[result.reason or "Guardrail failed"]
+                )
+                final_action = ActionSelectionResult(
+                    selected_action=HandlerActionType.PONDER,
+                    action_parameters=ponder_params.model_dump(mode="json"),
+                    rationale=f"Overridden by {entry.name}",
+                    confidence=0.3,
+                )
+                break
 
         return GuardrailResult(
             original_action=action_result,
             final_action=final_action,
-            overridden=not passes_guardrail,
-            override_reason=reason if not passes_guardrail else None,
-            epistemic_data=epistemic_data,
+            overridden=overridden,
+            override_reason=override_reason,
+            epistemic_data=epistemic_data or None,
         )

--- a/ciris_engine/guardrails/registry.py
+++ b/ciris_engine/guardrails/registry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from ciris_engine.registries.circuit_breaker import CircuitBreaker, CircuitBreakerConfig
+from .interface import GuardrailInterface
+
+@dataclass
+class GuardrailEntry:
+    name: str
+    guardrail: GuardrailInterface
+    priority: int = 0
+    enabled: bool = True
+    circuit_breaker: CircuitBreaker | None = None
+
+class GuardrailRegistry:
+    """Registry for dynamic guardrail management."""
+
+    def __init__(self) -> None:
+        self._entries: Dict[str, GuardrailEntry] = {}
+
+    def register_guardrail(
+        self,
+        name: str,
+        guardrail: GuardrailInterface,
+        priority: int = 0,
+        enabled: bool = True,
+        circuit_breaker_config: CircuitBreakerConfig | None = None,
+    ) -> None:
+        """Register a guardrail with priority."""
+        cb = CircuitBreaker(name, circuit_breaker_config or CircuitBreakerConfig())
+        entry = GuardrailEntry(name, guardrail, priority, enabled, cb)
+        self._entries[name] = entry
+
+    def get_guardrails(self) -> List[GuardrailEntry]:
+        """Return enabled guardrails ordered by priority."""
+        return sorted(
+            [e for e in self._entries.values() if e.enabled],
+            key=lambda e: e.priority,
+        )
+
+    def set_enabled(self, name: str, enabled: bool) -> None:
+        if name in self._entries:
+            self._entries[name].enabled = enabled


### PR DESCRIPTION
## Summary
- introduce `GuardrailInterface` protocol and `GuardrailRegistry`
- implement modular guardrails: entropy, coherence, optimization veto and epistemic humility
- rewrite `GuardrailOrchestrator` to use registry with circuit breakers
- update runtime to register guardrails
- adapt tests to new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a528e8148832b91a908d725df9333