### PR TITLE
Extend mock LLM for offline wakeup

### DIFF
--- a/ciris_engine/runtime/cli_runtime.py
+++ b/ciris_engine/runtime/cli_runtime.py
@@ -77,9 +77,12 @@ class CLIRuntime(CIRISRuntime):
         self.deferral_sink_task = asyncio.create_task(self.deferral_sink.start())
 
         logger.info("Starting agent processing with WAKEUP sequence...")
-        processing_task = asyncio.create_task(
-            self.agent_processor.start_processing(num_rounds=self.app_config.workflow.max_rounds)
-        )
+        if self.agent_processor:
+            asyncio.create_task(
+                self.agent_processor.start_processing(
+                    num_rounds=self.app_config.workflow.max_rounds
+                )
+            )
 
     async def _handle_observe_event(self, payload: Dict[str, Any]):
         """Enhanced observe event handling with CLI context"""

--- a/tests/adapters/mock_llm_service.py
+++ b/tests/adapters/mock_llm_service.py
@@ -6,13 +6,18 @@ from ciris_engine.schemas.dma_results_v1 import (
     EthicalDMAResult,
     CSDMAResult,
     DSDMAResult,
-    ActionSelectionResult, # Added import
+    ActionSelectionResult,
 )
 from ciris_engine.schemas.action_params_v1 import PonderParams # Added import
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType # Added import
 from ciris_engine.schemas.feedback_schemas_v1 import (
     OptimizationVetoResult,
     EpistemicHumilityResult,
+)
+from ciris_engine.dma.dsdma_base import BaseDSDMA
+from ciris_engine.schemas.epistemic_schemas_v1 import (
+    EntropyResult,
+    CoherenceResult,
 )
 
 
@@ -36,6 +41,17 @@ class MockLLMClient:
             return CSDMAResult(plausibility_score=0.9, flags=[])
         if response_model is DSDMAResult:
             return DSDMAResult(domain="mock", alignment_score=0.9, flags=[])
+        if response_model is BaseDSDMA.LLMOutputForDSDMA:
+            result = BaseDSDMA.LLMOutputForDSDMA(
+                domain_alignment_score=1.0,
+                recommended_action="proceed",
+                flags=[],
+                reasoning="mock",
+            )
+            # Mimic instructor's extra attributes
+            object.__setattr__(result, "finish_reason", "stop")
+            object.__setattr__(result, "_raw_response", {"mock": True})
+            return result
         if response_model is OptimizationVetoResult:
             return OptimizationVetoResult(
                 decision="proceed",
@@ -58,8 +74,12 @@ class MockLLMClient:
                 action_parameters=PonderParams(questions=["Mock LLM: What should I do next?"]).model_dump(mode='json'),
                 rationale="Mock LLM default action selection.",
                 confidence=0.9,
-                raw_llm_response={"mock_data": "ActionSelectionResult from MockLLM"}
+                raw_llm_response="ActionSelectionResult from MockLLM"
             )
+        if response_model is EntropyResult:
+            return EntropyResult(entropy=0.1)
+        if response_model is CoherenceResult:
+            return CoherenceResult(coherence=0.9)
         return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="OK"))])
 
 

--- a/tests/adapters/test_mock_llm_service.py
+++ b/tests/adapters/test_mock_llm_service.py
@@ -1,0 +1,20 @@
+import pytest
+from tests.adapters.mock_llm_service import MockLLMClient
+from ciris_engine.schemas.dma_results_v1 import EthicalDMAResult, CSDMAResult, ActionSelectionResult
+from ciris_engine.schemas.feedback_schemas_v1 import OptimizationVetoResult, EpistemicHumilityResult
+from ciris_engine.dma.dsdma_base import BaseDSDMA
+from ciris_engine.schemas.epistemic_schemas_v1 import EntropyResult, CoherenceResult
+
+@pytest.mark.asyncio
+async def test_mock_llm_structured_outputs():
+    client = MockLLMClient()
+    assert isinstance(await client._create(response_model=EthicalDMAResult), EthicalDMAResult)
+    assert isinstance(await client._create(response_model=CSDMAResult), CSDMAResult)
+    dsdma = await client._create(response_model=BaseDSDMA.LLMOutputForDSDMA)
+    assert isinstance(dsdma, BaseDSDMA.LLMOutputForDSDMA)
+    assert hasattr(dsdma, "finish_reason")
+    assert isinstance(await client._create(response_model=ActionSelectionResult), ActionSelectionResult)
+    assert isinstance(await client._create(response_model=OptimizationVetoResult), OptimizationVetoResult)
+    assert isinstance(await client._create(response_model=EpistemicHumilityResult), EpistemicHumilityResult)
+    assert isinstance(await client._create(response_model=EntropyResult), EntropyResult)
+    assert isinstance(await client._create(response_model=CoherenceResult), CoherenceResult)

--- a/tests/test_cli_wakeup_offline.py
+++ b/tests/test_cli_wakeup_offline.py
@@ -1,0 +1,118 @@
+import asyncio
+from unittest.mock import AsyncMock
+import pytest
+
+import main
+from ciris_engine.runtime.cli_runtime import CLIRuntime
+from tests.adapters.mock_llm_service import MockLLMService
+from ciris_engine.schemas.config_schemas_v1 import AppConfig, WorkflowConfig, LLMServicesConfig, OpenAIConfig
+from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus, ThoughtStatus
+
+class MemoryDB:
+    def __init__(self):
+        self.tasks = {}
+        self.thoughts = {}
+
+    def add_task(self, task):
+        self.tasks[task.task_id] = task
+
+    def task_exists(self, task_id):
+        return task_id in self.tasks
+
+    def get_task_by_id(self, task_id):
+        return self.tasks.get(task_id)
+
+    def update_task_status(self, task_id, status, **kwargs):
+        t = self.tasks.get(task_id)
+        if not t:
+            return False
+        self.tasks[task_id] = t.model_copy(update={"status": status})
+        return True
+
+    def get_pending_tasks_for_activation(self, limit=10):
+        return [t for t in self.tasks.values() if t.status == TaskStatus.PENDING][:limit]
+
+    def count_active_tasks(self):
+        return len([t for t in self.tasks.values() if t.status == TaskStatus.ACTIVE])
+
+    def get_tasks_needing_seed_thought(self, limit=50):
+        return [t for t in self.tasks.values() if t.status == TaskStatus.ACTIVE and not self.thought_exists_for(t.task_id)][:limit]
+
+    def add_thought(self, thought):
+        self.thoughts[thought.thought_id] = thought
+
+    def thought_exists_for(self, task_id):
+        return any(th.source_task_id == task_id for th in self.thoughts.values())
+
+    def get_pending_thoughts_for_active_tasks(self, limit=50):
+        active_ids = {t.task_id for t in self.tasks.values() if t.status == TaskStatus.ACTIVE}
+        pending = [th for th in self.thoughts.values() if th.status == ThoughtStatus.PENDING and th.source_task_id in active_ids]
+        return pending[:limit]
+
+    def get_tasks_by_parent_id(self, parent_id):
+        return [t for t in self.tasks.values() if getattr(t, 'parent_task_id', None) == parent_id]
+
+    def get_thoughts_by_task_id(self, task_id):
+        return [th for th in self.thoughts.values() if th.source_task_id == task_id]
+
+    def update_thought_status(self, thought_id, status, **kwargs):
+        th = self.thoughts.get(thought_id)
+        if not th:
+            return False
+        self.thoughts[thought_id] = th.model_copy(update={"status": status})
+        return True
+
+    def pending_thoughts(self):
+        return [th for th in self.thoughts.values() if th.status == ThoughtStatus.PENDING]
+
+    def count_pending_thoughts_for_active_tasks(self):
+        return len(self.get_pending_thoughts_for_active_tasks())
+
+def patch_persistence(monkeypatch, db: MemoryDB):
+    monkeypatch.setattr('ciris_engine.persistence.task_exists', db.task_exists)
+    monkeypatch.setattr('ciris_engine.persistence.add_task', db.add_task)
+    monkeypatch.setattr('ciris_engine.persistence.get_task_by_id', db.get_task_by_id)
+    monkeypatch.setattr('ciris_engine.persistence.update_task_status', db.update_task_status)
+    monkeypatch.setattr('ciris_engine.persistence.get_pending_tasks_for_activation', db.get_pending_tasks_for_activation, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.count_active_tasks', db.count_active_tasks, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.get_tasks_needing_seed_thought', db.get_tasks_needing_seed_thought, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.add_thought', db.add_thought)
+    monkeypatch.setattr('ciris_engine.persistence.thought_exists_for', db.thought_exists_for, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.get_pending_thoughts_for_active_tasks', db.get_pending_thoughts_for_active_tasks)
+    monkeypatch.setattr('ciris_engine.persistence.update_thought_status', db.update_thought_status)
+    monkeypatch.setattr('ciris_engine.persistence.pending_thoughts', db.pending_thoughts, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.count_pending_thoughts_for_active_tasks', db.count_pending_thoughts_for_active_tasks, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.get_thoughts_by_task_id', db.get_thoughts_by_task_id)
+    monkeypatch.setattr('ciris_engine.persistence.get_tasks_by_parent_id', db.get_tasks_by_parent_id, raising=False)
+    monkeypatch.setattr('ciris_engine.persistence.initialize_database', lambda: None)
+
+def create_test_runtime(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'x')
+    monkeypatch.setattr('ciris_engine.runtime.ciris_runtime.OpenAICompatibleLLM', MockLLMService)
+    config = AppConfig(workflow=WorkflowConfig(max_rounds=1), llm_services=LLMServicesConfig(openai=OpenAIConfig(model_name='mock-model')))
+    runtime = CLIRuntime(profile_name='default', interactive=False)
+    return runtime, config
+
+@pytest.mark.asyncio
+async def test_wakeup_sequence_offline(monkeypatch):
+    db = MemoryDB()
+    patch_persistence(monkeypatch, db)
+    runtime, cfg = create_test_runtime(monkeypatch)
+    monkeypatch.setattr(main, 'load_config', AsyncMock(return_value=cfg))
+    monkeypatch.setattr(main, 'create_runtime', lambda *a, **k: runtime)
+    await runtime.initialize()
+    result = await runtime.agent_processor.wakeup_processor.process_wakeup(0, non_blocking=True)
+    assert result['status'] == 'in_progress'
+    for t in runtime.agent_processor.wakeup_processor.wakeup_tasks[1:]:
+        db.update_task_status(t.task_id, TaskStatus.COMPLETED)
+    result = await runtime.agent_processor.wakeup_processor.process_wakeup(1, non_blocking=True)
+    assert result['wakeup_complete']
+
+@pytest.mark.asyncio
+async def test_run_runtime_timeout(monkeypatch):
+    runtime = AsyncMock()
+    runtime.run = AsyncMock(side_effect=asyncio.sleep(0.2))
+    runtime.shutdown = AsyncMock()
+    await main._run_runtime(runtime, timeout=0.1)
+    runtime.run.assert_awaited()
+    runtime.shutdown.assert_awaited()


### PR DESCRIPTION
## Summary
- extend the mock LLM client with more structured response types so wakeup can run offline
- start agent processing only when the processor exists in `CLIRuntime`
- add unit tests for the mock LLM
- add tests covering the wakeup processor with mock LLM and `_run_runtime` timeout logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b4ba08f00832bb6b75dc76cc11342