### PR TITLE
Fix observation routing

### DIFF
--- a/ciris_engine/runtime/discord_runtime.py
+++ b/ciris_engine/runtime/discord_runtime.py
@@ -173,7 +173,15 @@ class DiscordRuntime(CIRISRuntime):
         content = payload.get("content", "")
         metadata = {"observer_payload": payload}
 
-        await sink.send_message("ObserveHandler", str(channel_id), content, metadata)
+        message = IncomingMessage(
+            message_id=str(payload.get("message_id")),
+            author_id=str(payload.get("context", {}).get("author_id", "unknown")),
+            author_name=str(payload.get("context", {}).get("author_name", "unknown")),
+            content=content,
+            channel_id=str(channel_id),
+        )
+
+        await sink.observe_message("ObserveHandler", message, metadata)
         return None
         
     async def _build_action_dispatcher(self, dependencies):


### PR DESCRIPTION
## Notes
- Reworked observe event handlers in both CLIRuntime and DiscordRuntime to forward incoming messages via the `observe_message` method of `MultiServiceActionSink` rather than echoing them back as sent messages.

## Summary
- Fixed observer routing by building an `IncomingMessage` object and invoking `observe_message` in `DiscordRuntime`.
- Forwarded CLI observation events through the multi service sink to the observer queue.

All tests pass:
```
pytest -q
```


------
https://chatgpt.com/codex/tasks/task_e_683bdaa25cac832ba0a0740d717a864e