### PR TITLE
Centralize variable access in adapters

### DIFF
--- a/ciris_engine/adapters/api/api_observer.py
+++ b/ciris_engine/adapters/api/api_observer.py
@@ -44,11 +44,16 @@ class APIObserver:
         await self._recall_context(msg)
 
     async def _handle_passive_observation(self, msg: IncomingMessage) -> None:
-        from ciris_engine.config.env_utils import get_env_var
+        from ciris_engine.utils.constants import (
+            API_CHANNEL_ID,
+            API_DEFERRAL_CHANNEL_ID,
+            WA_API_USER,
+            DEFAULT_WA,
+        )
 
-        default_channel_id = get_env_var("API_CHANNEL_ID")
-        deferral_channel_id = get_env_var("API_DEFERRAL_CHANNEL_ID")
-        wa_api_user = get_env_var("WA_API_USER", DEFAULT_WA)
+        default_channel_id = API_CHANNEL_ID
+        deferral_channel_id = API_DEFERRAL_CHANNEL_ID
+        wa_api_user = WA_API_USER or DEFAULT_WA
         if msg.channel_id == default_channel_id and not self._is_agent_message(msg):
             await self._create_passive_observation_result(msg)
         elif msg.channel_id == deferral_channel_id and msg.author_name == wa_api_user:

--- a/ciris_engine/adapters/cli/cli_observer.py
+++ b/ciris_engine/adapters/cli/cli_observer.py
@@ -86,11 +86,15 @@ class CLIObserver:
         
         # Get environment variables for channel filtering. When running in CLI
         # mode the Discord variables may not be set, so fall back to 'cli'.
-        from ciris_engine.config.env_utils import get_env_var
+        from ciris_engine.config.config_manager import get_config
+        from ciris_engine.utils.constants import (
+            DISCORD_DEFERRAL_CHANNEL_ID,
+            DEFAULT_WA,
+        )
 
-        default_channel_id = get_env_var("DISCORD_CHANNEL_ID") or "cli"
-        deferral_channel_id = get_env_var("DISCORD_DEFERRAL_CHANNEL_ID")
-        wa_discord_user = get_env_var("WA_DISCORD_USER", DEFAULT_WA)
+        default_channel_id = get_config().discord_channel_id or "cli"
+        deferral_channel_id = DISCORD_DEFERRAL_CHANNEL_ID
+        wa_discord_user = DEFAULT_WA
         
         # Route messages based on channel and author
         if msg.channel_id == default_channel_id and not self._is_agent_message(msg):

--- a/ciris_engine/adapters/discord/discord_observer.py
+++ b/ciris_engine/adapters/discord/discord_observer.py
@@ -31,11 +31,10 @@ class DiscordObserver:
         self.multi_service_sink = multi_service_sink
         self._history: list[IncomingMessage] = []
 
-        from ciris_engine.config.env_utils import get_env_var
+        from ciris_engine.config.config_manager import get_config
 
-        env_id = get_env_var("DISCORD_CHANNEL_ID")
-        if monitored_channel_id is None and env_id:
-            monitored_channel_id = env_id.strip()
+        if monitored_channel_id is None:
+            monitored_channel_id = get_config().discord_channel_id
         self.monitored_channel_id: Optional[str] = monitored_channel_id
 
     async def start(self):
@@ -65,9 +64,15 @@ class DiscordObserver:
         await self._recall_context(msg)
 
     async def _handle_passive_observation(self, msg: IncomingMessage) -> None:
-        default_channel_id = get_env_var("DISCORD_CHANNEL_ID")
-        deferral_channel_id = get_env_var("DISCORD_DEFERRAL_CHANNEL_ID")
-        wa_discord_user = get_env_var("WA_DISCORD_USER", DEFAULT_WA)
+        from ciris_engine.config.config_manager import get_config
+        from ciris_engine.utils.constants import (
+            DISCORD_DEFERRAL_CHANNEL_ID,
+            DEFAULT_WA,
+        )
+
+        default_channel_id = get_config().discord_channel_id
+        deferral_channel_id = DISCORD_DEFERRAL_CHANNEL_ID
+        wa_discord_user = DEFAULT_WA
         if msg.channel_id == default_channel_id and not self._is_agent_message(msg):
             await self._create_passive_observation_result(msg)
         elif msg.channel_id == deferral_channel_id and msg.author_name == wa_discord_user:

--- a/ciris_engine/adapters/openai_compatible_llm.py
+++ b/ciris_engine/adapters/openai_compatible_llm.py
@@ -1,4 +1,3 @@
-import os
 import json
 import re
 import logging
@@ -41,25 +40,9 @@ class OpenAICompatibleClient(Service):
         }
         super().__init__(config=retry_config)
 
-        # Strict AppConfig > Env for all config values
-        from ciris_engine.config.env_utils import get_env_var
-
-        api_key_env_var = getattr(self.openai_config, 'api_key_env_var', 'OPENAI_API_KEY')
-        api_key = getattr(self.openai_config, 'api_key', None)
-        if not api_key:
-            api_key = get_env_var(api_key_env_var)
-
-        base_url = getattr(self.openai_config, 'base_url', None)
-        if not base_url:
-            base_url = get_env_var("OPENAI_BASE_URL")
-        if not base_url:
-            base_url = get_env_var("OPENAI_API_BASE")
-
-        model_name = getattr(self.openai_config, 'model_name', None)
-        if not model_name:
-            model_name = get_env_var("OPENAI_MODEL_NAME")
-        if not model_name:
-            model_name = 'gpt-4o-mini'
+        api_key = self.openai_config.api_key
+        base_url = self.openai_config.base_url
+        model_name = self.openai_config.model_name or 'gpt-4o-mini'
         self.model_name = model_name
 
         if not api_key and not base_url:

--- a/ciris_engine/utils/constants.py
+++ b/ciris_engine/utils/constants.py
@@ -8,6 +8,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_WA = get_env_var("WA_DISCORD_USER", "somecomputerguy")
 WA_USER_ID = get_env_var("WA_USER_ID")
 
+# Common service channel/environment variables
+DISCORD_CHANNEL_ID = get_env_var("DISCORD_CHANNEL_ID")
+DISCORD_DEFERRAL_CHANNEL_ID = get_env_var("DISCORD_DEFERRAL_CHANNEL_ID")
+API_CHANNEL_ID = get_env_var("API_CHANNEL_ID")
+API_DEFERRAL_CHANNEL_ID = get_env_var("API_DEFERRAL_CHANNEL_ID")
+WA_API_USER = get_env_var("WA_API_USER", DEFAULT_WA)
+
 # Load the CIRIS Covenant text for inclusion in prompts
 _COVENANT_PATH = Path(__file__).resolve().parents[2] / "covenant_1.0b.txt"
 try:

--- a/tests/ciris_engine/services/test_llm_client.py
+++ b/tests/ciris_engine/services/test_llm_client.py
@@ -61,9 +61,9 @@ def test_init_env_priority(mock_get_config, mock_patch, mock_async_openai):
     DummyAppConfig.LLMServices.OpenAI.model_name = None
     make_env(api_key="env-key", base_url="https://env-base", model_name="env-model")
     client = OpenAICompatibleClient()
-    assert client.model_name == "env-model"
+    assert client.model_name == "gpt-4o-mini"
     mock_async_openai.assert_called_with(
-        api_key="env-key", base_url="https://env-base", timeout=30, max_retries=0
+        api_key=None, base_url=None, timeout=30, max_retries=0
     )
     mock_patch.assert_called()
 


### PR DESCRIPTION
## Summary
- fetch env-based constants via `utils.constants`
- rely on app config in CLIObserver and DiscordObserver
- fetch API observer settings from constants
- drop env var lookups from OpenAI client
- update OpenAI client tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683de5ad8eb0832bbea1b72113dbbafc