### PR TITLE
Purge DiscordEventQueue

### DIFF
--- a/tests/ciris_engine/adapters/discord/test_discord_adapter.py
+++ b/tests/ciris_engine/adapters/discord/test_discord_adapter.py
@@ -1,32 +1,11 @@
 import pytest
 import asyncio
-from ciris_engine.adapters.discord.discord_adapter import DiscordAdapter, DiscordEventQueue
-
-@pytest.mark.asyncio
-async def test_discord_event_queue_basic_operations():
-    """Test basic queue operations work correctly."""
-    q = DiscordEventQueue(maxsize=2)
-    
-    # Test enqueue/dequeue
-    await q.enqueue("event1")
-    assert not q.empty()
-    event = await q.dequeue()
-    assert event == "event1"
-    assert q.empty()
-    
-    # Test nowait operations
-    q.enqueue_nowait("event2")
-    assert not q.empty()
-    event = await q.dequeue()
-    assert event == "event2"
-    assert q.empty()
+from ciris_engine.adapters.discord.discord_adapter import DiscordAdapter
 
 @pytest.mark.asyncio
 async def test_discord_adapter_initialization():
-    """Test that DiscordAdapter can be initialized with a message queue."""
-    q = DiscordEventQueue()
-    adapter = DiscordAdapter("fake_token", q)
-    
+    """Test that DiscordAdapter can be initialized without a queue."""
+    adapter = DiscordAdapter("fake_token")
+
     assert adapter.token == "fake_token"
-    assert adapter.message_queue is q
     assert adapter.client is None

--- a/tests/ciris_engine/services/test_discord_observer.py
+++ b/tests/ciris_engine/services/test_discord_observer.py
@@ -1,9 +1,0 @@
-import pytest
-from unittest.mock import AsyncMock, MagicMock
-from ciris_engine.adapters.discord.discord_observer import DiscordObserver
-
-@pytest.mark.asyncio
-async def test_handle_incoming_message_skips_non_incoming():
-    observer = DiscordObserver(lambda x: None, MagicMock())
-    await observer.handle_incoming_message("not_a_msg")
-    # Should log a warning and return

--- a/tests/test_discord_cli_failover.py
+++ b/tests/test_discord_cli_failover.py
@@ -49,12 +49,7 @@ async def test_discord_runtime_cli_fallback(monkeypatch):
         "ciris_engine.runtime.ciris_runtime.CIRISRuntime._build_components",
         AsyncMock(),
     )
-    monkeypatch.setattr(
-        "ciris_engine.runtime.discord_runtime.DiscordObserver.start", AsyncMock()
-    )
-    monkeypatch.setattr(
-        "ciris_engine.runtime.discord_runtime.CLIObserver.start", AsyncMock()
-    )
+    # Observers have been removed; no start methods to patch
     monkeypatch.setattr(
         "ciris_engine.runtime.discord_runtime.CLIAdapter.start", AsyncMock()
     )


### PR DESCRIPTION
## Summary
- remove DiscordEventQueue from discord adapter
- update Discord runtime to process messages directly via callback
- drop discord observer test
- adjust tests for new adapter API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bd2c0a564832ba73efc5cb776dddc