### PR TITLE
Implement SQLite migration runner

### DIFF
--- a/ciris_engine/persistence/README.md
+++ b/ciris_engine/persistence/README.md
@@ -1,3 +1,21 @@
 # persistence
 
 This module contains the persistence components of the CIRIS engine.
+
+## Database Migrations
+
+The persistence layer uses a very small migration system based on numbered SQL
+files located in `ciris_engine/persistence/migrations/`. On startup the runtime
+runs all pending migrations in order and records them in the `schema_migrations`
+table.
+
+To add a new migration:
+
+1. Create a new file in the migrations directory with a numeric prefix, e.g.
+   `003_new_feature.sql`.
+2. Write the SQL statements needed for the change. The file will be executed in
+   a single transaction.
+3. Incremental migrations will run automatically the next time the application
+   starts or when `initialize_database()` is called in tests.
+
+If a migration fails it is rolled back and the database remains unchanged.

--- a/ciris_engine/persistence/db.py
+++ b/ciris_engine/persistence/db.py
@@ -1,7 +1,12 @@
 import sqlite3
 import logging
 from ciris_engine.config.config_manager import get_sqlite_db_full_path
-from ciris_engine.schemas.db_tables_v1 import tasks_table_v1, thoughts_table_v1, feedback_mappings_table_v1
+from ciris_engine.schemas.db_tables_v1 import (
+    tasks_table_v1,
+    thoughts_table_v1,
+    feedback_mappings_table_v1,
+)
+from .migration_runner import run_migrations
 
 logger = logging.getLogger(__name__)
 
@@ -24,16 +29,14 @@ def get_feedback_mappings_table_schema_sql() -> str:
     return feedback_mappings_table_v1
 
 def initialize_database(db_path=None):
+    """Apply pending migrations to initialize or update the database."""
     try:
-        with get_db_connection(db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute(get_task_table_schema_sql())
-            cursor.execute(get_thought_table_schema_sql())
-            cursor.execute(get_feedback_mappings_table_schema_sql())
-            conn.commit()
-        logger.info(f"Database tables ensured at {db_path or get_sqlite_db_full_path()}")
+        run_migrations(db_path)
+        logger.info(
+            f"Database migrations applied at {db_path or get_sqlite_db_full_path()}"
+        )
     except sqlite3.Error as e:
-        logger.exception(f"Database error during table creation: {e}")
+        logger.exception(f"Database error during initialization: {e}")
         raise
 
 def get_all_tasks(db_path=None):

--- a/ciris_engine/persistence/migration_runner.py
+++ b/ciris_engine/persistence/migration_runner.py
@@ -1,0 +1,48 @@
+import logging
+from pathlib import Path
+import sqlite3
+
+logger = logging.getLogger(__name__)
+
+MIGRATIONS_DIR = Path(__file__).parent / "migrations"
+
+
+def _ensure_tracking_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            filename TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+
+def run_migrations(db_path: str | None = None) -> None:
+    """Apply pending migrations located in the migrations directory."""
+    from .db import get_db_connection
+
+    with get_db_connection(db_path) as conn:
+        _ensure_tracking_table(conn)
+        conn.commit()
+
+        migration_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
+        for file in migration_files:
+            name = file.name
+            cur = conn.execute(
+                "SELECT 1 FROM schema_migrations WHERE filename = ?", (name,)
+            )
+            if cur.fetchone():
+                continue
+            logger.info(f"Applying migration {name}")
+            sql = file.read_text()
+            try:
+                conn.executescript(sql)
+                conn.execute(
+                    "INSERT INTO schema_migrations (filename) VALUES (?)", (name,)
+                )
+                conn.commit()
+            except Exception as e:
+                conn.rollback()
+                logger.error(f"Migration {name} failed: {e}")
+                raise

--- a/ciris_engine/persistence/migrations/001_initial_schema.sql
+++ b/ciris_engine/persistence/migrations/001_initial_schema.sql
@@ -1,0 +1,45 @@
+-- Initial schema
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename TEXT PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Tasks table
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id TEXT PRIMARY KEY,
+    description TEXT NOT NULL,
+    status TEXT NOT NULL,
+    priority INTEGER DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    parent_task_id TEXT,
+    context_json TEXT,
+    outcome_json TEXT
+);
+
+-- Thoughts table
+CREATE TABLE IF NOT EXISTS thoughts (
+    thought_id TEXT PRIMARY KEY,
+    source_task_id TEXT NOT NULL,
+    thought_type TEXT DEFAULT 'standard',
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    round_number INTEGER DEFAULT 0,
+    content TEXT NOT NULL,
+    context_json TEXT,
+    ponder_count INTEGER DEFAULT 0,
+    ponder_notes_json TEXT,
+    parent_thought_id TEXT,
+    final_action_json TEXT,
+    FOREIGN KEY (source_task_id) REFERENCES tasks(task_id)
+);
+
+-- Feedback mappings table
+CREATE TABLE IF NOT EXISTS feedback_mappings (
+    feedback_id TEXT PRIMARY KEY,
+    source_message_id TEXT,
+    target_thought_id TEXT,
+    feedback_type TEXT,
+    created_at TEXT NOT NULL
+);

--- a/ciris_engine/persistence/migrations/002_add_retry_status.sql
+++ b/ciris_engine/persistence/migrations/002_add_retry_status.sql
@@ -1,0 +1,2 @@
+-- Example migration: add retry_count column to tasks
+ALTER TABLE tasks ADD COLUMN retry_count INTEGER DEFAULT 0;

--- a/tests/ciris_engine/persistence/test_migrations.py
+++ b/tests/ciris_engine/persistence/test_migrations.py
@@ -1,0 +1,67 @@
+import os
+import tempfile
+from ciris_engine.persistence.db import initialize_database, get_db_connection
+from ciris_engine.persistence.migration_runner import run_migrations, MIGRATIONS_DIR
+
+
+def temp_db_file():
+    f = tempfile.NamedTemporaryFile(delete=False)
+    f.close()
+    return f.name
+
+
+def test_initialize_runs_migrations():
+    db_path = temp_db_file()
+    try:
+        initialize_database(db_path=db_path)
+        with get_db_connection(db_path) as conn:
+            # migrations table exists
+            cur = conn.execute(
+                "SELECT filename FROM schema_migrations ORDER BY filename"
+            )
+            rows = [r[0] for r in cur.fetchall()]
+            assert rows == ["001_initial_schema.sql", "002_add_retry_status.sql"]
+            # column from second migration present
+            cur = conn.execute("PRAGMA table_info(tasks)")
+            cols = [r[1] for r in cur.fetchall()]
+            assert "retry_count" in cols
+    finally:
+        os.unlink(db_path)
+
+
+def test_failed_migration_rolls_back(tmp_path):
+    migrations_dir = tmp_path / "migs"
+    migrations_dir.mkdir()
+    (migrations_dir / "001_ok.sql").write_text(
+        "CREATE TABLE test (id INTEGER PRIMARY KEY);"
+    )
+    (migrations_dir / "002_fail.sql").write_text("INVALID SQL;")
+    db_path = temp_db_file()
+    try:
+        with get_db_connection(db_path) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS schema_migrations (filename TEXT PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)"
+            )
+            conn.commit()
+        original_dir = MIGRATIONS_DIR
+        try:
+            # patch migrations dir
+            import ciris_engine.persistence.migration_runner as mr
+
+            mr.MIGRATIONS_DIR = migrations_dir
+            try:
+                run_migrations(db_path=db_path)
+            except Exception:
+                pass
+        finally:
+            mr.MIGRATIONS_DIR = original_dir
+        with get_db_connection(db_path) as conn:
+            cur = conn.execute("SELECT filename FROM schema_migrations")
+            rows = [r[0] for r in cur.fetchall()]
+            assert rows == ["001_ok.sql"]
+            cur = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='test'"
+            )
+            assert cur.fetchone() is not None
+    finally:
+        os.unlink(db_path)


### PR DESCRIPTION
## Summary
- implement SQLite-based migration runner with tracking table
- run migrations automatically in initialize_database
- add initial migrations and example migration
- document how to add migrations
- add unit tests for migration system

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cdfda1728832b806aed812883c641