### PR TITLE
Integrate GUI with CIRIS SDK

### DIFF
--- a/CIRISGUI/README.md
+++ b/CIRISGUI/README.md
@@ -4,7 +4,7 @@ This sub-project provides a unified user interface and API runtime for the CIRIS
 
 ## Structure
 
-- **apps/agui** – Next.js 14 frontend
+- **apps/agui** – Next.js 14 frontend using the CIRIS SDK
 - **apps/ciris-api** – Wrapper around the Python API runtime
 - **docker/** – Dockerfiles and compose setup
 - **scripts/start.sh** – Local development bootstrap

--- a/CIRISGUI/apps/agui/app/audit/page.tsx
+++ b/CIRISGUI/apps/agui/app/audit/page.tsx
@@ -1,15 +1,13 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { CIRISClient } from "../../lib/cirisClient";
+
+const client = new CIRISClient();
 
 async function fetchAuditEntries() {
   try {
-    const res = await fetch(process.env.NEXT_PUBLIC_CIRIS_API_URL + '/v1/audit');
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-    }
-    const data = await res.json();
-    return data.entries || [];
+    return await client.auditList();
   } catch (error) {
     console.error('Failed to fetch audit log:', error);
     return [];

--- a/CIRISGUI/apps/agui/app/logs/page.tsx
+++ b/CIRISGUI/apps/agui/app/logs/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { CIRISClient } from "../../lib/cirisClient";
+
+const client = new CIRISClient();
 
 async function fetchLogs(filename: string, lines: number = 100) {
-  // Use the backend API endpoint for logs
-  const baseUrl = process.env.NEXT_PUBLIC_CIRIS_API_URL || '';
-  const url = `${baseUrl}/v1/logs/${filename}?tail=${lines}`;
-  const res = await fetch(url);
-  if (!res.ok) return `Failed to fetch logs: ${res.statusText}`;
-  return res.text();
+  try {
+    return await client.logFetch(filename, lines);
+  } catch (e: any) {
+    return `Failed to fetch logs: ${e.message}`;
+  }
 }
 
 const LOG_FILES = [

--- a/CIRISGUI/apps/agui/app/memory/page.tsx
+++ b/CIRISGUI/apps/agui/app/memory/page.tsx
@@ -1,31 +1,29 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { CIRISClient } from "../../lib/cirisClient";
 
-const API = process.env.NEXT_PUBLIC_CIRIS_API_URL;
+const client = new CIRISClient();
 
 async function fetchScopes() {
-  const res = await fetch(API + '/v1/memory/scopes');
-  return res.json();
+  return { scopes: await client.memoryScopes() };
 }
 
 async function fetchEntry(scope: string, key: string) {
-  const res = await fetch(`${API}/v1/memory/fetch?scope=${encodeURIComponent(scope)}&key=${encodeURIComponent(key)}`);
-  return res.json();
+  const entries = await client.memoryEntries(scope);
+  const match = entries.find((e: any) => e.key === key);
+  return { value: match?.value };
 }
 
 async function storeEntry(scope: string, key: string, value: any) {
-  const res = await fetch(`${API}/v1/memory/store`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ scope, entry: { key, value } }),
-  });
-  return res.json();
+  await client.memoryStore(scope, key, value);
+  return { result: 'ok' };
 }
 
 async function queryEntries(scope: string, prefix: string, limit: number) {
-  const res = await fetch(`${API}/v1/memory/query?scope=${encodeURIComponent(scope)}&prefix=${encodeURIComponent(prefix)}&limit=${limit}`);
-  return res.json();
+  const entries = await client.memoryEntries(scope);
+  const filtered = entries.filter((e: any) => e.key.startsWith(prefix)).slice(0, limit);
+  return { entries: filtered };
 }
 
 export default function MemoryPage() {

--- a/CIRISGUI/apps/agui/app/tools/page.tsx
+++ b/CIRISGUI/apps/agui/app/tools/page.tsx
@@ -1,19 +1,16 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { CIRISClient } from "../../lib/cirisClient";
+
+const client = new CIRISClient();
 
 async function fetchTools() {
-  const res = await fetch(process.env.NEXT_PUBLIC_CIRIS_API_URL + '/v1/tools');
-  return res.json();
+  return { tools: await client.toolsList() };
 }
 
 async function callTool(tool: string, args: any) {
-  const res = await fetch(process.env.NEXT_PUBLIC_CIRIS_API_URL + `/v1/tools/${tool}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(args),
-  });
-  return res.json();
+  return await client.toolExecute(tool, args);
 }
 
 export default function ToolsPage() {

--- a/CIRISGUI/apps/agui/app/wa/page.tsx
+++ b/CIRISGUI/apps/agui/app/wa/page.tsx
@@ -1,24 +1,17 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { CIRISClient } from "../../lib/cirisClient";
 
-// Fetch deferrals from the API (assume /v1/deferrals or /v1/audit?event_type=defer)
+const client = new CIRISClient();
+
+// Fetch deferrals from the API (audit endpoint)
 async function fetchDeferrals() {
-  // Try /v1/audit?event_type=defer for now
-  const res = await fetch(process.env.NEXT_PUBLIC_CIRIS_API_URL + '/v1/audit?event_type=defer');
-  if (!res.ok) return [];
-  const data = await res.json();
-  // Assume entries is an array of deferral audit log entries
-  return data.entries || [];
+  return await client.auditList('defer');
 }
 
 async function fetchGuidance(context: any = {}) {
-  const res = await fetch(process.env.NEXT_PUBLIC_CIRIS_API_URL + '/v1/guidance', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(context),
-  });
-  return res.json();
+  return await client.toolExecute('guidance', context);
 }
 
 export default function WAPage() {

--- a/CIRISGUI/apps/agui/lib/cirisClient.ts
+++ b/CIRISGUI/apps/agui/lib/cirisClient.ts
@@ -1,0 +1,56 @@
+export class CIRISClient {
+  constructor(private baseUrl: string = process.env.NEXT_PUBLIC_CIRIS_API_URL || '') {}
+
+  async auditList(eventType?: string, limit: number = 100): Promise<any[]> {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (eventType) params.append('event_type', eventType);
+    const res = await fetch(`${this.baseUrl}/v1/audit?${params.toString()}`);
+    if (!res.ok) throw new Error(res.statusText);
+    return res.json();
+  }
+
+  async logFetch(filename: string, tail: number = 100): Promise<string> {
+    const res = await fetch(`${this.baseUrl}/v1/logs/${filename}?tail=${tail}`);
+    if (!res.ok) throw new Error(res.statusText);
+    return res.text();
+  }
+
+  async memoryScopes(): Promise<string[]> {
+    const res = await fetch(`${this.baseUrl}/v1/memory/scopes`);
+    if (!res.ok) throw new Error(res.statusText);
+    const data = await res.json();
+    return data.scopes || [];
+  }
+
+  async memoryStore(scope: string, key: string, value: any): Promise<void> {
+    await fetch(`${this.baseUrl}/v1/memory/${encodeURIComponent(scope)}/store`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key, value }),
+    });
+  }
+
+  async memoryEntries(scope: string): Promise<any[]> {
+    const res = await fetch(`${this.baseUrl}/v1/memory/${encodeURIComponent(scope)}/entries`);
+    if (!res.ok) throw new Error(res.statusText);
+    const data = await res.json();
+    return data.entries || [];
+  }
+
+  async toolsList(): Promise<string[]> {
+    const res = await fetch(`${this.baseUrl}/v1/tools`);
+    if (!res.ok) throw new Error(res.statusText);
+    const data = await res.json();
+    return data.tools || [];
+  }
+
+  async toolExecute(name: string, args: any): Promise<any> {
+    const res = await fetch(`${this.baseUrl}/v1/tools/${name}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(args),
+    });
+    if (!res.ok) throw new Error(res.statusText);
+    return res.json();
+  }
+}

--- a/ciris_sdk/README.md
+++ b/ciris_sdk/README.md
@@ -8,4 +8,9 @@ from ciris_sdk import CIRISClient
 async def main():
     async with CIRISClient(base_url="http://localhost:8080") as client:
         await client.messages.send("hello")
+
+        # Fetch recent audit entries
+        entries = await client.audit.list()
+        # Read the last 50 lines of a log file
+        log_text = await client.logs.fetch("latest.log", tail=50)
 ```

--- a/ciris_sdk/client.py
+++ b/ciris_sdk/client.py
@@ -8,6 +8,8 @@ from .resources.messages import MessagesResource
 from .resources.memory import MemoryResource
 from .resources.tools import ToolsResource
 from .resources.guidance import GuidanceResource
+from .resources.audit import AuditResource
+from .resources.logs import LogsResource
 from .exceptions import CIRISTimeoutError, CIRISConnectionError
 
 class CIRISClient:
@@ -28,6 +30,8 @@ class CIRISClient:
         self.memory = MemoryResource(self._transport)
         self.tools = ToolsResource(self._transport)
         self.guidance = GuidanceResource(self._transport)
+        self.audit = AuditResource(self._transport)
+        self.logs = LogsResource(self._transport)
 
     async def __aenter__(self) -> "CIRISClient":
         await self._transport.__aenter__()

--- a/ciris_sdk/resources/audit.py
+++ b/ciris_sdk/resources/audit.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from ..transport import Transport
+
+class AuditResource:
+    """Access audit log entries from the CIRIS Engine API."""
+
+    def __init__(self, transport: Transport):
+        self._transport = transport
+
+    async def list(self, event_type: Optional[str] = None, limit: int = 100) -> List[Dict[str, Any]]:
+        params = {"limit": limit}
+        if event_type:
+            params["event_type"] = event_type
+        resp = await self._transport.request("GET", "/v1/audit", params=params)
+        return resp.json()

--- a/ciris_sdk/resources/logs.py
+++ b/ciris_sdk/resources/logs.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from ..transport import Transport
+
+class LogsResource:
+    """Access engine log files."""
+
+    def __init__(self, transport: Transport):
+        self._transport = transport
+
+    async def fetch(self, filename: str, tail: int = 100) -> str:
+        resp = await self._transport.request("GET", f"/v1/logs/{filename}", params={"tail": tail})
+        return resp.text

--- a/ciris_sdk/resources/memory.py
+++ b/ciris_sdk/resources/memory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, List, Optional
 
 from ..transport import Transport
 
@@ -11,3 +11,17 @@ class MemoryResource:
     async def store(self, scope: str, key: str, value: Any) -> None:
         payload = {"key": key, "value": value}
         await self._transport.request("POST", f"/v1/memory/{scope}/store", json=payload)
+
+    async def list_scopes(self) -> List[str]:
+        resp = await self._transport.request("GET", "/v1/memory/scopes")
+        return resp.json().get("scopes", [])
+
+    async def fetch(self, scope: str, key: str) -> Optional[Any]:
+        params = {"scope": scope, "key": key}
+        resp = await self._transport.request("GET", "/v1/memory/fetch", params=params)
+        return resp.json().get("value")
+
+    async def query(self, scope: str, prefix: str = "", limit: int = 10) -> Any:
+        params = {"scope": scope, "prefix": prefix, "limit": limit}
+        resp = await self._transport.request("GET", "/v1/memory/query", params=params)
+        return resp.json()

--- a/ciris_sdk/resources/tools.py
+++ b/ciris_sdk/resources/tools.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, List
 
 from ..transport import Transport
 
@@ -12,3 +12,7 @@ class ToolsResource:
         payload = {"name": name, "args": args}
         resp = await self._transport.request("POST", "/v1/tools/execute", json=payload)
         return resp.json()
+
+    async def list(self) -> List[str]:
+        resp = await self._transport.request("GET", "/v1/tools")
+        return resp.json().get("tools", [])

--- a/tests/ciris_sdk/test_client.py
+++ b/tests/ciris_sdk/test_client.py
@@ -25,7 +25,37 @@ async def test_send_message(monkeypatch):
     client.memory._transport = mt
     client.tools._transport = mt
     client.guidance._transport = mt
+    client.audit._transport = mt
+    client.logs._transport = mt
     async with client:
         await client.messages.send("hi")
     assert mt.requests[0][0] == "POST"
+
+
+@pytest.mark.asyncio
+async def test_memory_and_tools(monkeypatch):
+    mt = MockTransport()
+    client = CIRISClient()
+    client._transport = mt
+    client.memory._transport = mt
+    client.tools._transport = mt
+    async with client:
+        await client.memory.list_scopes()
+        await client.tools.list()
+    assert mt.requests[0][1] == "/v1/memory/scopes"
+    assert mt.requests[1][1] == "/v1/tools"
+
+
+@pytest.mark.asyncio
+async def test_audit_and_logs(monkeypatch):
+    mt = MockTransport()
+    client = CIRISClient()
+    client._transport = mt
+    client.audit._transport = mt
+    client.logs._transport = mt
+    async with client:
+        await client.audit.list()
+        await client.logs.fetch("latest.log")
+    assert mt.requests[0][1] == "/v1/audit"
+    assert mt.requests[1][1] == "/v1/logs/latest.log"
 


### PR DESCRIPTION
## Summary
- extend Python SDK with Audit and Logs resources
- expose memory scopes and query helpers
- add a small TypeScript client wrapper for the GUI
- refactor Next.js pages to call the SDK
- update SDK and GUI docs
- cover new SDK features with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e8088234c832b87a8e903f9d5b1b1