### PR TITLE
Add subsystem protocol interfaces

### DIFF
--- a/ciris_engine/protocols/README.md
+++ b/ciris_engine/protocols/README.md
@@ -1,3 +1,11 @@
 # protocols
 
-This module contains the protocols components of the CIRIS engine.
+This module defines abstract interfaces used across the CIRIS engine. 
+Implementations should depend on these contracts rather than concrete 
+classes from other subpackages.
+
+The directory provides service protocols under `services.py` and 
+additional subsystem interfaces such as `ProcessorInterface`, 
+`DMAEvaluatorInterface`, `GuardrailInterface`, and 
+`PersistenceInterface`. Common Pydantic models are re-exported via 
+`schemas.py` for convenience when implementing these protocols.

--- a/ciris_engine/protocols/__init__.py
+++ b/ciris_engine/protocols/__init__.py
@@ -1,6 +1,4 @@
-"""
-CIRIS Agent service protocols.
-"""
+"""CIRIS Agent service and subsystem protocols."""
 
 from .services import (
     CommunicationService,
@@ -10,12 +8,20 @@ from .services import (
     AuditService,
     LLMService,
 )
+from .processor_interface import ProcessorInterface
+from .dma_interface import DMAEvaluatorInterface
+from .guardrail_interface import GuardrailInterface
+from .persistence_interface import PersistenceInterface
 
 __all__ = [
     "CommunicationService",
-    "WiseAuthorityService", 
+    "WiseAuthorityService",
     "MemoryService",
     "ToolService",
     "AuditService",
     "LLMService",
+    "ProcessorInterface",
+    "DMAEvaluatorInterface",
+    "GuardrailInterface",
+    "PersistenceInterface",
 ]

--- a/ciris_engine/protocols/dma_interface.py
+++ b/ciris_engine/protocols/dma_interface.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+from typing import Any
+from ciris_engine.protocols.schemas import Thought, EthicalDMAResult
+
+class DMAEvaluatorInterface(ABC):
+    """Protocol for decision making algorithms."""
+
+    @abstractmethod
+    async def evaluate(self, thought: Thought) -> EthicalDMAResult:
+        """Return an ethical analysis of the thought."""

--- a/ciris_engine/protocols/guardrail_interface.py
+++ b/ciris_engine/protocols/guardrail_interface.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+from ciris_engine.protocols.schemas import GuardrailCheckResult, ActionSelectionResult
+
+class GuardrailInterface(ABC):
+    """Contract for guardrail checks."""
+
+    @abstractmethod
+    def check(self, action: ActionSelectionResult, data: Dict[str, Any]) -> GuardrailCheckResult:
+        """Return warnings or errors if guardrail is violated."""

--- a/ciris_engine/protocols/persistence_interface.py
+++ b/ciris_engine/protocols/persistence_interface.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+class PersistenceInterface(ABC):
+    """Minimal persistence interface."""
+
+    @abstractmethod
+    def save_state(self, key: str, data: Any) -> None:
+        ...
+
+    @abstractmethod
+    def load_state(self, key: str) -> Any:
+        ...

--- a/ciris_engine/protocols/processor_interface.py
+++ b/ciris_engine/protocols/processor_interface.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+class ProcessorInterface(ABC):
+    """Contract for main agent processors."""
+
+    @abstractmethod
+    async def handle_observation(self, observation: Dict[str, Any]) -> None:
+        """Given an incoming observation, run the full pipeline."""
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Cleanly tear down processor resources."""

--- a/ciris_engine/protocols/schemas.py
+++ b/ciris_engine/protocols/schemas.py
@@ -1,0 +1,34 @@
+from ciris_engine.schemas.agent_core_schemas_v1 import Task, Thought
+from ciris_engine.schemas.dma_results_v1 import (
+    EthicalDMAResult,
+    CSDMAResult,
+    DSDMAResult,
+    ActionSelectionResult,
+)
+from ciris_engine.schemas.guardrails_schemas_v1 import GuardrailCheckResult
+from ciris_engine.schemas.processing_schemas_v1 import (
+    DMAResults,
+    GuardrailResult,
+    ThoughtContext,
+)
+from ciris_engine.schemas.foundational_schemas_v1 import (
+    HandlerActionType,
+    TaskStatus,
+    ThoughtStatus,
+)
+
+__all__ = [
+    "Task",
+    "Thought",
+    "EthicalDMAResult",
+    "CSDMAResult",
+    "DSDMAResult",
+    "ActionSelectionResult",
+    "GuardrailCheckResult",
+    "DMAResults",
+    "GuardrailResult",
+    "ThoughtContext",
+    "HandlerActionType",
+    "TaskStatus",
+    "ThoughtStatus",
+]


### PR DESCRIPTION
## Summary
- add Processor, DMA, Guardrail, and Persistence interface definitions
- expose new contracts via `ciris_engine.protocols`
- provide `schemas.py` to re-export common models
- update protocols README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e34accd68832bac8136df40b7094d