### PR TITLE
Fix message truncation and flag follow ups

### DIFF
--- a/ciris_engine/action_handlers/forget_handler.py
+++ b/ciris_engine/action_handlers/forget_handler.py
@@ -120,6 +120,7 @@ class ForgetHandler(BaseActionHandler):
             follow_up_content = (
                 f"This is a follow-up thought from a FORGET action performed on parent task {thought.source_task_id}. Failed to forget key '{node.id}' in scope {node.scope.value}. If the task is now resolved, the next step may be to mark the parent task complete with COMPLETE_TASK."
             )
+        #PROMPT_FOLLOW_UP_THOUGHT
         follow_up = create_follow_up_thought(
             parent=thought,
             content=follow_up_content,

--- a/ciris_engine/action_handlers/memorize_handler.py
+++ b/ciris_engine/action_handlers/memorize_handler.py
@@ -127,6 +127,7 @@ class MemorizeHandler(BaseActionHandler):
             )
         else:  # Failed or Deferred
             follow_up_text = f"MEMORIZE action for thought {thought_id} resulted in status {final_thought_status.value}. Info: {follow_up_content_key_info}. Review and determine next steps."
+        #PROMPT_FOLLOW_UP_THOUGHT
 
         try:
             new_follow_up = create_follow_up_thought(

--- a/ciris_engine/action_handlers/observe_handler.py
+++ b/ciris_engine/action_handlers/observe_handler.py
@@ -101,6 +101,7 @@ class ObserveHandler(BaseActionHandler):
                 final_action=result,
             )
             follow_up_text = f"OBSERVE action failed for thought {thought_id}. Reason: {e}"
+            #PROMPT_FOLLOW_UP_THOUGHT
             try:
                 fu = create_follow_up_thought(parent=thought, content=follow_up_text)
                 fu.context = {
@@ -171,7 +172,7 @@ class ObserveHandler(BaseActionHandler):
             f"OBSERVE action completed. Info: {follow_up_info}"
             if action_performed
             else f"OBSERVE action failed: {follow_up_info}"
-        )
+        )  #PROMPT_FOLLOW_UP_THOUGHT
         try:
             logger.info(f"ObserveHandler: Creating follow-up thought for {thought_id}")
             new_follow_up = create_follow_up_thought(parent=thought, content=follow_up_text)

--- a/ciris_engine/action_handlers/ponder_handler.py
+++ b/ciris_engine/action_handlers/ponder_handler.py
@@ -123,6 +123,7 @@ class PonderHandler(BaseActionHandler):
                     f"Pondered questions: {questions_list}. "
                     "If the task is now resolved, the next step may be to mark the parent task complete with COMPLETE_TASK."
                 )
+                #PROMPT_FOLLOW_UP_THOUGHT
                 from .helpers import create_follow_up_thought
                 follow_up = create_follow_up_thought(
                     parent=thought,
@@ -161,6 +162,7 @@ class PonderHandler(BaseActionHandler):
                     f"Pondered questions: {questions_list}. "
                     "The update failed. If the task is now resolved, the next step may be to mark the parent task complete with COMPLETE_TASK."
                 )
+                #PROMPT_FOLLOW_UP_THOUGHT
                 from .helpers import create_follow_up_thought
                 follow_up = create_follow_up_thought(
                     parent=thought,

--- a/ciris_engine/action_handlers/recall_handler.py
+++ b/ciris_engine/action_handlers/recall_handler.py
@@ -24,7 +24,7 @@ class RecallHandler(BaseActionHandler):
             follow_up = create_follow_up_thought(
                 parent=thought,
                 content=f"RECALL action failed: {e}"
-            )
+            )  #PROMPT_FOLLOW_UP_THOUGHT
             self.dependencies.persistence.add_thought(follow_up)
             return
         memory_service: Optional[MemoryService] = await self.get_memory_service()
@@ -36,7 +36,7 @@ class RecallHandler(BaseActionHandler):
             follow_up = create_follow_up_thought(
                 parent=thought,
                 content=f"RECALL action failed: MemoryService unavailable for thought {thought_id}"
-            )
+            )  #PROMPT_FOLLOW_UP_THOUGHT
             self.dependencies.persistence.add_thought(follow_up)
             await self._audit_log(
                 HandlerActionType.RECALL,
@@ -64,6 +64,7 @@ class RecallHandler(BaseActionHandler):
             follow_up_content = f"Memory query '{node.id}' returned: {data}"
         else:
             follow_up_content = f"No memories found for query '{node.id}' in scope {node.scope.value}"
+        #PROMPT_FOLLOW_UP_THOUGHT
         follow_up = create_follow_up_thought(
             parent=thought,
             content=follow_up_content,

--- a/ciris_engine/action_handlers/reject_handler.py
+++ b/ciris_engine/action_handlers/reject_handler.py
@@ -33,6 +33,7 @@ class RejectHandler(BaseActionHandler):
             follow_up_content_key_info = f"REJECT action failed: {e}"
             final_thought_status = ThoughtStatus.FAILED
             follow_up_text = f"REJECT action failed for thought {thought_id}. Reason: {follow_up_content_key_info}. This path of reasoning is terminated. Review and determine if a new approach or task is needed."
+            #PROMPT_FOLLOW_UP_THOUGHT
             try:
                 new_follow_up = create_follow_up_thought(
                     parent=thought,
@@ -90,6 +91,7 @@ class RejectHandler(BaseActionHandler):
 
         # Create a follow-up thought indicating failure and reason
         follow_up_text = f"REJECT action failed for thought {thought_id}. Reason: {follow_up_content_key_info}. This path of reasoning is terminated. Review and determine if a new approach or task is needed."
+        #PROMPT_FOLLOW_UP_THOUGHT
         try:
             new_follow_up = create_follow_up_thought(
                 parent=thought,

--- a/ciris_engine/action_handlers/speak_handler.py
+++ b/ciris_engine/action_handlers/speak_handler.py
@@ -68,10 +68,10 @@ class SpeakHandler(BaseActionHandler):
         task_description = task.description if task else f"task {thought.source_task_id}"
         
         follow_up_content_key_info = (
-            f"YOU Spoke, as a result of your action: '{params.content[:50]}...' in channel #{params.channel_id} as a response to task: {task_description[:100]} this thought was created. The next action is probably TASK COMPLETE to mark the original task as handled. Any further user action will trigger a further observation thought automatically."
+            f"YOU Spoke, as a result of your action: '{params.content}' in channel #{params.channel_id} as a response to task: {task_description} this thought was created. The next action is probably TASK COMPLETE to mark the original task as handled. Any further user action will trigger a further observation thought automatically."
             if success
             else f"Failed to send message to {params.channel_id}"
-        )
+        )  #PROMPT_FOLLOW_UP_THOUGHT
 
         # Pass ActionSelectionResult directly to persistence - it handles serialization
         persistence.update_thought_status(
@@ -81,10 +81,10 @@ class SpeakHandler(BaseActionHandler):
         )
 
         follow_up_text = (
-            f"Successfully spoke: '{params.content[:70]}...'"
+            f"Successfully spoke: '{params.content}'"
             if success
             else f"SPEAK action failed for thought {thought_id}. Reason: {follow_up_content_key_info}."
-        )
+        )  #PROMPT_FOLLOW_UP_THOUGHT
 
         try:
             new_follow_up = create_follow_up_thought(parent=thought, content=follow_up_text)

--- a/ciris_engine/action_handlers/tool_handler.py
+++ b/ciris_engine/action_handlers/tool_handler.py
@@ -91,6 +91,7 @@ class ToolHandler(BaseActionHandler):
             follow_up_text = f"TOOL action {params.name} executed for thought {thought_id}. Info: {follow_up_content_key_info}. Awaiting tool results or next steps. If task complete, use TASK_COMPLETE."
         else:
             follow_up_text = f"TOOL action failed for thought {thought_id}. Reason: {follow_up_content_key_info}. Review and determine next steps."
+        #PROMPT_FOLLOW_UP_THOUGHT
         try:
             new_follow_up = create_follow_up_thought(
                 parent=thought,

--- a/ciris_engine/adapters/api/api_observer.py
+++ b/ciris_engine/adapters/api/api_observer.py
@@ -77,7 +77,7 @@ class APIObserver:
 
             task = Task(
                 task_id=str(uuid.uuid4()),
-                description=f"Respond to message from @{msg.author_name} in #{msg.channel_id}: '{msg.content[:100]}...'",
+                description=f"Respond to message from @{msg.author_name} in #{msg.channel_id}: '{msg.content}'",
                 status=TaskStatus.PENDING,
                 priority=0,
                 created_at=datetime.now(timezone.utc).isoformat(),

--- a/ciris_engine/adapters/cli/cli_observer.py
+++ b/ciris_engine/adapters/cli/cli_observer.py
@@ -128,7 +128,7 @@ class CLIObserver:
 
             task = Task(
                 task_id=str(uuid.uuid4()),
-                description=f"Respond to message from @{msg.author_name} in #{msg.channel_id}: '{msg.content[:100]}...'",
+                description=f"Respond to message from @{msg.author_name} in #{msg.channel_id}: '{msg.content}'",
                 status=TaskStatus.PENDING,
                 priority=0,
                 created_at=datetime.now(timezone.utc).isoformat(),

--- a/ciris_engine/adapters/discord/discord_observer.py
+++ b/ciris_engine/adapters/discord/discord_observer.py
@@ -97,7 +97,7 @@ class DiscordObserver:
             # Create task for this observation
             task = Task(
                 task_id=str(uuid.uuid4()),
-                description=f"Respond to message from @{msg.author_name} in #{msg.channel_id}: '{msg.content[:100]}...'",
+                description=f"Respond to message from @{msg.author_name} in #{msg.channel_id}: '{msg.content}'",
                 status=TaskStatus.PENDING,
                 priority=0,
                 created_at=datetime.now(timezone.utc).isoformat(),

--- a/ciris_engine/adapters/openai_compatible_llm.py
+++ b/ciris_engine/adapters/openai_compatible_llm.py
@@ -104,7 +104,7 @@ class OpenAICompatibleClient(Service):
             try:
                 return json.loads(json_str.replace("'", '"'))
             except json.JSONDecodeError:
-                return {"error": f"Failed to parse JSON. Raw content snippet: {raw[:250]}..."}
+                return {"error": f"Failed to parse JSON. Raw content snippet: {raw}"}
 
     async def call_llm_raw(
         self,

--- a/ciris_engine/formatters/prompt_blocks.py
+++ b/ciris_engine/formatters/prompt_blocks.py
@@ -15,7 +15,7 @@ def format_parent_task_chain(parent_tasks: List[Dict[str, Any]]) -> str:
             prefix = "Direct Parent"
         else:
             prefix = f"Parent {i}"
-        desc = pt.get("description", "")[:150]
+        desc = pt.get("description", "")
         tid = pt.get("task_id", "N/A")
         lines.append(f"{prefix}: {desc} (Task ID: {tid})")
     return "\n".join(lines)
@@ -29,7 +29,7 @@ def format_thoughts_chain(thoughts: List[Dict[str, Any]]) -> str:
     for i, thought in enumerate(thoughts):
         is_active = i == len(thoughts) - 1
         label = "Active Thought" if is_active else f"Thought {i+1}"
-        content = str(thought.get("content", ""))[:500]
+        content = str(thought.get("content", ""))
         lines.append(f"{label}: {content}")
     return "\n".join(lines)
 

--- a/ciris_engine/formatters/user_profiles.py
+++ b/ciris_engine/formatters/user_profiles.py
@@ -17,7 +17,7 @@ def format_user_profiles(profiles: Optional[Dict[str, Any]], max_profiles: int =
 
             interest = profile_data.get('interest')
             if interest:
-                profile_summary += f", Interest: '{str(interest)[:50]}...'"  # Truncate for brevity
+                profile_summary += f", Interest: '{str(interest)}'"
 
             channel = profile_data.get('channel')
             if channel:

--- a/ciris_engine/persistence/maintenance.py
+++ b/ciris_engine/persistence/maintenance.py
@@ -98,7 +98,7 @@ class DatabaseMaintenanceService:
 
         for step_task in wakeup_step_tasks:
             if step_task.status not in [TaskStatus.COMPLETED, TaskStatus.FAILED]: # Removed TaskStatus.ARCHIVED
-                logger.info(f"Found stale, non-terminal wakeup step task: {step_task.task_id} ('{step_task.description[:30]}...') with status {step_task.status}. Marking as FAILED.")
+                logger.info(f"Found stale, non-terminal wakeup step task: {step_task.task_id} ('{step_task.description}') with status {step_task.status}. Marking as FAILED.")
                 update_task_status(step_task.task_id, TaskStatus.FAILED)
                 stale_wakeup_steps_failed_count += 1
                 
@@ -137,11 +137,11 @@ class DatabaseMaintenanceService:
                 if not parent_task or parent_task.status not in [TaskStatus.ACTIVE, TaskStatus.COMPLETED]:
                     is_orphan = True
             elif task.task_id not in self.valid_root_task_ids:
-                logger.info(f"Task {task.task_id} ('{task.description[:30]}...') is active but not a recognized root task. Marking as orphaned.")
+                logger.info(f"Task {task.task_id} ('{task.description}') is active but not a recognized root task. Marking as orphaned.")
                 is_orphan = True
 
             if is_orphan:
-                logger.info(f"Orphaned active task found: {task.task_id} ('{task.description[:30]}...'). Parent missing or not active/completed. Marking for deletion.")
+                logger.info(f"Orphaned active task found: {task.task_id} ('{task.description}'). Parent missing or not active/completed. Marking for deletion.")
                 task_ids_to_delete.append(task.task_id)
 
         if task_ids_to_delete:

--- a/ciris_engine/processor/solitude_processor.py
+++ b/ciris_engine/processor/solitude_processor.py
@@ -109,7 +109,7 @@ class SolitudeProcessor(BaseProcessor):
                 critical_count += 1
                 logger.info(
                     f"Critical task found: {task.task_id} "
-                    f"(Priority: {task.priority}) - {task.description[:50]}..."
+                    f"(Priority: {task.priority}) - {task.description}"
                 )
         
         return critical_count

--- a/ciris_engine/processor/task_manager.py
+++ b/ciris_engine/processor/task_manager.py
@@ -69,7 +69,7 @@ class TaskManager:
             except Exception:
                 pass
         persistence.add_task(task)
-        logger.info(f"Created task {task.task_id}: {description[:50]}...")
+        logger.info(f"Created task {task.task_id}: {description}")
         return task
     
     def activate_pending_tasks(self) -> int:

--- a/ciris_engine/utils/task_formatters.py
+++ b/ciris_engine/utils/task_formatters.py
@@ -33,7 +33,7 @@ def format_task_context(current_task: Dict[str, str],
         raise TypeError("current_task must be a dict")
 
     out_lines: List[str] = ["=== Current Task ==="]
-    cur_desc = str(current_task.get("description", ""))[:200]
+    cur_desc = str(current_task.get("description", ""))
     task_id = current_task.get("task_id", "N/A")
     status = current_task.get("status", "N/A")
     priority = current_task.get("priority", "N/A")
@@ -44,16 +44,16 @@ def format_task_context(current_task: Dict[str, str],
         for idx, act in enumerate(recent_actions[:max_actions], 1):
             if not isinstance(act, dict):
                 continue
-            desc = str(act.get("description", ""))[:120]
-            outcome = str(act.get("outcome", ""))[:100]
+            desc = str(act.get("description", ""))
+            outcome = str(act.get("outcome", ""))
             upd = act.get("updated_at", "N/A")
             out_lines.append(f"{idx}. {desc} | Outcome: {outcome} (updated: {upd})")
 
     if completed_tasks:
         last = completed_tasks[0]
         if isinstance(last, dict):
-            desc = str(last.get("description", ""))[:120]
-            outcome = str(last.get("outcome", ""))[:100]
+            desc = str(last.get("description", ""))
+            outcome = str(last.get("outcome", ""))
             upd = last.get("updated_at", "N/A")
             out_lines.append(f"\n=== Last Completed Task ===\n{desc} | Outcome: {outcome} (completed: {upd})")
 

--- a/tests/ciris_engine/services/test_llm_client.py
+++ b/tests/ciris_engine/services/test_llm_client.py
@@ -115,9 +115,9 @@ def test_instructor_patch_fallback(mock_patch, mock_async_openai):
 @pytest.mark.parametrize("raw,expected", [
     ("""{'foo': 1}""", {"foo": 1}),
     ('```json\n{"bar": 2}\n```', {"bar": 2}),
-    ("no json here", {"error": "Failed to parse JSON. Raw content snippet: no json here..."}),
+    ("no json here", {"error": "Failed to parse JSON. Raw content snippet: no json here"}),
     ("""{'baz': 3}""", {"baz": 3}),
-    ("""{'bad': 1,}""", {"error": "Failed to parse JSON. Raw content snippet: {'bad': 1,..."}),
+    ("""{'bad': 1,}""", {"error": "Failed to parse JSON. Raw content snippet: {'bad': 1,"}),
 ])
 def test_extract_json(raw, expected):
     result = OpenAICompatibleClient.extract_json(raw)


### PR DESCRIPTION
## Summary
- remove string truncation throughout pipeline
- mark follow-up text with `#PROMPT_FOLLOW_UP_THOUGHT`
- adjust tests for changed error messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e00a39a64832baa051567c85e354d