### PR TITLE
Fix environment variable loading for Discord mode

### DIFF
--- a/ciris_engine/main.py
+++ b/ciris_engine/main.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from typing import Optional
 
 import click
+from dotenv import load_dotenv
+
+load_dotenv()
 
 from .utils.logging_config import setup_basic_logging
 from .config.config_manager import load_config_from_file_async, AppConfig


### PR DESCRIPTION
## Summary
- load `.env` file automatically in `ciris_engine.main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a7602fdc0832b9fac86c0adc00dcd