### PR TITLE
Implement Epistemic Faculty interface and manager

### DIFF
--- a/ciris_engine/dma/__init__.py
+++ b/ciris_engine/dma/__init__.py
@@ -3,4 +3,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-__all__: list[str] = []
+from .base_dma import BaseDMA
+
+__all__: list[str] = ["BaseDMA"]

--- a/ciris_engine/dma/action_selection_pdma.py
+++ b/ciris_engine/dma/action_selection_pdma.py
@@ -27,6 +27,7 @@ from ciris_engine.schemas.action_params_v1 import ToolParams
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, CIRISSchemaVersion
 from ciris_engine.schemas.config_schemas_v1 import DEFAULT_OPENAI_MODEL_NAME
 from ciris_engine.registries.base import ServiceRegistry
+from .base_dma import BaseDMA
 from instructor.exceptions import InstructorRetryException
 from ciris_engine.utils import DEFAULT_WA, ENGINE_OVERVIEW_TEMPLATE
 from ciris_engine.utils import COVENANT_TEXT
@@ -45,7 +46,7 @@ DEFAULT_TEMPLATE = """{system_header}
 
 {closing_reminder}"""
 
-class ActionSelectionPDMAEvaluator:
+class ActionSelectionPDMAEvaluator(BaseDMA):
     """
     The second PDMA in the sequence. It takes the original thought and the outputs
     of the Ethical PDMA, CSDMA, and DSDMA, then performs a PDMA process
@@ -190,11 +191,13 @@ class ActionSelectionPDMAEvaluator:
             prompt_overrides: Optional prompt overrides dict.
             instructor_mode: instructor.Mode (must be passed as keyword argument).
         """
-        self.service_registry = service_registry
-        self.model_name = model_name
-        self.max_retries = max_retries  # Store max_retries
+        super().__init__(
+            service_registry=service_registry,
+            model_name=model_name,
+            max_retries=max_retries,
+            instructor_mode=instructor_mode,
+        )
         self.prompt = {**self.DEFAULT_PROMPT, **(prompt_overrides or {})}
-        self.instructor_mode = instructor_mode  # Store for reference if needed
 
     def _get_profile_specific_prompt(self, base_key: str, agent_profile_name: Optional[str]) -> str:
         if agent_profile_name:
@@ -423,12 +426,7 @@ Adhere strictly to the schema for your JSON output.
         original_thought: Thought = triaged_inputs['original_thought'] # For logging & post-processing
         processing_context_data = triaged_inputs.get('processing_context') # Define this at the start of the method
 
-        llm_service = None
-        if self.service_registry:
-            llm_service = await self.service_registry.get_service(
-                handler=self.__class__.__name__,
-                service_type="llm"
-            )
+        llm_service = await self.get_llm_service()
         if not llm_service:
             raise RuntimeError("LLM service unavailable for ActionSelectionPDMA")
 

--- a/ciris_engine/dma/base_dma.py
+++ b/ciris_engine/dma/base_dma.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import instructor
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from pydantic import BaseModel
+
+from ciris_engine.registries.base import ServiceRegistry
+from ciris_engine.protocols.services import LLMService
+
+
+class BaseDMA(ABC):
+    """Abstract base class for Decision Making Algorithms."""
+
+    def __init__(
+        self,
+        service_registry: ServiceRegistry,
+        model_name: Optional[str] = None,
+        max_retries: int = 3,
+        *,
+        instructor_mode: instructor.Mode = instructor.Mode.JSON,
+    ) -> None:
+        self.service_registry = service_registry
+        self.model_name = model_name
+        self.max_retries = max_retries
+        self.instructor_mode = instructor_mode
+
+    async def get_llm_service(self) -> LLMService:
+        """Return the LLM service for this DMA from the service registry."""
+        return await self.service_registry.get_service(
+            handler=self.__class__.__name__,
+            service_type="llm",
+        )
+
+    @abstractmethod
+    async def evaluate(self, *args, **kwargs) -> BaseModel:
+        """Execute DMA evaluation and return a pydantic model."""
+        raise NotImplementedError

--- a/ciris_engine/faculties/__init__.py
+++ b/ciris_engine/faculties/__init__.py
@@ -1,4 +1,12 @@
 # This file makes the 'faculties' directory a Python package.
 import logging
 
+from .faculty_manager import EntropyFaculty, CoherenceFaculty, FacultyManager
+
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "EntropyFaculty",
+    "CoherenceFaculty",
+    "FacultyManager",
+]

--- a/ciris_engine/faculties/faculty_manager.py
+++ b/ciris_engine/faculties/faculty_manager.py
@@ -1,0 +1,87 @@
+import asyncio
+import logging
+from typing import Dict, Any, Optional
+
+from ciris_engine.registries.base import ServiceRegistry
+from ciris_engine.protocols.services import LLMService
+from ciris_engine.protocols.faculties import EpistemicFaculty
+from ciris_engine.schemas.epistemic_schemas_v1 import EntropyResult, CoherenceResult, FacultyResult
+from . import epistemic as epi_helpers
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_NAME = "gpt-4o"
+
+class EntropyFaculty:
+    """Measure entropy/chaos in content."""
+
+    def __init__(self, service_registry: ServiceRegistry, model_name: str = DEFAULT_MODEL_NAME):
+        self.service_registry = service_registry
+        self.model_name = model_name
+
+    async def _get_llm(self) -> Optional[LLMService]:
+        return await self.service_registry.get_service(self.__class__.__name__, "llm")
+
+    async def evaluate(self, content: str, context: Optional[Dict[str, Any]] = None) -> EntropyResult:
+        llm = await self._get_llm()
+        if not llm:
+            logger.error("EntropyFaculty: No LLM service available")
+            return EntropyResult(entropy=0.0)
+        try:
+            messages = epi_helpers._create_entropy_messages_for_instructor(content)
+            data = await llm.generate_structured_response(
+                messages,
+                EntropyResult.model_json_schema(),
+                model=self.model_name,
+            )
+            return EntropyResult(**data)
+        except Exception as e:
+            logger.error(f"EntropyFaculty evaluation failed: {e}", exc_info=True)
+            return EntropyResult(entropy=0.0)
+
+class CoherenceFaculty:
+    """Assess coherence/alignment in content."""
+
+    def __init__(self, service_registry: ServiceRegistry, model_name: str = DEFAULT_MODEL_NAME):
+        self.service_registry = service_registry
+        self.model_name = model_name
+
+    async def _get_llm(self) -> Optional[LLMService]:
+        return await self.service_registry.get_service(self.__class__.__name__, "llm")
+
+    async def evaluate(self, content: str, context: Optional[Dict[str, Any]] = None) -> CoherenceResult:
+        llm = await self._get_llm()
+        if not llm:
+            logger.error("CoherenceFaculty: No LLM service available")
+            return CoherenceResult(coherence=0.0)
+        try:
+            messages = epi_helpers._create_coherence_messages_for_instructor(content)
+            data = await llm.generate_structured_response(
+                messages,
+                CoherenceResult.model_json_schema(),
+                model=self.model_name,
+            )
+            return CoherenceResult(**data)
+        except Exception as e:
+            logger.error(f"CoherenceFaculty evaluation failed: {e}", exc_info=True)
+            return CoherenceResult(coherence=0.0)
+
+class FacultyManager:
+    """Manages all epistemic faculties."""
+
+    def __init__(self, service_registry: ServiceRegistry):
+        self.faculties: Dict[str, EpistemicFaculty] = {}
+        self.service_registry = service_registry
+
+    def register_faculty(self, name: str, faculty: EpistemicFaculty):
+        self.faculties[name] = faculty
+
+    async def run_all_faculties(self, content: str) -> Dict[str, FacultyResult]:
+        tasks = {name: asyncio.create_task(fac.evaluate(content)) for name, fac in self.faculties.items()}
+        results: Dict[str, FacultyResult] = {}
+        for name, task in tasks.items():
+            try:
+                results[name] = await task
+            except Exception as e:
+                logger.error(f"Faculty '{name}' failed: {e}", exc_info=True)
+        return results

--- a/ciris_engine/protocols/faculties.py
+++ b/ciris_engine/protocols/faculties.py
@@ -1,0 +1,13 @@
+from typing import Protocol, Optional, Dict, Any
+from pydantic import BaseModel
+
+class EpistemicFaculty(Protocol):
+    """Protocol for epistemic faculties."""
+
+    async def evaluate(
+        self,
+        content: str,
+        context: Optional[Dict[str, Any]] = None
+    ) -> BaseModel:
+        """Evaluate content through this faculty."""
+        ...

--- a/ciris_engine/schemas/epistemic_schemas_v1.py
+++ b/ciris_engine/schemas/epistemic_schemas_v1.py
@@ -1,9 +1,14 @@
 from pydantic import BaseModel, Field
 
-class EntropyResult(BaseModel):
+
+class FacultyResult(BaseModel):
+    """Base class for epistemic faculty results."""
+    pass
+
+class EntropyResult(FacultyResult):
     """Result from entropy evaluation."""
     entropy: float = Field(..., ge=0.0, le=1.0)
     
-class CoherenceResult(BaseModel):
+class CoherenceResult(FacultyResult):
     """Result from coherence evaluation."""
     coherence: float = Field(..., ge=0.0, le=1.0)

--- a/tests/ciris_engine/faculties/test_faculty_manager.py
+++ b/tests/ciris_engine/faculties/test_faculty_manager.py
@@ -1,0 +1,36 @@
+import pytest
+
+from ciris_engine.registries.base import ServiceRegistry
+from ciris_engine.faculties import EntropyFaculty, CoherenceFaculty, FacultyManager
+from ciris_engine.schemas.epistemic_schemas_v1 import EntropyResult, CoherenceResult
+
+class DummyLLM:
+    def __init__(self, data):
+        self.data = data
+
+    async def generate_structured_response(self, messages, schema, model=None):
+        return self.data
+
+@pytest.mark.asyncio
+async def test_entropy_faculty_evaluate():
+    registry = ServiceRegistry()
+    llm = DummyLLM({"entropy": 0.42})
+    registry.register("EntropyFaculty", "llm", llm)
+    faculty = EntropyFaculty(registry)
+    result = await faculty.evaluate("hello")
+    assert isinstance(result, EntropyResult)
+    assert result.entropy == 0.42
+
+@pytest.mark.asyncio
+async def test_faculty_manager_runs_all():
+    registry = ServiceRegistry()
+    registry.register("EntropyFaculty", "llm", DummyLLM({"entropy": 0.1}))
+    registry.register("CoherenceFaculty", "llm", DummyLLM({"coherence": 0.9}))
+
+    manager = FacultyManager(registry)
+    manager.register_faculty("entropy", EntropyFaculty(registry))
+    manager.register_faculty("coherence", CoherenceFaculty(registry))
+
+    results = await manager.run_all_faculties("test")
+    assert isinstance(results["entropy"], EntropyResult)
+    assert isinstance(results["coherence"], CoherenceResult)


### PR DESCRIPTION
## Summary
- create `EpistemicFaculty` protocol
- extend schemas with `FacultyResult` base class
- implement `EntropyFaculty`, `CoherenceFaculty`, and `FacultyManager`
- expose new faculties in package init
- add tests for faculty evaluation and manager execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a528e8148832b91a908d725df9333