### PR TITLE
Add DMA timeouts with automatic deferral

### DIFF
--- a/ciris_engine/dma/exceptions.py
+++ b/ciris_engine/dma/exceptions.py
@@ -1,0 +1,4 @@
+class DMAFailure(Exception):
+    """Raised when a DMA repeatedly fails or times out."""
+
+    is_dma_failure = True

--- a/ciris_engine/schemas/config_schemas_v1.py
+++ b/ciris_engine/schemas/config_schemas_v1.py
@@ -25,6 +25,10 @@ class WorkflowConfig(BaseModel):
     max_rounds: int = Field(default=5, description="Maximum ponder iterations before auto-defer")
     num_rounds: Optional[int] = Field(default=None, description="Maximum number of processing rounds (None = infinite)")
     DMA_RETRY_LIMIT: int = Field(default=3, description="Maximum retry attempts for DMAs")
+    DMA_TIMEOUT_SECONDS: float = Field(
+        default=30.0,
+        description="Timeout in seconds for each DMA evaluation",
+    )
     GUARDRAIL_RETRY_LIMIT: int = Field(default=2, description="Maximum retry attempts for guardrails")
 
 class OpenAIConfig(BaseModel):
@@ -83,3 +87,4 @@ class AppConfig(BaseModel):
 # Expose commonly used constants at module level for convenience
 DMA_RETRY_LIMIT = 3
 GUARDRAIL_RETRY_LIMIT = 2
+DMA_TIMEOUT_SECONDS = 30.0

--- a/tests/ciris_engine/dma/test_dma_executor.py
+++ b/tests/ciris_engine/dma/test_dma_executor.py
@@ -1,18 +1,36 @@
 import pytest
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
-from ciris_engine.dma.dma_executor import run_dma_with_retries, run_pdma, run_csdma, run_dsdma, run_action_selection_pdma
+from ciris_engine.dma.dma_executor import (
+    run_dma_with_retries,
+    run_pdma,
+    run_csdma,
+    run_dsdma,
+    run_action_selection_pdma,
+    DMAFailure,
+)
 
 @pytest.mark.asyncio
 async def test_run_dma_with_retries_success():
     async def fn(x): return x + 1
-    result = await run_dma_with_retries(fn, 1, retry_limit=2)
+    result = await run_dma_with_retries(fn, 1, retry_limit=2, timeout_seconds=0.5)
     assert result == 2
 
 @pytest.mark.asyncio
 async def test_run_dma_with_retries_failure():
     async def fn(x): raise ValueError("fail")
-    with pytest.raises(ValueError):
-        await run_dma_with_retries(fn, 1, retry_limit=1)
+    with pytest.raises(DMAFailure):
+        await run_dma_with_retries(fn, 1, retry_limit=1, timeout_seconds=0.5)
+
+
+@pytest.mark.asyncio
+async def test_run_dma_with_retries_timeout():
+    async def fn(x):
+        await asyncio.sleep(0.2)
+        return x
+
+    with pytest.raises(DMAFailure):
+        await run_dma_with_retries(fn, 1, retry_limit=1, timeout_seconds=0.1)
 
 @pytest.mark.asyncio
 async def test_run_pdma():

--- a/tests/ciris_engine/schemas/test_config_schemas_v1.py
+++ b/tests/ciris_engine/schemas/test_config_schemas_v1.py
@@ -22,3 +22,4 @@ def test_workflow_config_defaults():
     assert config.max_rounds == 5
     assert config.DMA_RETRY_LIMIT == 3
     assert config.GUARDRAIL_RETRY_LIMIT == 2
+    assert config.DMA_TIMEOUT_SECONDS == 30.0


### PR DESCRIPTION
## Summary
- add DMA failure exception and timeout config
- wrap DMA calls with `run_dma_with_retries` using asyncio timeouts
- defer a thought when DMAs fail or time out
- expose `DMA_TIMEOUT_SECONDS` in workflow config
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d16744c80832b9a9450e1292829a1