### PR TITLE
Fix CLI dispatcher registration

### DIFF
--- a/ciris_engine/runtime/api_runtime.py
+++ b/ciris_engine/runtime/api_runtime.py
@@ -1,6 +1,4 @@
 """API runtime implementation for REST interfaces."""
-import asyncio
-import json
 import logging
 import uuid
 from typing import Optional, Dict, Any
@@ -140,7 +138,8 @@ class APIRuntime(CIRISRuntime):
     async def _build_action_dispatcher(self, dependencies):
         return build_action_dispatcher(
             service_registry=self.service_registry,
-            max_rounds=self.app_config.workflow.max_rounds
+            max_rounds=self.app_config.workflow.max_rounds,
+            shutdown_callback=dependencies.shutdown_callback
         )
 
     async def run(self, max_rounds: Optional[int] = None):

--- a/ciris_engine/runtime/cli_runtime.py
+++ b/ciris_engine/runtime/cli_runtime.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import asyncio
 from typing import Optional, Dict, Any
 
@@ -140,12 +139,9 @@ class CLIRuntime(CIRISRuntime):
 
     async def _build_action_dispatcher(self, dependencies):
         return build_action_dispatcher(
-            audit_service=self.audit_service,
+            service_registry=self.service_registry,
             max_rounds=self.app_config.workflow.max_rounds,
-            action_sink=self.action_sink,
-            memory_service=self.memory_service,
-            observer_service=self.cli_observer,
-            io_adapter=self.cli_adapter,
+            shutdown_callback=dependencies.shutdown_callback,
         )
 
     async def shutdown(self):

--- a/ciris_engine/runtime/discord_runtime.py
+++ b/ciris_engine/runtime/discord_runtime.py
@@ -11,7 +11,6 @@ import asyncio
 import discord
 
 from ciris_engine.runtime.ciris_runtime import CIRISRuntime
-from ciris_engine.adapters.discord.discord_adapter import DiscordAdapter
 from ciris_engine.schemas.foundational_schemas_v1 import IncomingMessage
 from ciris_engine.adapters.discord.discord_adapter import DiscordAdapter, DiscordEventQueue
 from ciris_engine.adapters.discord.discord_observer import DiscordObserver
@@ -26,7 +25,7 @@ from ciris_engine.adapters.cli.cli_tools import CLIToolService
 
 # Import multi-service sink components
 from ciris_engine.sinks import MultiServiceActionSink
-from ciris_engine.registries.base import ServiceRegistry, Priority
+from ciris_engine.registries.base import Priority
 from ciris_engine.adapters import CIRISNodeClient
 
 logger = logging.getLogger(__name__)
@@ -78,7 +77,7 @@ class DiscordRuntime(CIRISRuntime):
 
         # Create action sink using MultiServiceActionSink
         if not self.service_registry:
-            logger.error("ServiceRegistry not initialized before creating MultiServiceActionSink.")
+            logger.error("Service registry not initialized before creating MultiServiceActionSink.")
             # Potentially raise an error or handle appropriately
             # For now, we'll proceed, but this is a critical dependency
         self.action_sink = MultiServiceActionSink(
@@ -224,7 +223,6 @@ class DiscordRuntime(CIRISRuntime):
                     )
                 logger.info("Registered CLI adapter as fallback communication service")
             
-            # CRITICAL FIX: Register Discord observer service
             if self.discord_observer:
                 self.service_registry.register(
                     handler="ObserveHandler",


### PR DESCRIPTION
## Summary
- fix service registration order in `CLIRuntime._build_action_dispatcher`
- ensure API runtime includes shutdown callback when building dispatchers
- clean unused imports and stale comments across runtimes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bce3a32b4832ba40da33a2f27395f