### PR TITLE
Fix observe handling in runtime and observers

### DIFF
--- a/ciris_engine/action_handlers/observe_handler.py
+++ b/ciris_engine/action_handlers/observe_handler.py
@@ -130,6 +130,8 @@ class ObserveHandler(BaseActionHandler):
             or dispatch_context.get("channel_id")
             or getattr(thought, "context", {}).get("channel_id")
         )
+        if channel_id and isinstance(channel_id, str) and channel_id.startswith("@"):  # likely user mention
+            channel_id = None
         params.channel_id = channel_id
 
         # Get services with better logging

--- a/ciris_engine/adapters/api/api_observer.py
+++ b/ciris_engine/adapters/api/api_observer.py
@@ -10,6 +10,8 @@ from ciris_engine.sinks.multi_service_sink import MultiServiceActionSink
 
 logger = logging.getLogger(__name__)
 
+PASSIVE_CONTEXT_LIMIT = 10
+
 class APIObserver:
     def __init__(
         self,
@@ -90,7 +92,18 @@ class APIObserver:
                     "author_name": msg.author_name,
                     "message_id": msg.message_id,
                     "origin_service": "api",
-                    "observation_type": "passive"
+                    "observation_type": "passive",
+                    "recent_messages": [
+                        {
+                            "id": m.message_id,
+                            "content": m.content,
+                            "author_id": m.author_id,
+                            "author_name": m.author_name,
+                            "channel_id": m.channel_id,
+                            "timestamp": getattr(m, "timestamp", "n/a"),
+                        }
+                        for m in self._history[-PASSIVE_CONTEXT_LIMIT:]
+                    ],
                 }
             )
             assert "channel_id" in task.context and task.context["channel_id"], "Task context must include a non-empty channel_id"
@@ -105,7 +118,7 @@ class APIObserver:
                 updated_at=datetime.now(timezone.utc).isoformat(),
                 round_number=0,
                 content=f"User @{msg.author_name} said: {msg.content}",
-                context=task.context
+                context=dict(task.context)
             )
             assert "channel_id" in thought.context and thought.context["channel_id"], "Thought context must include a non-empty channel_id"
             persistence.add_thought(thought)
@@ -142,7 +155,7 @@ class APIObserver:
         if not self.memory_service:
             return
         recall_ids = {f"channel/{msg.channel_id}"}
-        for m in self._history[-10:]:
+        for m in self._history[-PASSIVE_CONTEXT_LIMIT:]:
             if m.author_id:
                 recall_ids.add(f"user/{m.author_id}")
         for rid in recall_ids:

--- a/ciris_engine/adapters/cli/cli_observer.py
+++ b/ciris_engine/adapters/cli/cli_observer.py
@@ -12,6 +12,8 @@ from ciris_engine.sinks.multi_service_sink import MultiServiceActionSink
 
 logger = logging.getLogger(__name__)
 
+PASSIVE_CONTEXT_LIMIT = 10
+
 class CLIObserver:
     """Observer that converts CLI input events into observation payloads."""
 
@@ -139,7 +141,18 @@ class CLIObserver:
                     "author_name": msg.author_name,
                     "message_id": msg.message_id,
                     "origin_service": "cli",
-                    "observation_type": "passive"
+                    "observation_type": "passive",
+                    "recent_messages": [
+                        {
+                            "id": m.message_id,
+                            "content": m.content,
+                            "author_id": m.author_id,
+                            "author_name": m.author_name,
+                            "channel_id": m.channel_id,
+                            "timestamp": getattr(m, "timestamp", "n/a"),
+                        }
+                        for m in self._history[-PASSIVE_CONTEXT_LIMIT:]
+                    ],
                 }
             )
             assert "channel_id" in task.context and task.context["channel_id"], "Task context must include a non-empty channel_id"
@@ -154,7 +167,7 @@ class CLIObserver:
                 updated_at=datetime.now(timezone.utc).isoformat(),
                 round_number=0,
                 content=f"User @{msg.author_name} said: {msg.content}",
-                context=task.context
+                context=dict(task.context)
             )
             assert "channel_id" in thought.context and thought.context["channel_id"], "Thought context must include a non-empty channel_id"
             persistence.add_thought(thought)
@@ -199,7 +212,7 @@ class CLIObserver:
             return
         import socket
         recall_ids = {f"channel/{socket.gethostname()}"}
-        for m in self._history[-10:]:
+        for m in self._history[-PASSIVE_CONTEXT_LIMIT:]:
             if m.author_id:
                 recall_ids.add(f"user/{m.author_id}")
         for rid in recall_ids:

--- a/ciris_engine/adapters/discord/discord_observer.py
+++ b/ciris_engine/adapters/discord/discord_observer.py
@@ -11,6 +11,8 @@ from ciris_engine.sinks.multi_service_sink import MultiServiceActionSink
 
 logger = logging.getLogger(__name__)
 
+PASSIVE_CONTEXT_LIMIT = 10
+
 
 class DiscordObserver:
     """
@@ -108,7 +110,18 @@ class DiscordObserver:
                     "author_name": msg.author_name,
                     "message_id": msg.message_id,
                     "origin_service": "discord",
-                    "observation_type": "passive"
+                    "observation_type": "passive",
+                    "recent_messages": [
+                        {
+                            "id": m.message_id,
+                            "content": m.content,
+                            "author_id": m.author_id,
+                            "author_name": m.author_name,
+                            "channel_id": m.channel_id,
+                            "timestamp": getattr(m, "timestamp", "n/a"),
+                        }
+                        for m in self._history[-PASSIVE_CONTEXT_LIMIT:]
+                    ],
                 }
             )
             assert "channel_id" in task.context and task.context["channel_id"], "Task context must include a non-empty channel_id"
@@ -124,7 +137,7 @@ class DiscordObserver:
                 updated_at=datetime.now(timezone.utc).isoformat(),
                 round_number=0,
                 content=f"User @{msg.author_name} said: {msg.content}",
-                context=task.context
+                context=dict(task.context)
             )
             assert "channel_id" in thought.context and thought.context["channel_id"], "Thought context must include a non-empty channel_id"
             persistence.add_thought(thought)
@@ -161,7 +174,7 @@ class DiscordObserver:
         if not self.memory_service:
             return
         recall_ids = {f"channel/{msg.channel_id}"}
-        for m in self._history[-10:]:
+        for m in self._history[-PASSIVE_CONTEXT_LIMIT:]:
             if m.author_id:
                 recall_ids.add(f"user/{m.author_id}")
         for rid in recall_ids:

--- a/ciris_engine/runtime/ciris_runtime.py
+++ b/ciris_engine/runtime/ciris_runtime.py
@@ -326,7 +326,13 @@ class CIRISRuntime(RuntimeInterface):
         # Create dependencies for handlers and ThoughtProcessor
         dependencies = ActionHandlerDependencies(
             service_registry=self.service_registry,
-            shutdown_callback=lambda: self.request_shutdown("Handler requested shutdown due to critical service failure")
+            io_adapter=self.io_adapter,
+            shutdown_callback=lambda: self.request_shutdown(
+                "Handler requested shutdown due to critical service failure"
+            ),
+            multi_service_sink=self.multi_service_sink,
+            memory_service=self.memory_service,
+            audit_service=self.audit_service,
         )
         
         # Register runtime shutdown with global manager
@@ -417,6 +423,8 @@ class CIRISRuntime(RuntimeInterface):
             max_rounds=self.app_config.workflow.max_rounds,
             audit_service=self.audit_service,
             memory_service=self.memory_service,
+            multi_service_sink=self.multi_service_sink,
+            io_adapter=self.io_adapter,
         )
         
     async def run(self, num_rounds: Optional[int] = None):

--- a/ciris_engine/runtime/cli_runtime.py
+++ b/ciris_engine/runtime/cli_runtime.py
@@ -131,6 +131,10 @@ class CLIRuntime(CIRISRuntime):
             service_registry=self.service_registry,
             max_rounds=self.app_config.workflow.max_rounds,
             shutdown_callback=dependencies.shutdown_callback,
+            audit_service=self.audit_service,
+            memory_service=self.memory_service,
+            multi_service_sink=self.multi_service_sink,
+            io_adapter=self.cli_adapter,
         )
 
     async def shutdown(self):

--- a/ciris_engine/runtime/discord_runtime.py
+++ b/ciris_engine/runtime/discord_runtime.py
@@ -160,6 +160,7 @@ class DiscordRuntime(CIRISRuntime):
             max_rounds=self.app_config.workflow.max_rounds,
             audit_service=self.audit_service,
             memory_service=self.memory_service,
+            multi_service_sink=self.multi_service_sink,
             io_adapter=self.discord_adapter,
         )
         


### PR DESCRIPTION
## Summary
- wire multi_service_sink and services to handlers
- include recent message history in passive observation context
- sanitize observe handler channel IDs
- expose sink to runtimes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f08f202ac832ba11af0f8701ce523