### PR TITLE
Add graph and correlation persistence schemas

### DIFF
--- a/ciris_engine/adapters/local_graph_memory/local_graph_memory_service.py
+++ b/ciris_engine/adapters/local_graph_memory/local_graph_memory_service.py
@@ -13,23 +13,10 @@ from ciris_engine.schemas.graph_schemas_v1 import (
     NodeType,
     GraphEdge,
 )
-from ciris_engine.schemas.foundational_schemas_v1 import CaseInsensitiveEnum, TaskStatus
+from ciris_engine.schemas.memory_schemas_v1 import MemoryOpStatus, MemoryOpResult
 from ciris_engine.adapters.base import Service
-from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
-
-
-class MemoryOpStatus(CaseInsensitiveEnum):
-    OK = "ok"
-    DEFERRED = "deferred"
-    DENIED = "denied"
-
-
-class MemoryOpResult(BaseModel):
-    status: MemoryOpStatus
-    reason: Optional[str] = None
-    data: Optional[Any] = None
 
 
 class LocalGraphMemoryService(Service):

--- a/ciris_engine/persistence/__init__.py
+++ b/ciris_engine/persistence/__init__.py
@@ -5,6 +5,9 @@ from .db import (
     initialize_database,
     get_tasks_older_than,
     get_thoughts_older_than,
+    get_graph_nodes_table_schema_sql,
+    get_graph_edges_table_schema_sql,
+    get_service_correlations_table_schema_sql,
     run_migrations,
     MIGRATIONS_DIR,
 )
@@ -76,4 +79,7 @@ __all__ = [
     "pending_thoughts",
     "thought_exists_for",
     "count_thoughts_by_status",
+    "get_graph_nodes_table_schema_sql",
+    "get_graph_edges_table_schema_sql",
+    "get_service_correlations_table_schema_sql",
 ]

--- a/ciris_engine/persistence/db/__init__.py
+++ b/ciris_engine/persistence/db/__init__.py
@@ -5,6 +5,9 @@ from .core import (
     get_thoughts_by_status,
     get_tasks_older_than,
     get_thoughts_older_than,
+    get_graph_nodes_table_schema_sql,
+    get_graph_edges_table_schema_sql,
+    get_service_correlations_table_schema_sql,
 )
 from ciris_engine.config.config_manager import get_sqlite_db_full_path
 from .setup import initialize_database
@@ -21,4 +24,7 @@ __all__ = [
     "run_migrations",
     "MIGRATIONS_DIR",
     "get_sqlite_db_full_path",
+    "get_graph_nodes_table_schema_sql",
+    "get_graph_edges_table_schema_sql",
+    "get_service_correlations_table_schema_sql",
 ]

--- a/ciris_engine/persistence/db/core.py
+++ b/ciris_engine/persistence/db/core.py
@@ -5,6 +5,9 @@ from ciris_engine.schemas.db_tables_v1 import (
     tasks_table_v1,
     thoughts_table_v1,
     feedback_mappings_table_v1,
+    graph_nodes_table_v1,
+    graph_edges_table_v1,
+    service_correlations_table_v1,
 )
 from .migration_runner import run_migrations
 
@@ -27,6 +30,15 @@ def get_thought_table_schema_sql() -> str:
 
 def get_feedback_mappings_table_schema_sql() -> str:
     return feedback_mappings_table_v1
+
+def get_graph_nodes_table_schema_sql() -> str:
+    return graph_nodes_table_v1
+
+def get_graph_edges_table_schema_sql() -> str:
+    return graph_edges_table_v1
+
+def get_service_correlations_table_schema_sql() -> str:
+    return service_correlations_table_v1
 
 def initialize_database(db_path=None):
     """Apply pending migrations to initialize or update the database."""

--- a/ciris_engine/persistence/migrations/001_initial_schema.sql
+++ b/ciris_engine/persistence/migrations/001_initial_schema.sql
@@ -43,3 +43,51 @@ CREATE TABLE IF NOT EXISTS feedback_mappings (
     feedback_type TEXT,
     created_at TEXT NOT NULL
 );
+
+-- Graph nodes table
+CREATE TABLE IF NOT EXISTS graph_nodes (
+    node_id TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    node_type TEXT NOT NULL,
+    attributes_json TEXT,
+    version INTEGER DEFAULT 1,
+    updated_by TEXT,
+    updated_at TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (node_id, scope)
+);
+
+-- Graph edges table
+CREATE TABLE IF NOT EXISTS graph_edges (
+    edge_id TEXT PRIMARY KEY,
+    source_node_id TEXT NOT NULL,
+    target_node_id TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    relationship TEXT NOT NULL,
+    weight REAL DEFAULT 1.0,
+    attributes_json TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (source_node_id, scope) REFERENCES graph_nodes(node_id, scope),
+    FOREIGN KEY (target_node_id, scope) REFERENCES graph_nodes(node_id, scope)
+);
+
+-- Indexes for graph performance
+CREATE INDEX IF NOT EXISTS idx_graph_nodes_scope ON graph_nodes(scope);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_scope ON graph_edges(scope);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_source ON graph_edges(source_node_id);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_target ON graph_edges(target_node_id);
+
+-- Service correlations table
+CREATE TABLE IF NOT EXISTS service_correlations (
+    correlation_id TEXT PRIMARY KEY,
+    service_type TEXT NOT NULL,
+    handler_name TEXT NOT NULL,
+    action_type TEXT NOT NULL,
+    request_data TEXT,
+    response_data TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_correlations_status ON service_correlations(status);
+CREATE INDEX IF NOT EXISTS idx_correlations_handler ON service_correlations(handler_name);

--- a/ciris_engine/schemas/__init__.py
+++ b/ciris_engine/schemas/__init__.py
@@ -3,6 +3,8 @@ from .action_params_v1 import *
 from .dma_results_v1 import *
 from .foundational_schemas_v1 import *
 from .service_actions_v1 import *
+from .memory_schemas_v1 import *
+from .correlation_schemas_v1 import *
 
 __all__ = [
     'Task', 'Thought',
@@ -15,5 +17,9 @@ __all__ = [
     'ActionType', 'ActionMessage', 'SendMessageAction', 'FetchMessagesAction',
     'FetchGuidanceAction', 'SendDeferralAction', 'MemorizeAction', 'RecallAction',
     'ForgetAction', 'SendToolAction', 'FetchToolAction', 'ObserveMessageAction',
+    # Memory operation schemas
+    'MemoryOpStatus', 'MemoryOpAction', 'MemoryOpResult',
+    # Service correlation schemas
+    'ServiceCorrelationStatus', 'ServiceCorrelation',
 ]
 

--- a/ciris_engine/schemas/correlation_schemas_v1.py
+++ b/ciris_engine/schemas/correlation_schemas_v1.py
@@ -1,0 +1,26 @@
+from enum import Enum
+from typing import Optional, Dict, Any
+from pydantic import BaseModel
+
+class ServiceCorrelationStatus(str, Enum):
+    """Status values for service correlations."""
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+class ServiceCorrelation(BaseModel):
+    """Record correlating service requests and responses."""
+    correlation_id: str
+    service_type: str
+    handler_name: str
+    action_type: str
+    request_data: Optional[Dict[str, Any]] = None
+    response_data: Optional[Dict[str, Any]] = None
+    status: ServiceCorrelationStatus = ServiceCorrelationStatus.PENDING
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+__all__ = [
+    "ServiceCorrelationStatus",
+    "ServiceCorrelation",
+]

--- a/ciris_engine/schemas/db_tables_v1.py
+++ b/ciris_engine/schemas/db_tables_v1.py
@@ -42,3 +42,52 @@ CREATE TABLE IF NOT EXISTS feedback_mappings (
     created_at TEXT NOT NULL
 );
 '''
+
+graph_nodes_table_v1 = '''
+CREATE TABLE IF NOT EXISTS graph_nodes (
+    node_id TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    node_type TEXT NOT NULL,
+    attributes_json TEXT,
+    version INTEGER DEFAULT 1,
+    updated_by TEXT,
+    updated_at TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (node_id, scope)
+);
+CREATE INDEX IF NOT EXISTS idx_graph_nodes_scope ON graph_nodes(scope);
+'''
+
+graph_edges_table_v1 = '''
+CREATE TABLE IF NOT EXISTS graph_edges (
+    edge_id TEXT PRIMARY KEY,
+    source_node_id TEXT NOT NULL,
+    target_node_id TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    relationship TEXT NOT NULL,
+    weight REAL DEFAULT 1.0,
+    attributes_json TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (source_node_id, scope) REFERENCES graph_nodes(node_id, scope),
+    FOREIGN KEY (target_node_id, scope) REFERENCES graph_nodes(node_id, scope)
+);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_scope ON graph_edges(scope);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_source ON graph_edges(source_node_id);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_target ON graph_edges(target_node_id);
+'''
+
+service_correlations_table_v1 = '''
+CREATE TABLE IF NOT EXISTS service_correlations (
+    correlation_id TEXT PRIMARY KEY,
+    service_type TEXT NOT NULL,
+    handler_name TEXT NOT NULL,
+    action_type TEXT NOT NULL,
+    request_data TEXT,
+    response_data TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_correlations_status ON service_correlations(status);
+CREATE INDEX IF NOT EXISTS idx_correlations_handler ON service_correlations(handler_name);
+'''

--- a/ciris_engine/schemas/memory_schemas_v1.py
+++ b/ciris_engine/schemas/memory_schemas_v1.py
@@ -1,0 +1,28 @@
+from enum import Enum
+from typing import Any, Optional
+from pydantic import BaseModel
+from .foundational_schemas_v1 import CaseInsensitiveEnum
+
+class MemoryOpStatus(CaseInsensitiveEnum):
+    """Status of a memory operation."""
+    OK = "ok"
+    DEFERRED = "deferred"
+    DENIED = "denied"
+
+class MemoryOpAction(str, Enum):
+    """Memory operation types."""
+    MEMORIZE = "memorize"
+    RECALL = "recall"
+    FORGET = "forget"
+
+class MemoryOpResult(BaseModel):
+    """Result of a memory operation."""
+    status: MemoryOpStatus
+    reason: Optional[str] = None
+    data: Optional[Any] = None
+
+__all__ = [
+    "MemoryOpStatus",
+    "MemoryOpAction",
+    "MemoryOpResult",
+]

--- a/tests/ciris_engine/action_handlers/test_remaining_handlers.py
+++ b/tests/ciris_engine/action_handlers/test_remaining_handlers.py
@@ -19,7 +19,7 @@ from ciris_engine.schemas.agent_core_schemas_v1 import Thought, Task
 from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
 from ciris_engine.schemas.graph_schemas_v1 import GraphScope, GraphNode, NodeType
 from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, ThoughtStatus, TaskStatus
-from ciris_engine.adapters.local_graph_memory import MemoryOpResult, MemoryOpStatus
+from ciris_engine.schemas.memory_schemas_v1 import MemoryOpResult, MemoryOpStatus
 
 
 DEFAULT_THOUGHT_KWARGS = dict(


### PR DESCRIPTION
## Summary
- support graph storage and service correlations in the persistence layer
- expose SQL schema strings for graph nodes/edges and service correlations
- add `MemoryOp*` and correlation schemas
- adjust local graph memory and tests to import from new schemas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d261842bc832ba94fa790235e56c2