### PR TITLE
Add run scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,18 @@ export DISCORD_BOT_TOKEN="your_discord_bot_token_here"
 
 ## Running Agents
 
-Run the agent using the unified entry point. Specify the mode and profile as needed:
+Run the agent using the unified entry point or one of the convenience scripts. Specify the mode and profile as needed:
 
 ```bash
 python -m ciris_engine.main --mode discord --profile default
+```
+
+Convenience wrappers are also provided:
+
+```bash
+python run_discord.py --profile teacher  # Discord runtime
+python run_cli.py --profile default      # Interactive CLI
+python run_api.py --profile default      # API server
 ```
 
 Use `--mode cli` for a local command-line interface or `--mode api` for the API runtime. Enable debug logging with `--debug`.

--- a/run_api.py
+++ b/run_api.py
@@ -1,0 +1,16 @@
+import asyncio
+from typing import Optional
+import click
+from ciris_engine.main import main as engine_main
+
+@click.command()
+@click.option("--profile", default="default", help="Agent profile name")
+@click.option("--config", type=click.Path(exists=True), help="Path to app config")
+@click.option("--debug/--no-debug", default=False, help="Enable debug logging")
+def run(profile: str, config: Optional[str], debug: bool) -> None:
+    """Run the CIRIS Engine in API mode."""
+    asyncio.run(engine_main.callback(mode="api", profile=profile, config=config, debug=debug))
+
+
+if __name__ == "__main__":
+    run()

--- a/run_cli.py
+++ b/run_cli.py
@@ -1,0 +1,16 @@
+import asyncio
+from typing import Optional
+import click
+from ciris_engine.main import main as engine_main
+
+@click.command()
+@click.option("--profile", default="default", help="Agent profile name")
+@click.option("--config", type=click.Path(exists=True), help="Path to app config")
+@click.option("--debug/--no-debug", default=False, help="Enable debug logging")
+def run(profile: str, config: Optional[str], debug: bool) -> None:
+    """Run the CIRIS Engine in CLI mode."""
+    asyncio.run(engine_main.callback(mode="cli", profile=profile, config=config, debug=debug))
+
+
+if __name__ == "__main__":
+    run()

--- a/run_discord.py
+++ b/run_discord.py
@@ -1,0 +1,16 @@
+import asyncio
+from typing import Optional
+import click
+from ciris_engine.main import main as engine_main
+
+@click.command()
+@click.option("--profile", default="default", help="Agent profile name")
+@click.option("--config", type=click.Path(exists=True), help="Path to app config")
+@click.option("--debug/--no-debug", default=False, help="Enable debug logging")
+def run(profile: str, config: Optional[str], debug: bool) -> None:
+    """Run the CIRIS Engine in Discord mode."""
+    asyncio.run(engine_main.callback(mode="discord", profile=profile, config=config, debug=debug))
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/ciris_engine/runtime/test_api_runtime.py
+++ b/tests/ciris_engine/runtime/test_api_runtime.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from ciris_engine.runtime.api_runtime import APIRuntime
+from ciris_engine.runtime.runtime_interface import RuntimeInterface
 
 @pytest.mark.asyncio
 async def test_api_runtime_initialization_calls_register(monkeypatch):


### PR DESCRIPTION
## Summary
- add `run_discord.py`, `run_cli.py` and `run_api.py` wrappers
- explain new scripts in the README
- import `RuntimeInterface` in API runtime test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a6d4d4118832b96a48f7693df8ea1