### PR TITLE
Add fixtures and integration test skeleton

### DIFF
--- a/ciris_engine/dma/__init__.py
+++ b/ciris_engine/dma/__init__.py
@@ -3,4 +3,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-__all__: list[str] = []
+from .base_dma import BaseDMA
+
+__all__: list[str] = ["BaseDMA"]

--- a/ciris_engine/dma/action_selection_pdma.py
+++ b/ciris_engine/dma/action_selection_pdma.py
@@ -27,6 +27,7 @@ from ciris_engine.schemas.action_params_v1 import ToolParams
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, CIRISSchemaVersion
 from ciris_engine.schemas.config_schemas_v1 import DEFAULT_OPENAI_MODEL_NAME
 from ciris_engine.registries.base import ServiceRegistry
+from .base_dma import BaseDMA
 from instructor.exceptions import InstructorRetryException
 from ciris_engine.utils import DEFAULT_WA, ENGINE_OVERVIEW_TEMPLATE
 from ciris_engine.utils import COVENANT_TEXT
@@ -45,7 +46,7 @@ DEFAULT_TEMPLATE = """{system_header}
 
 {closing_reminder}"""
 
-class ActionSelectionPDMAEvaluator:
+class ActionSelectionPDMAEvaluator(BaseDMA):
     """
     The second PDMA in the sequence. It takes the original thought and the outputs
     of the Ethical PDMA, CSDMA, and DSDMA, then performs a PDMA process
@@ -190,11 +191,13 @@ class ActionSelectionPDMAEvaluator:
             prompt_overrides: Optional prompt overrides dict.
             instructor_mode: instructor.Mode (must be passed as keyword argument).
         """
-        self.service_registry = service_registry
-        self.model_name = model_name
-        self.max_retries = max_retries  # Store max_retries
+        super().__init__(
+            service_registry=service_registry,
+            model_name=model_name,
+            max_retries=max_retries,
+            instructor_mode=instructor_mode,
+        )
         self.prompt = {**self.DEFAULT_PROMPT, **(prompt_overrides or {})}
-        self.instructor_mode = instructor_mode  # Store for reference if needed
 
     def _get_profile_specific_prompt(self, base_key: str, agent_profile_name: Optional[str]) -> str:
         if agent_profile_name:
@@ -423,12 +426,7 @@ Adhere strictly to the schema for your JSON output.
         original_thought: Thought = triaged_inputs['original_thought'] # For logging & post-processing
         processing_context_data = triaged_inputs.get('processing_context') # Define this at the start of the method
 
-        llm_service = None
-        if self.service_registry:
-            llm_service = await self.service_registry.get_service(
-                handler=self.__class__.__name__,
-                service_type="llm"
-            )
+        llm_service = await self.get_llm_service()
         if not llm_service:
             raise RuntimeError("LLM service unavailable for ActionSelectionPDMA")
 

--- a/ciris_engine/dma/base_dma.py
+++ b/ciris_engine/dma/base_dma.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import instructor
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from pydantic import BaseModel
+
+from ciris_engine.registries.base import ServiceRegistry
+from ciris_engine.protocols.services import LLMService
+
+
+class BaseDMA(ABC):
+    """Abstract base class for Decision Making Algorithms."""
+
+    def __init__(
+        self,
+        service_registry: ServiceRegistry,
+        model_name: Optional[str] = None,
+        max_retries: int = 3,
+        *,
+        instructor_mode: instructor.Mode = instructor.Mode.JSON,
+    ) -> None:
+        self.service_registry = service_registry
+        self.model_name = model_name
+        self.max_retries = max_retries
+        self.instructor_mode = instructor_mode
+
+    async def get_llm_service(self) -> LLMService:
+        """Return the LLM service for this DMA from the service registry."""
+        return await self.service_registry.get_service(
+            handler=self.__class__.__name__,
+            service_type="llm",
+        )
+
+    @abstractmethod
+    async def evaluate(self, *args, **kwargs) -> BaseModel:
+        """Execute DMA evaluation and return a pydantic model."""
+        raise NotImplementedError

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,20 @@
+import pytest
+
+from ciris_engine.registries.base import ServiceRegistry
+from ciris_engine.runtime.ciris_runtime import CIRISRuntime
+
+
+@pytest.fixture
+async def service_registry():
+    """Provide a configured service registry with mock services."""
+    registry = ServiceRegistry()
+    # Register mock services here when needed
+    return registry
+
+
+@pytest.fixture
+async def runtime(service_registry):
+    """Provide a CIRISRuntime instance using the service registry."""
+    runtime = CIRISRuntime()
+    runtime.service_registry = service_registry
+    return runtime

--- a/tests/integration/test_full_cycle.py
+++ b/tests/integration/test_full_cycle.py
@@ -1,0 +1,17 @@
+pytest_plugins = ("tests.fixtures",)
+import pytest
+
+from ciris_engine.runtime.ciris_runtime import CIRISRuntime
+from tests.fixtures import runtime
+
+
+@pytest.mark.asyncio
+async def test_full_thought_cycle(runtime: CIRISRuntime):
+    """Test complete thought processing cycle."""
+    # 1. Create task
+    # 2. Generate thought
+    # 3. Run DMAs
+    # 4. Apply guardrails
+    # 5. Execute action
+    # 6. Verify outcome
+    assert runtime.service_registry is not None


### PR DESCRIPTION
## Summary
- add reusable `service_registry` and `runtime` fixtures
- start new `tests/integration` suite with `test_full_cycle`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a528e8148832b91a908d725df9333