### PR TITLE
Add runtime protocol and API runtime skeleton

### DIFF
--- a/ciris_engine/dma/__init__.py
+++ b/ciris_engine/dma/__init__.py
@@ -3,4 +3,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-__all__: list[str] = []
+from .base_dma import BaseDMA
+
+__all__: list[str] = ["BaseDMA"]

--- a/ciris_engine/dma/action_selection_pdma.py
+++ b/ciris_engine/dma/action_selection_pdma.py
@@ -27,6 +27,7 @@ from ciris_engine.schemas.action_params_v1 import ToolParams
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, CIRISSchemaVersion
 from ciris_engine.schemas.config_schemas_v1 import DEFAULT_OPENAI_MODEL_NAME
 from ciris_engine.registries.base import ServiceRegistry
+from .base_dma import BaseDMA
 from instructor.exceptions import InstructorRetryException
 from ciris_engine.utils import DEFAULT_WA, ENGINE_OVERVIEW_TEMPLATE
 from ciris_engine.utils import COVENANT_TEXT
@@ -45,7 +46,7 @@ DEFAULT_TEMPLATE = """{system_header}
 
 {closing_reminder}"""
 
-class ActionSelectionPDMAEvaluator:
+class ActionSelectionPDMAEvaluator(BaseDMA):
     """
     The second PDMA in the sequence. It takes the original thought and the outputs
     of the Ethical PDMA, CSDMA, and DSDMA, then performs a PDMA process
@@ -190,11 +191,13 @@ class ActionSelectionPDMAEvaluator:
             prompt_overrides: Optional prompt overrides dict.
             instructor_mode: instructor.Mode (must be passed as keyword argument).
         """
-        self.service_registry = service_registry
-        self.model_name = model_name
-        self.max_retries = max_retries  # Store max_retries
+        super().__init__(
+            service_registry=service_registry,
+            model_name=model_name,
+            max_retries=max_retries,
+            instructor_mode=instructor_mode,
+        )
         self.prompt = {**self.DEFAULT_PROMPT, **(prompt_overrides or {})}
-        self.instructor_mode = instructor_mode  # Store for reference if needed
 
     def _get_profile_specific_prompt(self, base_key: str, agent_profile_name: Optional[str]) -> str:
         if agent_profile_name:
@@ -423,12 +426,7 @@ Adhere strictly to the schema for your JSON output.
         original_thought: Thought = triaged_inputs['original_thought'] # For logging & post-processing
         processing_context_data = triaged_inputs.get('processing_context') # Define this at the start of the method
 
-        llm_service = None
-        if self.service_registry:
-            llm_service = await self.service_registry.get_service(
-                handler=self.__class__.__name__,
-                service_type="llm"
-            )
+        llm_service = await self.get_llm_service()
         if not llm_service:
             raise RuntimeError("LLM service unavailable for ActionSelectionPDMA")
 

--- a/ciris_engine/dma/base_dma.py
+++ b/ciris_engine/dma/base_dma.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import instructor
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from pydantic import BaseModel
+
+from ciris_engine.registries.base import ServiceRegistry
+from ciris_engine.protocols.services import LLMService
+
+
+class BaseDMA(ABC):
+    """Abstract base class for Decision Making Algorithms."""
+
+    def __init__(
+        self,
+        service_registry: ServiceRegistry,
+        model_name: Optional[str] = None,
+        max_retries: int = 3,
+        *,
+        instructor_mode: instructor.Mode = instructor.Mode.JSON,
+    ) -> None:
+        self.service_registry = service_registry
+        self.model_name = model_name
+        self.max_retries = max_retries
+        self.instructor_mode = instructor_mode
+
+    async def get_llm_service(self) -> LLMService:
+        """Return the LLM service for this DMA from the service registry."""
+        return await self.service_registry.get_service(
+            handler=self.__class__.__name__,
+            service_type="llm",
+        )
+
+    @abstractmethod
+    async def evaluate(self, *args, **kwargs) -> BaseModel:
+        """Execute DMA evaluation and return a pydantic model."""
+        raise NotImplementedError

--- a/ciris_engine/runtime/__init__.py
+++ b/ciris_engine/runtime/__init__.py
@@ -2,4 +2,14 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-__all__ = []
+from .runtime_interface import RuntimeInterface
+from .ciris_runtime import CIRISRuntime
+from .discord_runtime import DiscordRuntime
+from .api_runtime import APIRuntime
+
+__all__ = [
+    "RuntimeInterface",
+    "CIRISRuntime",
+    "DiscordRuntime",
+    "APIRuntime",
+]

--- a/ciris_engine/runtime/api_runtime.py
+++ b/ciris_engine/runtime/api_runtime.py
@@ -1,0 +1,24 @@
+"""API runtime implementation for REST or GraphQL interfaces."""
+from typing import Optional
+
+from .ciris_runtime import CIRISRuntime
+
+
+class APIRuntime(CIRISRuntime):
+    """Runtime for REST/GraphQL API mode."""
+
+    def __init__(self, profile_name: str = "default", startup_channel_id: Optional[str] = None):
+        super().__init__(profile_name=profile_name, io_adapter=None, startup_channel_id=startup_channel_id)
+        self.api_server = None  # Placeholder for future HTTP adapter
+
+    async def _register_api_services(self):
+        """Register API-specific services."""
+        if not self.service_registry:
+            return
+        # Register HTTP adapter, webhook handlers and response formatters here
+        # This is currently a stub until API components are implemented
+        return
+
+    async def initialize(self):
+        await super().initialize()
+        await self._register_api_services()

--- a/ciris_engine/runtime/ciris_runtime.py
+++ b/ciris_engine/runtime/ciris_runtime.py
@@ -18,6 +18,7 @@ from ciris_engine.adapters.local_graph_memory import LocalGraphMemoryService
 from ciris_engine.adapters.openai_compatible_llm import OpenAICompatibleLLM
 from ciris_engine.adapters import AuditService
 from ciris_engine.persistence.maintenance import DatabaseMaintenanceService
+from .runtime_interface import RuntimeInterface
 from ciris_engine.action_handlers.base_handler import ActionHandlerDependencies
 
 # Service Registry
@@ -47,7 +48,7 @@ import instructor
 logger = logging.getLogger(__name__)
 
 
-class CIRISRuntime:
+class CIRISRuntime(RuntimeInterface):
     """
     Main runtime orchestrator for CIRIS Agent.
     Handles initialization of all components and services.

--- a/ciris_engine/runtime/runtime_interface.py
+++ b/ciris_engine/runtime/runtime_interface.py
@@ -1,0 +1,17 @@
+from typing import Protocol, Optional, runtime_checkable
+
+@runtime_checkable
+class RuntimeInterface(Protocol):
+    """Protocol for CIRIS runtimes."""
+
+    async def initialize(self) -> None:
+        """Initialize runtime and all services."""
+        ...
+
+    async def run(self, max_rounds: Optional[int] = None) -> None:
+        """Run the agent processing loop."""
+        ...
+
+    async def shutdown(self) -> None:
+        """Gracefully shutdown all services."""
+        ...

--- a/tests/ciris_engine/runtime/test_api_runtime.py
+++ b/tests/ciris_engine/runtime/test_api_runtime.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from ciris_engine.runtime.api_runtime import APIRuntime
+from ciris_engine.runtime.runtime_interface import RuntimeInterface
+
+
+@pytest.mark.asyncio
+async def test_api_runtime_initialization_calls_register(monkeypatch):
+    monkeypatch.setattr(
+        "ciris_engine.adapters.openai_compatible_llm.OpenAICompatibleLLM.start",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "ciris_engine.adapters.openai_compatible_llm.OpenAICompatibleLLM.get_client",
+        MagicMock(return_value=MagicMock(instruct_client=None, client=None, model_name="test")),
+    )
+    monkeypatch.setattr(
+        "ciris_engine.runtime.ciris_runtime.CIRISRuntime._build_components",
+        AsyncMock(),
+    )
+    register_mock = AsyncMock()
+    monkeypatch.setattr(APIRuntime, "_register_api_services", register_mock)
+
+    runtime = APIRuntime(profile_name="test_profile")
+    await runtime.initialize()
+
+    register_mock.assert_awaited_once()
+    assert runtime.profile_name == "test_profile"
+
+
+def test_api_runtime_implements_interface():
+    runtime = APIRuntime()
+    assert isinstance(runtime, RuntimeInterface)


### PR DESCRIPTION
## Summary
- define `RuntimeInterface` protocol for runtimes
- expose runtime classes from `ciris_engine.runtime`
- make `CIRISRuntime` implement the new interface
- add placeholder `APIRuntime` with `_register_api_services`
- test API runtime initialization and protocol compliance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a528e8148832b91a908d725df9333