### PR TITLE
Remove legacy action sink usages

### DIFF
--- a/ciris_engine/action_handlers/reject_handler.py
+++ b/ciris_engine/action_handlers/reject_handler.py
@@ -78,12 +78,9 @@ class RejectHandler(BaseActionHandler):
                     try:
                         await comm_service.send_message(original_event_channel_id, f"Unable to proceed: {params.reason}")
                     except Exception as e:
-                        self.logger.error(f"Failed to send REJECT notification via communication service for thought {thought_id}: {e}")
-                elif self.dependencies.action_sink:
-                    try:
-                        await self.dependencies.action_sink.send_message(self.__class__.__name__, original_event_channel_id, f"Unable to proceed: {params.reason}")
-                    except Exception as e:
-                        self.logger.error(f"Failed to send REJECT notification to channel {original_event_channel_id} for thought {thought_id}: {e}")
+                        self.logger.error(
+                            f"Failed to send REJECT notification via communication service for thought {thought_id}: {e}"
+                        )
         # v1 uses 'final_action' instead of 'final_action_result'
         result_data = result.model_dump() if hasattr(result, 'model_dump') else result
         persistence.update_thought_status(

--- a/ciris_engine/schemas/__init__.py
+++ b/ciris_engine/schemas/__init__.py
@@ -1,0 +1,19 @@
+from .agent_core_schemas_v1 import Task, Thought
+from .action_params_v1 import *
+from .dma_results_v1 import *
+from .foundational_schemas_v1 import *
+from .service_actions_v1 import *
+
+__all__ = [
+    'Task', 'Thought',
+    'ActionSelectionResult', 'EthicalDMAResult', 'CSDMAResult', 'DSDMAResult',
+    'HandlerActionType', 'TaskStatus', 'ThoughtStatus', 'ObservationSourceType', 'IncomingMessage',
+    # Action params
+    'ObserveParams', 'SpeakParams', 'ToolParams', 'PonderParams', 'RejectParams',
+    'DeferParams', 'MemorizeParams', 'RecallParams', 'ForgetParams',
+    # Service actions enums and dataclasses
+    'ActionType', 'ActionMessage', 'SendMessageAction', 'FetchMessagesAction',
+    'FetchGuidanceAction', 'SendDeferralAction', 'MemorizeAction', 'RecallAction',
+    'ForgetAction', 'SendToolAction', 'FetchToolAction', 'ObserveMessageAction',
+]
+

--- a/tests/ciris_engine/action_handlers/test_defer_handler.py
+++ b/tests/ciris_engine/action_handlers/test_defer_handler.py
@@ -10,11 +10,15 @@ from ciris_engine.action_handlers.base_handler import ActionHandlerDependencies
 
 @pytest.mark.asyncio
 async def test_defer_handler_schema_driven(monkeypatch):
-    action_sink = AsyncMock()
+    wa_service = AsyncMock()
     deps = ActionHandlerDependencies(
-        action_sink=action_sink,
         memory_service=MagicMock(),
     )
+    async def get_service(handler, service_type, **kwargs):
+        if service_type == "wise_authority":
+            return wa_service
+        return None
+    deps.get_service = AsyncMock(side_effect=get_service)
     handler = DeferHandler(deps)
 
     action_result = ActionSelectionResult(
@@ -45,8 +49,7 @@ async def test_defer_handler_schema_driven(monkeypatch):
 
     await handler.handle(action_result, thought, {"channel_id": "chan1", "source_task_id": "s1"})
 
-    action_sink.submit_deferral.assert_awaited()
-    assert "deferral_package" in action_sink.submit_deferral.call_args.args[3]
+    wa_service.send_deferral.assert_awaited_with("t1", "Need WA")
     update_thought.assert_called_once()
     assert update_thought.call_args.kwargs["status"] == ThoughtStatus.DEFERRED
     update_task.assert_called_once()

--- a/tests/ciris_engine/action_handlers/test_followup_thoughts.py
+++ b/tests/ciris_engine/action_handlers/test_followup_thoughts.py
@@ -18,7 +18,6 @@ async def test_speak_handler_creates_followup(monkeypatch):
     add_thought_mock = MagicMock()
     monkeypatch.setattr('ciris_engine.action_handlers.speak_handler.persistence.add_thought', add_thought_mock)
     deps = MagicMock()
-    deps.action_sink = AsyncMock()
     deps.persistence = MagicMock()
     deps.persistence.add_thought = add_thought_mock
     audit_service = MagicMock()
@@ -158,7 +157,6 @@ def test_ponder_handler_creates_followup(monkeypatch):
 async def test_task_complete_handler_no_followup():
     deps = MagicMock()
     deps.persistence = MagicMock()
-    deps.action_sink = AsyncMock()
     audit_service = MagicMock()
     audit_service.log_action = AsyncMock()
     async def get_service(handler, service_type, **kwargs):

--- a/tests/ciris_engine/action_handlers/test_handler_followup_persistence.py
+++ b/tests/ciris_engine/action_handlers/test_handler_followup_persistence.py
@@ -82,7 +82,6 @@ async def test_handler_creates_followup_persistence(handler_cls, params, result_
         deps.memory_service.recall = AsyncMock(return_value=MagicMock(status="OK", data="result"))
         deps.memory_service.forget = AsyncMock(return_value=MagicMock(status="OK"))
         deps.memory_service.memorize = AsyncMock(return_value=MagicMock(status="SAVED"))
-        deps.action_sink = AsyncMock()
         audit_service = MagicMock()
         audit_service.log_action = AsyncMock()
         async def get_service(handler, service_type, **kwargs):

--- a/tests/ciris_engine/adapters/cli/test_cli_runtime.py
+++ b/tests/ciris_engine/adapters/cli/test_cli_runtime.py
@@ -19,7 +19,7 @@ async def test_cli_runtime_initialization(monkeypatch):
         "ciris_engine.runtime.cli_runtime.CLIAdapter.start", AsyncMock()
     )
     monkeypatch.setattr(
-        "ciris_engine.runtime.cli_runtime.MultiServiceActionSink.start", AsyncMock()
+        "ciris_engine.sinks.multi_service_sink.MultiServiceActionSink.start", AsyncMock()
     )
 
     runtime = CLIRuntime(profile_name="test_profile", interactive=False)
@@ -38,7 +38,7 @@ async def test_cli_message_processing(monkeypatch):
     monkeypatch.setattr("ciris_engine.runtime.ciris_runtime.CIRISRuntime._build_components", AsyncMock())
     monkeypatch.setattr("ciris_engine.runtime.cli_runtime.CLIObserver.start", AsyncMock())
     monkeypatch.setattr("ciris_engine.runtime.cli_runtime.CLIAdapter.start", AsyncMock())
-    monkeypatch.setattr("ciris_engine.runtime.cli_runtime.MultiServiceActionSink.start", AsyncMock())
+    monkeypatch.setattr("ciris_engine.sinks.multi_service_sink.MultiServiceActionSink.start", AsyncMock())
 
     runtime = CLIRuntime(profile_name="default", interactive=False)
     await runtime.initialize()

--- a/tests/ciris_engine/processor/test_guardrail_bypass_prevention.py
+++ b/tests/ciris_engine/processor/test_guardrail_bypass_prevention.py
@@ -50,7 +50,6 @@ class TestGuardrailBypassPrevention:
     def mock_dependencies(self):
         """Create mock dependencies for testing."""
         deps = MagicMock(spec=ActionHandlerDependencies)
-        deps.action_sink = AsyncMock()
         deps.llm_client = AsyncMock()
         deps.memory_system = AsyncMock()
         return deps

--- a/tests/ciris_engine/runtime/test_cli_service_registry.py
+++ b/tests/ciris_engine/runtime/test_cli_service_registry.py
@@ -21,7 +21,7 @@ async def test_cli_service_registry(monkeypatch):
     )
     monkeypatch.setattr("ciris_engine.runtime.cli_runtime.CLIObserver.start", AsyncMock())
     monkeypatch.setattr("ciris_engine.runtime.cli_runtime.CLIAdapter.start", AsyncMock())
-    monkeypatch.setattr("ciris_engine.runtime.cli_runtime.MultiServiceActionSink.start", AsyncMock())
+    monkeypatch.setattr("ciris_engine.sinks.multi_service_sink.MultiServiceActionSink.start", AsyncMock())
 
     runtime = CLIRuntime(profile_name="default", interactive=False)
     await runtime.initialize()

--- a/tests/test_discord_cli_failover.py
+++ b/tests/test_discord_cli_failover.py
@@ -54,7 +54,7 @@ async def test_discord_runtime_cli_fallback(monkeypatch):
         "ciris_engine.runtime.discord_runtime.CLIAdapter.start", AsyncMock()
     )
     monkeypatch.setattr(
-        "ciris_engine.runtime.discord_runtime.MultiServiceActionSink.start", AsyncMock()
+        "ciris_engine.sinks.multi_service_sink.MultiServiceActionSink.start", AsyncMock()
     )
 
     runtime = DiscordRuntime(token="tok", profile_name="p", startup_channel_id="chan")

--- a/tests/test_memory_handlers.py
+++ b/tests/test_memory_handlers.py
@@ -14,7 +14,6 @@ def test_memorize_handler_with_new_schema(monkeypatch):
             return memory_service
         return None
     deps.get_service = AsyncMock(side_effect=get_service)
-    deps.memory_service = memory_service
     # Patch persistence functions and helper
     monkeypatch.setattr("ciris_engine.persistence.update_thought_status", Mock())
     monkeypatch.setattr("ciris_engine.persistence.add_thought", Mock())
@@ -39,7 +38,7 @@ def test_memorize_handler_with_new_schema(monkeypatch):
     asyncio.run(handler.handle(result, thought, {"channel_id": "test"}))
     
     # Verify memory service was called correctly
-    assert deps.memory_service.memorize.called
+    assert memory_service.memorize.called
 
 def test_memorize_handler_with_old_schema(monkeypatch):
     # Test backward compatibility
@@ -51,7 +50,6 @@ def test_memorize_handler_with_old_schema(monkeypatch):
             return memory_service
         return None
     deps.get_service = AsyncMock(side_effect=get_service)
-    deps.memory_service = memory_service
     monkeypatch.setattr("ciris_engine.persistence.update_thought_status", Mock())
     monkeypatch.setattr("ciris_engine.persistence.add_thought", Mock())
     monkeypatch.setattr(
@@ -71,4 +69,4 @@ def test_memorize_handler_with_old_schema(monkeypatch):
     thought = Mock(thought_id="test_thought", source_task_id="test_task")
     import asyncio
     asyncio.run(handler.handle(result, thought, {"channel_id": "test"}))
-    assert deps.memory_service.memorize.called
+    assert memory_service.memorize.called


### PR DESCRIPTION
## Summary
- remove deprecated `action_sink` hooks from handlers
- update runtimes to rely on shared multi-service sink
- add schema re-export module
- validate actions before routing
- update tests for new service registry approach

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c62a10394832ba3c2b4c17a2e6fb4