### PR TITLE
Add ConfigLoader and dynamic ConfigManager

### DIFF
--- a/ciris_engine/config/README.md
+++ b/ciris_engine/config/README.md
@@ -1,3 +1,10 @@
 # config
 
-This module contains the config components of the CIRIS engine.
+This module contains configuration utilities for the CIRIS engine.
+
+* `config_loader.py` provides `ConfigLoader.load_config` for loading YAML based
+  configuration files and merging them with agent profiles and environment
+  variables.
+* `dynamic_config.py` implements a lightweight `ConfigManager` that can update
+  configuration values at runtime and reload agent profiles.
+* `config_manager.py` retains the original JSON helpers used in tests.

--- a/ciris_engine/config/__init__.py
+++ b/ciris_engine/config/__init__.py
@@ -1,0 +1,32 @@
+from .config_manager import (
+    load_config_from_file,
+    save_config_to_json,
+    get_config,
+    get_config_as_json_str,
+    get_config_file_path,
+    get_project_root_for_config,
+    load_config_from_file_async,
+    get_config_async,
+    save_config_to_json_async,
+    get_sqlite_db_full_path,
+    get_graph_memory_full_path,
+)
+
+from .config_loader import ConfigLoader
+from .dynamic_config import ConfigManager
+
+__all__ = [
+    "load_config_from_file",
+    "save_config_to_json",
+    "get_config",
+    "get_config_as_json_str",
+    "get_config_file_path",
+    "get_project_root_for_config",
+    "load_config_from_file_async",
+    "get_config_async",
+    "save_config_to_json_async",
+    "get_sqlite_db_full_path",
+    "get_graph_memory_full_path",
+    "ConfigLoader",
+    "ConfigManager",
+]

--- a/ciris_engine/config/config_loader.py
+++ b/ciris_engine/config/config_loader.py
@@ -1,0 +1,67 @@
+import os
+import asyncio
+from pathlib import Path
+from typing import Optional, Dict, Any
+import yaml
+
+from ciris_engine.schemas.config_schemas_v1 import AppConfig
+
+
+def _deep_merge(base: Dict[str, Any], update: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge two dictionaries."""
+    for key, value in update.items():
+        if (
+            key in base
+            and isinstance(base[key], dict)
+            and isinstance(value, dict)
+        ):
+            base[key] = _deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+async def _load_yaml(path: Path) -> Dict[str, Any]:
+    def _loader(p: Path) -> Dict[str, Any]:
+        if not p.exists():
+            return {}
+        with open(p, "r") as f:
+            return yaml.safe_load(f) or {}
+
+    return await asyncio.to_thread(_loader, path)
+
+
+def _load_env_config() -> Dict[str, Any]:
+    env_config: Dict[str, Any] = {}
+    discord_id = os.getenv("DISCORD_CHANNEL_ID")
+    if discord_id:
+        env_config["discord_channel_id"] = discord_id
+    return env_config
+
+
+def _merge_configs(*configs: Dict[str, Any]) -> Dict[str, Any]:
+    merged: Dict[str, Any] = {}
+    for cfg in configs:
+        merged = _deep_merge(merged, cfg)
+    return merged
+
+
+class ConfigLoader:
+    """Load and validate configuration."""
+
+    @staticmethod
+    async def load_config(
+        config_path: Optional[Path] = None,
+        profile_name: str = "default",
+    ) -> AppConfig:
+        """Load config with profile overlay."""
+
+        base_path = Path(config_path or "config/base.yaml")
+        profile_path = Path("ciris_profiles") / f"{profile_name}.yaml"
+
+        base_config = await _load_yaml(base_path)
+        profile_config = await _load_yaml(profile_path)
+        env_config = _load_env_config()
+
+        merged = _merge_configs(base_config, profile_config, env_config)
+        return AppConfig(**merged)

--- a/ciris_engine/config/dynamic_config.py
+++ b/ciris_engine/config/dynamic_config.py
@@ -1,0 +1,41 @@
+import asyncio
+from typing import Any, Callable
+from pathlib import Path
+
+from ciris_engine.schemas.config_schemas_v1 import AppConfig
+from .config_loader import ConfigLoader
+
+
+class ConfigManager:
+    """Manage runtime configuration changes."""
+
+    def __init__(self, config: AppConfig):
+        self._config = config
+        self._lock = asyncio.Lock()
+
+    @property
+    def config(self) -> AppConfig:
+        return self._config
+
+    async def watch_config_changes(self, callback: Callable[[AppConfig], None]):
+        """Watch for config file changes.
+
+        Placeholder implementation that simply invokes callback with the current
+        configuration. Real file watching is out of scope for tests.
+        """
+        await callback(self._config)
+
+    async def update_config(self, path: str, value: Any):
+        """Update configuration value at runtime."""
+        async with self._lock:
+            parts = path.split(".")
+            obj = self._config
+            for part in parts[:-1]:
+                obj = getattr(obj, part)
+            setattr(obj, parts[-1], value)
+
+    async def reload_profile(self, profile_name: str, config_path: Path | None = None):
+        """Hot-reload agent profile."""
+        new_config = await ConfigLoader.load_config(config_path, profile_name)
+        async with self._lock:
+            self._config = new_config

--- a/ciris_engine/dma/__init__.py
+++ b/ciris_engine/dma/__init__.py
@@ -3,4 +3,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-__all__: list[str] = []
+from .base_dma import BaseDMA
+
+__all__: list[str] = ["BaseDMA"]

--- a/ciris_engine/dma/action_selection_pdma.py
+++ b/ciris_engine/dma/action_selection_pdma.py
@@ -27,6 +27,7 @@ from ciris_engine.schemas.action_params_v1 import ToolParams
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, CIRISSchemaVersion
 from ciris_engine.schemas.config_schemas_v1 import DEFAULT_OPENAI_MODEL_NAME
 from ciris_engine.registries.base import ServiceRegistry
+from .base_dma import BaseDMA
 from instructor.exceptions import InstructorRetryException
 from ciris_engine.utils import DEFAULT_WA, ENGINE_OVERVIEW_TEMPLATE
 from ciris_engine.utils import COVENANT_TEXT
@@ -45,7 +46,7 @@ DEFAULT_TEMPLATE = """{system_header}
 
 {closing_reminder}"""
 
-class ActionSelectionPDMAEvaluator:
+class ActionSelectionPDMAEvaluator(BaseDMA):
     """
     The second PDMA in the sequence. It takes the original thought and the outputs
     of the Ethical PDMA, CSDMA, and DSDMA, then performs a PDMA process
@@ -190,11 +191,13 @@ class ActionSelectionPDMAEvaluator:
             prompt_overrides: Optional prompt overrides dict.
             instructor_mode: instructor.Mode (must be passed as keyword argument).
         """
-        self.service_registry = service_registry
-        self.model_name = model_name
-        self.max_retries = max_retries  # Store max_retries
+        super().__init__(
+            service_registry=service_registry,
+            model_name=model_name,
+            max_retries=max_retries,
+            instructor_mode=instructor_mode,
+        )
         self.prompt = {**self.DEFAULT_PROMPT, **(prompt_overrides or {})}
-        self.instructor_mode = instructor_mode  # Store for reference if needed
 
     def _get_profile_specific_prompt(self, base_key: str, agent_profile_name: Optional[str]) -> str:
         if agent_profile_name:
@@ -423,12 +426,7 @@ Adhere strictly to the schema for your JSON output.
         original_thought: Thought = triaged_inputs['original_thought'] # For logging & post-processing
         processing_context_data = triaged_inputs.get('processing_context') # Define this at the start of the method
 
-        llm_service = None
-        if self.service_registry:
-            llm_service = await self.service_registry.get_service(
-                handler=self.__class__.__name__,
-                service_type="llm"
-            )
+        llm_service = await self.get_llm_service()
         if not llm_service:
             raise RuntimeError("LLM service unavailable for ActionSelectionPDMA")
 

--- a/ciris_engine/dma/base_dma.py
+++ b/ciris_engine/dma/base_dma.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import instructor
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from pydantic import BaseModel
+
+from ciris_engine.registries.base import ServiceRegistry
+from ciris_engine.protocols.services import LLMService
+
+
+class BaseDMA(ABC):
+    """Abstract base class for Decision Making Algorithms."""
+
+    def __init__(
+        self,
+        service_registry: ServiceRegistry,
+        model_name: Optional[str] = None,
+        max_retries: int = 3,
+        *,
+        instructor_mode: instructor.Mode = instructor.Mode.JSON,
+    ) -> None:
+        self.service_registry = service_registry
+        self.model_name = model_name
+        self.max_retries = max_retries
+        self.instructor_mode = instructor_mode
+
+    async def get_llm_service(self) -> LLMService:
+        """Return the LLM service for this DMA from the service registry."""
+        return await self.service_registry.get_service(
+            handler=self.__class__.__name__,
+            service_type="llm",
+        )
+
+    @abstractmethod
+    async def evaluate(self, *args, **kwargs) -> BaseModel:
+        """Execute DMA evaluation and return a pydantic model."""
+        raise NotImplementedError

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -1,0 +1,19 @@
+version: "1.0"
+log_level: "INFO"
+database:
+  db_filename: "ciris_engine.db"
+  data_directory: "data"
+  graph_memory_filename: "graph_memory.pkl"
+llm_services:
+  openai:
+    model_name: "gpt-4o-mini"
+    base_url: null
+    timeout_seconds: 30.0
+    max_retries: 3
+    api_key_env_var: "OPENAI_API_KEY"
+    instructor_mode: "JSON"
+workflow: {}
+guardrails: {}
+profile_directory: "ciris_profiles"
+default_profile: "default"
+agent_profiles: {}

--- a/tests/ciris_engine/config/test_config_loader.py
+++ b/tests/ciris_engine/config/test_config_loader.py
@@ -1,0 +1,55 @@
+import yaml
+import pytest
+
+
+from ciris_engine.config.config_loader import ConfigLoader
+from ciris_engine.config.dynamic_config import ConfigManager
+
+
+@pytest.mark.asyncio
+async def test_load_config_overlays(tmp_path, monkeypatch):
+    base = tmp_path / "base.yaml"
+    profile_dir = tmp_path / "ciris_profiles"
+    profile_dir.mkdir()
+    profile = profile_dir / "agent.yaml"
+
+    with open(base, "w") as f:
+        yaml.safe_dump({"database": {"db_filename": "base.db"}}, f)
+
+    with open(profile, "w") as f:
+        yaml.safe_dump({"database": {"db_filename": "profile.db"}}, f)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", "123")
+
+    config = await ConfigLoader.load_config(base, "agent")
+    assert config.database.db_filename == "profile.db"
+    assert config.discord_channel_id == "123"
+
+
+@pytest.mark.asyncio
+async def test_config_manager_update_and_reload(tmp_path, monkeypatch):
+    base = tmp_path / "base.yaml"
+    profiles = tmp_path / "ciris_profiles"
+    profiles.mkdir()
+    prof1 = profiles / "p1.yaml"
+    prof2 = profiles / "p2.yaml"
+
+    with open(base, "w") as f:
+        yaml.safe_dump({"database": {"db_filename": "base.db"}}, f)
+
+    with open(prof1, "w") as f:
+        yaml.safe_dump({"database": {"db_filename": "p1.db"}}, f)
+
+    with open(prof2, "w") as f:
+        yaml.safe_dump({"database": {"db_filename": "p2.db"}}, f)
+
+    monkeypatch.chdir(tmp_path)
+    cfg = await ConfigLoader.load_config(base, "p1")
+    mgr = ConfigManager(cfg)
+
+    await mgr.update_config("database.db_filename", "updated.db")
+    assert mgr.config.database.db_filename == "updated.db"
+
+    await mgr.reload_profile("p2", base)
+    assert mgr.config.database.db_filename == "p2.db"


### PR DESCRIPTION
## Summary
- implement YAML-based `ConfigLoader`
- implement lightweight `ConfigManager` for runtime updates
- expose new utilities from `ciris_engine.config`
- provide default `config/base.yaml`
- document configuration utilities
- add tests for loader overlays and manager reload functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a528e8148832b91a908d725df9333