### PR TITLE
Add schema versioning and registry

### DIFF
--- a/ciris_engine/dma/__init__.py
+++ b/ciris_engine/dma/__init__.py
@@ -3,4 +3,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-__all__: list[str] = []
+from .base_dma import BaseDMA
+
+__all__: list[str] = ["BaseDMA"]

--- a/ciris_engine/dma/base_dma.py
+++ b/ciris_engine/dma/base_dma.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import instructor
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from pydantic import BaseModel
+
+from ciris_engine.registries.base import ServiceRegistry
+from ciris_engine.protocols.services import LLMService
+
+
+class BaseDMA(ABC):
+    """Abstract base class for Decision Making Algorithms."""
+
+    def __init__(
+        self,
+        service_registry: ServiceRegistry,
+        model_name: Optional[str] = None,
+        max_retries: int = 3,
+        *,
+        instructor_mode: instructor.Mode = instructor.Mode.JSON,
+    ) -> None:
+        self.service_registry = service_registry
+        self.model_name = model_name
+        self.max_retries = max_retries
+        self.instructor_mode = instructor_mode
+
+    async def get_llm_service(self) -> LLMService:
+        """Return the LLM service for this DMA from the service registry."""
+        return await self.service_registry.get_service(
+            handler=self.__class__.__name__,
+            service_type="llm",
+        )
+
+    @abstractmethod
+    async def evaluate(self, *args, **kwargs) -> BaseModel:
+        """Execute DMA evaluation and return a pydantic model."""
+        raise NotImplementedError

--- a/ciris_engine/schemas/README.md
+++ b/ciris_engine/schemas/README.md
@@ -1,3 +1,7 @@
 # schemas
 
-This module contains the schemas components of the CIRIS engine.
+This module contains the pydantic schemas used throughout the CIRIS Engine.
+All schemas inherit from `BaseModel`, and many now extend `VersionedSchema`
+which adds a `schema_version` field. The `SchemaRegistry` provides a central
+mapping of schema names to classes and exposes `validate_schema` for
+runtime validation.

--- a/ciris_engine/schemas/foundational_schemas_v1.py
+++ b/ciris_engine/schemas/foundational_schemas_v1.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from pydantic import BaseModel
+from .versioning import SchemaVersion
 from typing import Optional
 
 class CaseInsensitiveEnum(str, Enum):
@@ -63,9 +64,9 @@ class IncomingMessage(BaseModel):
     is_bot: bool = False
     is_dm: bool = False
 
-class CIRISSchemaVersion(str, Enum):
-    """Version tracking for schema evolution."""
-    V1_0_BETA = "1.0-beta"
+
+# Backwards-compatible alias for SchemaVersion
+CIRISSchemaVersion = SchemaVersion
 
 
 __all__ = [
@@ -75,5 +76,6 @@ __all__ = [
     "ThoughtStatus",
     "ObservationSourceType",
     "IncomingMessage",
+    "SchemaVersion",
     "CIRISSchemaVersion",
 ]

--- a/ciris_engine/schemas/schema_registry.py
+++ b/ciris_engine/schemas/schema_registry.py
@@ -1,0 +1,42 @@
+from typing import Dict, Type, Any
+from pydantic import BaseModel
+
+from .agent_core_schemas_v1 import Task, Thought
+from .action_params_v1 import (
+    ObserveParams,
+    SpeakParams,
+    ToolParams,
+    PonderParams,
+    RejectParams,
+    DeferParams,
+    MemorizeParams,
+    RecallParams,
+    ForgetParams,
+)
+from .dma_results_v1 import ActionSelectionResult
+
+class SchemaRegistry:
+    """Central registry for schema validation."""
+
+    schemas: Dict[str, Type[BaseModel]] = {
+        "Task": Task,
+        "Thought": Thought,
+        "ObserveParams": ObserveParams,
+        "SpeakParams": SpeakParams,
+        "ToolParams": ToolParams,
+        "PonderParams": PonderParams,
+        "RejectParams": RejectParams,
+        "DeferParams": DeferParams,
+        "MemorizeParams": MemorizeParams,
+        "RecallParams": RecallParams,
+        "ForgetParams": ForgetParams,
+        "ActionSelectionResult": ActionSelectionResult,
+    }
+
+    @classmethod
+    def validate_schema(cls, name: str, data: Dict[str, Any]) -> BaseModel:
+        """Validate data against a registered schema."""
+        schema = cls.schemas.get(name)
+        if schema is None:
+            raise ValueError(f"Schema '{name}' not registered")
+        return schema(**data)

--- a/ciris_engine/schemas/tool_schemas_v1.py
+++ b/ciris_engine/schemas/tool_schemas_v1.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 from typing import Any, Dict, Optional
 from enum import Enum
-from .foundational_schemas_v1 import CIRISSchemaVersion
+from .versioning import SchemaVersion
 
 class ToolExecutionStatus(str, Enum):
     SUCCESS = "success"
@@ -12,7 +12,7 @@ class ToolExecutionStatus(str, Enum):
 
 class ToolResult(BaseModel):
     """Result from tool execution."""
-    schema_version: CIRISSchemaVersion = Field(default=CIRISSchemaVersion.V1_0_BETA)
+    schema_version: SchemaVersion = Field(default=SchemaVersion.V1_0)
     tool_name: str
     execution_status: ToolExecutionStatus
     result_data: Optional[Dict[str, Any]] = None

--- a/ciris_engine/schemas/versioning.py
+++ b/ciris_engine/schemas/versioning.py
@@ -1,0 +1,10 @@
+from enum import Enum
+from pydantic import BaseModel, Field
+
+class SchemaVersion(str, Enum):
+    """Track schema versions."""
+    V1_0 = "1.0"
+
+class VersionedSchema(BaseModel):
+    """Base model with schema version metadata."""
+    schema_version: SchemaVersion = Field(default=SchemaVersion.V1_0)

--- a/tests/ciris_engine/dma/test_action_selection_pdma.py
+++ b/tests/ciris_engine/dma/test_action_selection_pdma.py
@@ -5,7 +5,7 @@ from ciris_engine.registries.base import ServiceRegistry, Priority
 from ciris_engine.dma.action_selection_pdma import ActionSelectionPDMAEvaluator, HandlerActionType, ActionSelectionResult, PonderParams, SpeakParams
 from ciris_engine.schemas.dma_results_v1 import EthicalDMAResult, CSDMAResult, DSDMAResult
 from ciris_engine.schemas.agent_core_schemas_v1 import Thought
-from ciris_engine.schemas.foundational_schemas_v1 import CIRISSchemaVersion
+from ciris_engine.schemas.foundational_schemas_v1 import SchemaVersion
 from ciris_engine.schemas.action_params_v1 import PonderParams, SpeakParams
 from pydantic import ValidationError
 
@@ -48,7 +48,7 @@ async def test_forced_ponder(monkeypatch):
 async def test_llm_success(monkeypatch):
     # Patch the instructor client to return a dummy LLM response
     dummy_llm_response = DummyLLMResponse(
-        schema_version=CIRISSchemaVersion.V1_0_BETA,
+        schema_version=SchemaVersion.V1_0,
         context_summary_for_action_selection="summary",
         action_alignment_check={"SPEAK": "ok"},
         action_conflicts=None,

--- a/tests/ciris_engine/schemas/test_foundational_schemas_v1.py
+++ b/tests/ciris_engine/schemas/test_foundational_schemas_v1.py
@@ -73,7 +73,7 @@ def test_incoming_message_required_fields():
 
 
 @pytest.mark.parametrize("enum_cls, val, expected", [
-    (fs.CIRISSchemaVersion, "1.0-beta", fs.CIRISSchemaVersion.V1_0_BETA),
+    (fs.SchemaVersion, "1.0", fs.SchemaVersion.V1_0),
 ])
 def test_other_enums(enum_cls, val, expected):
     assert enum_cls(val) == expected

--- a/tests/ciris_engine/schemas/test_tool_schemas_v1.py
+++ b/tests/ciris_engine/schemas/test_tool_schemas_v1.py
@@ -1,5 +1,5 @@
 from ciris_engine.schemas.tool_schemas_v1 import ToolExecutionStatus, ToolResult
-from ciris_engine.schemas.foundational_schemas_v1 import CIRISSchemaVersion
+from ciris_engine.schemas.foundational_schemas_v1 import SchemaVersion
 
 def test_tool_execution_status_enum():
     assert ToolExecutionStatus.SUCCESS == "success"
@@ -9,6 +9,6 @@ def test_tool_result_minimal():
     res = ToolResult(tool_name="foo", execution_status=ToolExecutionStatus.SUCCESS)
     assert res.tool_name == "foo"
     assert res.execution_status == ToolExecutionStatus.SUCCESS
-    assert res.schema_version == CIRISSchemaVersion.V1_0_BETA
+    assert res.schema_version == SchemaVersion.V1_0
     assert res.result_data is None
     assert isinstance(res.metadata, dict)


### PR DESCRIPTION
## Summary
- finalize schema versioning with `SchemaVersion` and `VersionedSchema`
- create a `SchemaRegistry` for runtime validation
- use the new version enum in tool schemas and DMAs
- keep backwards compatibility via `CIRISSchemaVersion` alias
- document schemas module updates
- adjust tests for the locked `1.0` version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a528e8148832b91a908d725df9333