### PR TITLE
Add runtime service registry tests

### DIFF
--- a/tests/ciris_engine/runtime/test_api_service_registry.py
+++ b/tests/ciris_engine/runtime/test_api_service_registry.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from ciris_engine.runtime.api_runtime import APIRuntime
+
+
+@pytest.mark.asyncio
+async def test_api_service_registry(monkeypatch):
+    """Ensure APIRuntime registers expected services."""
+    monkeypatch.setattr(
+        "ciris_engine.adapters.openai_compatible_llm.OpenAICompatibleLLM.start",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "ciris_engine.adapters.openai_compatible_llm.OpenAICompatibleLLM.get_client",
+        MagicMock(return_value=MagicMock(instruct_client=None, client=None, model_name="test")),
+    )
+    monkeypatch.setattr(
+        "ciris_engine.runtime.ciris_runtime.CIRISRuntime._build_components",
+        AsyncMock(),
+    )
+    monkeypatch.setattr("ciris_engine.adapters.api.api_observer.APIObserver.start", AsyncMock())
+
+    runtime = APIRuntime(profile_name="default")
+    runtime.api_tool_service = MagicMock()
+    await runtime.initialize()
+
+    info = runtime.service_registry.get_provider_info()
+    handlers = info.get("handlers", {})
+
+    # Communication service
+    comm = handlers.get("SpeakHandler", {}).get("communication", [])
+    assert any(p["name"].startswith("APIAdapter") for p in comm)
+
+    # Wise authority service
+    wa = handlers.get("SpeakHandler", {}).get("wise_authority", [])
+    assert any(p["name"].startswith("APIAdapter") for p in wa)
+
+    # Tool service
+    tool = handlers.get("ToolHandler", {}).get("tool", [])
+    assert any(p["name"].startswith("MagicMock") for p in tool)
+
+    await runtime.shutdown()

--- a/tests/ciris_engine/runtime/test_cli_service_registry.py
+++ b/tests/ciris_engine/runtime/test_cli_service_registry.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from ciris_engine.runtime.cli_runtime import CLIRuntime
+
+
+@pytest.mark.asyncio
+async def test_cli_service_registry(monkeypatch):
+    """Ensure CLIRuntime registers expected services."""
+    monkeypatch.setattr(
+        "ciris_engine.adapters.openai_compatible_llm.OpenAICompatibleLLM.start",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "ciris_engine.adapters.openai_compatible_llm.OpenAICompatibleLLM.get_client",
+        MagicMock(return_value=MagicMock(model_name="test", instruct_client=None, client=None)),
+    )
+    monkeypatch.setattr(
+        "ciris_engine.runtime.ciris_runtime.CIRISRuntime._build_components",
+        AsyncMock(),
+    )
+    monkeypatch.setattr("ciris_engine.runtime.cli_runtime.CLIObserver.start", AsyncMock())
+    monkeypatch.setattr("ciris_engine.runtime.cli_runtime.CLIAdapter.start", AsyncMock())
+    monkeypatch.setattr("ciris_engine.runtime.cli_runtime.MultiServiceActionSink.start", AsyncMock())
+    monkeypatch.setattr("ciris_engine.runtime.cli_runtime.MultiServiceDeferralSink.start", AsyncMock())
+
+    runtime = CLIRuntime(profile_name="default", interactive=False)
+    await runtime.initialize()
+
+    info = runtime.service_registry.get_provider_info()
+    handlers = info.get("handlers", {})
+
+    # Check communication service registration
+    speak_comm = handlers.get("SpeakHandler", {}).get("communication", [])
+    assert any(p["name"].startswith("CLIAdapter") for p in speak_comm)
+
+    # Observer service
+    observe_observers = handlers.get("ObserveHandler", {}).get("observer", [])
+    assert any(p["name"].startswith("CLIObserver") for p in observe_observers)
+
+    # Tool service
+    tool_services = handlers.get("ToolHandler", {}).get("tool", [])
+    assert any(p["name"].startswith("CLIToolService") for p in tool_services)
+
+    # Wise authority service
+    wa_services = handlers.get("DeferHandler", {}).get("wise_authority", [])
+    assert any(p["name"].startswith("CLIWiseAuthorityService") for p in wa_services)
+
+    await runtime.shutdown()

--- a/tests/live/test_discord_service_registry_live.py
+++ b/tests/live/test_discord_service_registry_live.py
@@ -1,0 +1,35 @@
+import os
+import pytest
+
+from ciris_engine.runtime.discord_runtime import DiscordRuntime
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_discord_runtime_service_registry_live():
+    """Connect to Discord and verify handler service registrations."""
+    token = os.getenv("DISCORD_BOT_TOKEN")
+    channel = os.getenv("DISCORD_CHANNEL_ID")
+    if not token or not channel:
+        pytest.skip("Discord credentials not provided")
+
+    runtime = DiscordRuntime(token=token, startup_channel_id=channel)
+    await runtime.initialize()
+
+    info = runtime.service_registry.get_provider_info()
+    handlers = info.get("handlers", {})
+
+    expected_handlers = [
+        "SpeakHandler",
+        "ObserveHandler",
+        "ToolHandler",
+        "DeferHandler",
+        "MemorizeHandler",
+        "RecallHandler",
+        "TaskCompleteHandler",
+    ]
+
+    for handler in expected_handlers:
+        assert handler in handlers, f"{handler} missing in registry"
+
+    await runtime.shutdown()


### PR DESCRIPTION
## Summary
- add live Discord runtime test placeholder
- ensure CLI runtime registers adapter, observer, tool, and WA services
- ensure API runtime registers adapter and tool services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b6e6054a0832b8f85263a4a67bf82