### PR TITLE
Fix observer routing via action sink

### DIFF
--- a/ciris_engine/runtime/api_runtime.py
+++ b/ciris_engine/runtime/api_runtime.py
@@ -92,6 +92,17 @@ class APIRuntime(CIRISRuntime):
 
     async def _handle_observe_event(self, payload: Dict[str, Any]):
         logger.debug("API runtime received observe event: %s", payload)
+
+        sink = self.multi_service_sink
+        if not sink:
+            logger.warning("No action sink available for API observe payload")
+            return None
+
+        channel_id = payload.get("context", {}).get("channel_id", "api")
+        content = payload.get("content", "")
+        metadata = {"observer_payload": payload}
+
+        await sink.send_message("ObserveHandler", str(channel_id), content, metadata)
         return None
 
     async def _register_api_services(self):


### PR DESCRIPTION
## Summary
- forward discord observer events through `MultiServiceActionSink`
- do the same for API runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bc25a9760832b8958996f0b91f244