### PR TITLE
Fix observer registry usage

### DIFF
--- a/ciris_engine/action_handlers/observe_handler.py
+++ b/ciris_engine/action_handlers/observe_handler.py
@@ -22,13 +22,6 @@ logger = logging.getLogger(__name__)
 
 
 class ObserveHandler(BaseActionHandler):
-    async def get_communication_service(self) -> Optional[CommunicationService]:
-        """Get communication service with both send_message and fetch_messages capabilities for active observation"""
-        return await self.dependencies.get_service(
-            self.__class__.__name__,
-            "communication",
-            required_capabilities=["send_message", "fetch_messages"]
-        )
 
     async def _recall_from_messages(
         self,
@@ -115,7 +108,7 @@ class ObserveHandler(BaseActionHandler):
         params.channel_id = channel_id
 
         # Get services with better logging
-        comm_service = await self.get_communication_service()
+        comm_service = await self.get_communication_service(["fetch_messages"])
         logger.debug(f"ObserveHandler: Got communication service: {type(comm_service).__name__ if comm_service else 'None'}")
         
         observer_service = await self.get_observer_service()
@@ -204,10 +197,3 @@ class ObserveHandler(BaseActionHandler):
             )
             raise FollowUpCreationError from e
 
-    async def get_communication_service(self) -> Optional[CommunicationService]:
-        """Get communication service with both send_message and fetch_messages capabilities for active observation"""
-        return await self.dependencies.get_service(
-            self.__class__.__name__,
-            "communication",
-            required_capabilities=["send_message", "fetch_messages"]
-        )

--- a/tests/ciris_engine/action_handlers/test_handler_followup_persistence.py
+++ b/tests/ciris_engine/action_handlers/test_handler_followup_persistence.py
@@ -82,8 +82,13 @@ async def test_handler_creates_followup_persistence(handler_cls, params, result_
         deps.memory_service.forget = AsyncMock(return_value=MagicMock(status="OK"))
         deps.memory_service.memorize = AsyncMock(return_value=MagicMock(status="SAVED"))
         deps.action_sink = AsyncMock()
-        deps.audit_service = MagicMock()
-        deps.audit_service.log_action = AsyncMock()
+        audit_service = MagicMock()
+        audit_service.log_action = AsyncMock()
+        async def get_service(handler, service_type, **kwargs):
+            if service_type == "audit":
+                return audit_service
+            return None
+        deps.get_service = AsyncMock(side_effect=get_service)
         handler_mod = importlib.import_module(handler_cls.__module__)
         # Patch strategy: if module has 'persistence', patch it; else patch deps.persistence
         patch_module = hasattr(handler_mod, 'persistence')

--- a/tests/ciris_engine/action_handlers/test_remaining_handlers.py
+++ b/tests/ciris_engine/action_handlers/test_remaining_handlers.py
@@ -211,7 +211,15 @@ async def test_tool_handler_schema_driven(monkeypatch):
             return True
 
     deps = ActionHandlerDependencies()
-    deps.get_service = AsyncMock(return_value=DummyToolService())
+    audit_service = MagicMock()
+    audit_service.log_action = AsyncMock()
+    async def get_service(handler, service_type, **kwargs):
+        if service_type == "tool":
+            return DummyToolService()
+        if service_type == "audit":
+            return audit_service
+        return None
+    deps.get_service = AsyncMock(side_effect=get_service)
     handler = ToolHandler(deps)
 
     params = ToolParams(name="echo", args={})

--- a/tests/test_memory_handlers.py
+++ b/tests/test_memory_handlers.py
@@ -9,9 +9,12 @@ def test_memorize_handler_with_new_schema(monkeypatch):
     memory_service = Mock()
     memory_service.memorize = AsyncMock(return_value=Mock(status=Mock(value="ok")))
     deps = ActionHandlerDependencies()
-    deps.get_service = AsyncMock(return_value=memory_service)
+    async def get_service(handler, service_type, **kwargs):
+        if service_type == "memory":
+            return memory_service
+        return None
+    deps.get_service = AsyncMock(side_effect=get_service)
     deps.memory_service = memory_service
-    deps.audit_service = None
     # Patch persistence functions and helper
     monkeypatch.setattr("ciris_engine.persistence.update_thought_status", Mock())
     monkeypatch.setattr("ciris_engine.persistence.add_thought", Mock())
@@ -42,9 +45,12 @@ def test_memorize_handler_with_old_schema(monkeypatch):
     memory_service = Mock()
     memory_service.memorize = AsyncMock(return_value=Mock(status=Mock(value="ok")))
     deps = ActionHandlerDependencies()
-    deps.get_service = AsyncMock(return_value=memory_service)
+    async def get_service(handler, service_type, **kwargs):
+        if service_type == "memory":
+            return memory_service
+        return None
+    deps.get_service = AsyncMock(side_effect=get_service)
     deps.memory_service = memory_service
-    deps.audit_service = None
     monkeypatch.setattr("ciris_engine.persistence.update_thought_status", Mock())
     monkeypatch.setattr("ciris_engine.persistence.add_thought", Mock())
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- remove direct `DiscordObserver` from base handler
- require audit service via registry
- allow BaseActionHandler.get_communication_service to request extra capabilities
- update ObserveHandler to request `fetch_messages`
- adjust tests for new audit service lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b6a791248832bb738cd91b8575688