### PR TITLE
Ensure context is preserved in follow‑ups

### DIFF
--- a/ciris_engine/action_handlers/forget_handler.py
+++ b/ciris_engine/action_handlers/forget_handler.py
@@ -27,12 +27,16 @@ class ForgetHandler(BaseActionHandler):
                     parent=thought,
                     content=f"This is a follow-up thought from a FORGET action performed on parent task {thought.source_task_id}. FORGET action failed: Invalid parameters. {e}. If the task is now resolved, the next step may be to mark the parent task complete with COMPLETE_TASK."
                 )
-                follow_up.context = {
+                ctx = {
                     "action_performed": HandlerActionType.FORGET.name,
                     "parent_task_id": thought.source_task_id,
                     "is_follow_up": True,
                     "error": str(e)
                 }
+                if isinstance(follow_up.context, dict):
+                    follow_up.context.update(ctx)
+                else:
+                    follow_up.context = ctx
                 self.dependencies.persistence.add_thought(follow_up)
                 await self._audit_log(HandlerActionType.FORGET, {**dispatch_context, "thought_id": thought_id}, outcome="failed")
                 return
@@ -42,12 +46,16 @@ class ForgetHandler(BaseActionHandler):
                 parent=thought,
                 content=f"This is a follow-up thought from a FORGET action performed on parent task {thought.source_task_id}. FORGET action failed: Invalid parameters type: {type(raw_params)}. If the task is now resolved, the next step may be to mark the parent task complete with COMPLETE_TASK."
             )
-            follow_up.context = {
+            ctx = {
                 "action_performed": HandlerActionType.FORGET.name,
                 "parent_task_id": thought.source_task_id,
                 "is_follow_up": True,
                 "error": f"Invalid params type: {type(raw_params)}"
             }
+            if isinstance(follow_up.context, dict):
+                follow_up.context.update(ctx)
+            else:
+                follow_up.context = ctx
             self.dependencies.persistence.add_thought(follow_up)
             await self._audit_log(HandlerActionType.FORGET, {**dispatch_context, "thought_id": thought_id}, outcome="failed")
             return
@@ -57,12 +65,16 @@ class ForgetHandler(BaseActionHandler):
                 parent=thought,
                 content=f"This is a follow-up thought from a FORGET action performed on parent task {thought.source_task_id}. FORGET action was not permitted. If the task is now resolved, the next step may be to mark the parent task complete with COMPLETE_TASK."
             )
-            follow_up.context = {
+            ctx = {
                 "action_performed": HandlerActionType.FORGET.name,
                 "parent_task_id": thought.source_task_id,
                 "is_follow_up": True,
                 "error": "Permission denied or WA required"
             }
+            if isinstance(follow_up.context, dict):
+                follow_up.context.update(ctx)
+            else:
+                follow_up.context = ctx
             self.dependencies.persistence.add_thought(follow_up)
             return
         memory_service: Optional[MemoryService] = await self.get_memory_service()
@@ -88,12 +100,16 @@ class ForgetHandler(BaseActionHandler):
                 parent=thought,
                 content="FORGET action denied: WA authorization required"
             )
-            follow_up.context = {
+            ctx = {
                 "action_performed": HandlerActionType.FORGET.name,
                 "parent_task_id": thought.source_task_id,
                 "is_follow_up": True,
                 "error": "wa_denied",
             }
+            if isinstance(follow_up.context, dict):
+                follow_up.context.update(ctx)
+            else:
+                follow_up.context = ctx
             self.dependencies.persistence.add_thought(follow_up)
             await self._audit_log(
                 HandlerActionType.FORGET,
@@ -125,7 +141,7 @@ class ForgetHandler(BaseActionHandler):
             parent=thought,
             content=follow_up_content,
         )
-        follow_up.context = {
+        ctx_final = {
             "action_performed": HandlerActionType.FORGET.name,
             "parent_task_id": thought.source_task_id,
             "is_follow_up": True,
@@ -133,6 +149,10 @@ class ForgetHandler(BaseActionHandler):
             "forget_scope": node.scope.value,
             "forget_status": str(getattr(forget_result, "status", forget_result))
         }
+        if isinstance(follow_up.context, dict):
+            follow_up.context.update(ctx_final)
+        else:
+            follow_up.context = ctx_final
         self.dependencies.persistence.add_thought(follow_up)
         await self._audit_log(
             HandlerActionType.FORGET,

--- a/ciris_engine/action_handlers/memorize_handler.py
+++ b/ciris_engine/action_handlers/memorize_handler.py
@@ -145,7 +145,10 @@ class MemorizeHandler(BaseActionHandler):
             # Pass action parameters directly - persistence will handle serialization
             context_for_follow_up["action_params"] = result.action_parameters
 
-            new_follow_up.context = context_for_follow_up  # v1 uses 'context'
+            if isinstance(new_follow_up.context, dict):
+                new_follow_up.context.update(context_for_follow_up)  # v1 uses 'context'
+            else:
+                new_follow_up.context = context_for_follow_up
             persistence.add_thought(new_follow_up)
             self.logger.info(
                 f"Created follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after MEMORIZE action."

--- a/ciris_engine/action_handlers/observe_handler.py
+++ b/ciris_engine/action_handlers/observe_handler.py
@@ -184,7 +184,10 @@ class ObserveHandler(BaseActionHandler):
             }
             if final_status == ThoughtStatus.FAILED:
                 ctx["error_details"] = follow_up_info
-            new_follow_up.context = ctx
+            if isinstance(new_follow_up.context, dict):
+                new_follow_up.context.update(ctx)
+            else:
+                new_follow_up.context = ctx
             persistence.add_thought(new_follow_up)
             logger.info(f"ObserveHandler: Follow-up thought created for {thought_id}")
             #TODO: Fix auditing

--- a/ciris_engine/action_handlers/ponder_handler.py
+++ b/ciris_engine/action_handlers/ponder_handler.py
@@ -159,12 +159,16 @@ class PonderHandler(BaseActionHandler):
                 parent=thought,
                 content=follow_up_content,
             )
-            follow_up.context = {
+            ctx = {
                 "action_performed": HandlerActionType.PONDER.name,
                 "parent_task_id": thought.source_task_id,
                 "is_follow_up": True,
                 "ponder_notes": questions_list,
             }
+            if isinstance(follow_up.context, dict):
+                follow_up.context.update(ctx)
+            else:
+                follow_up.context = ctx
             persistence.add_thought(follow_up)
             # Note: The thought is already set to PENDING status, so it will be automatically
             # picked up in the next processing round when the queue is populated from the database
@@ -198,12 +202,16 @@ class PonderHandler(BaseActionHandler):
                 parent=thought,
                 content=follow_up_content,
             )
-            follow_up.context = {
+            ctx2 = {
                 "action_performed": HandlerActionType.PONDER.name,
                 "parent_task_id": thought.source_task_id,
                 "is_follow_up": True,
                 "ponder_notes": questions_list,
                 "error": "Failed to update for re-processing"
             }
+            if isinstance(follow_up.context, dict):
+                follow_up.context.update(ctx2)
+            else:
+                follow_up.context = ctx2
             persistence.add_thought(follow_up)
             return None

--- a/ciris_engine/action_handlers/reject_handler.py
+++ b/ciris_engine/action_handlers/reject_handler.py
@@ -46,7 +46,10 @@ class RejectHandler(BaseActionHandler):
                     "error_details": follow_up_content_key_info,
                 }
                 context_for_follow_up["action_params"] = params
-                new_follow_up.context = context_for_follow_up
+                if isinstance(new_follow_up.context, dict):
+                    new_follow_up.context.update(context_for_follow_up)
+                else:
+                    new_follow_up.context = context_for_follow_up
                 persistence.add_thought(new_follow_up)
                 await self._audit_log(HandlerActionType.REJECT, {**dispatch_context, "thought_id": thought_id}, outcome="failed")
             except Exception as e2:
@@ -109,7 +112,10 @@ class RejectHandler(BaseActionHandler):
             # Pass params directly - persistence will handle serialization
             context_for_follow_up["action_params"] = params
 
-            new_follow_up.context = context_for_follow_up  # v1 uses 'context'
+            if isinstance(new_follow_up.context, dict):
+                new_follow_up.context.update(context_for_follow_up)  # v1 uses 'context'
+            else:
+                new_follow_up.context = context_for_follow_up
 
             persistence.add_thought(new_follow_up)
             self.logger.info(

--- a/ciris_engine/action_handlers/speak_handler.py
+++ b/ciris_engine/action_handlers/speak_handler.py
@@ -111,7 +111,10 @@ class SpeakHandler(BaseActionHandler):
             }
             if not success:
                 ctx["error_details"] = follow_up_error_context
-            new_follow_up.context = ctx
+            if isinstance(new_follow_up.context, dict):
+                new_follow_up.context.update(ctx)
+            else:
+                new_follow_up.context = ctx
             persistence.add_thought(new_follow_up)
             await self._audit_log(
                 HandlerActionType.SPEAK,

--- a/ciris_engine/action_handlers/tool_handler.py
+++ b/ciris_engine/action_handlers/tool_handler.py
@@ -102,7 +102,10 @@ class ToolHandler(BaseActionHandler):
                 context_for_follow_up["error_details"] = follow_up_content_key_info
             # Pass params directly - persistence will handle serialization
             context_for_follow_up["action_params"] = params
-            new_follow_up.context = context_for_follow_up
+            if isinstance(new_follow_up.context, dict):
+                new_follow_up.context.update(context_for_follow_up)
+            else:
+                new_follow_up.context = context_for_follow_up
             persistence.add_thought(new_follow_up)
             self.logger.info(
                 f"Created follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after TOOL action."

--- a/tests/ciris_engine/context/test_builder.py
+++ b/tests/ciris_engine/context/test_builder.py
@@ -5,6 +5,7 @@ from ciris_engine.schemas.context_schemas_v1 import ThoughtContext, SystemSnapsh
 from pydantic import BaseModel
 import types
 import asyncio
+from ciris_engine.action_handlers.helpers import create_follow_up_thought
 
 class DummyMemoryService:
     def __init__(self):
@@ -51,7 +52,7 @@ async def test_build_thought_context_minimal():
     thought = make_thought()
     ctx = await builder.build_thought_context(thought)
     assert isinstance(ctx, ThoughtContext)
-    assert isinstance(ctx.system_snapshot, dict) or isinstance(ctx.system_snapshot, SystemSnapshot)
+    assert isinstance(ctx.system_snapshot, SystemSnapshot)
     assert isinstance(ctx.user_profiles, dict)
     assert isinstance(ctx.task_history, list)
 
@@ -62,7 +63,7 @@ async def test_build_thought_context_with_memory_and_graphql():
     task = make_task()
     ctx = await builder.build_thought_context(thought, task)
     # Should have user_profiles from GraphQL
-    assert ctx.user_profiles["u1"]["name"] == "Alice"
+    assert ctx.user_profiles["u1"].name == "Alice"
     # Should have identity_context from DummyMemoryService
     assert "Agent identity string" in ctx.identity_context
     # Should have task_history from recently_completed_tasks_summary
@@ -88,3 +89,14 @@ async def test_build_context_includes_task_summaries():
     snap = ctx.system_snapshot
     assert isinstance(snap.recently_completed_tasks_summary, list)
     assert isinstance(snap.top_pending_tasks_summary, list)
+
+
+@pytest.mark.asyncio
+async def test_followup_thought_channel_context():
+    builder = ContextBuilder()
+    parent = make_thought()
+    parent.context = {"channel_id": "chan-123"}
+    child = create_follow_up_thought(parent, content="child")
+    task = make_task()
+    ctx = await builder.build_thought_context(child, task)
+    assert ctx.system_snapshot.channel_id == "chan-123"

--- a/tests/ciris_engine/dma/test_dma_executor.py
+++ b/tests/ciris_engine/dma/test_dma_executor.py
@@ -36,7 +36,19 @@ async def test_run_dma_with_retries_timeout():
 async def test_run_pdma():
     evaluator = MagicMock()
     evaluator.evaluate = AsyncMock(return_value="ok")
-    result = await run_pdma(evaluator, "item")
+    from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+    item = Thought(
+        thought_id="t1",
+        source_task_id="task1",
+        thought_type="test",
+        status="pending",
+        created_at="now",
+        updated_at="now",
+        round_number=1,
+        content="c",
+        context={},
+    )
+    result = await run_pdma(evaluator, item)
     assert result == "ok"
 
 @pytest.mark.asyncio

--- a/tests/ciris_engine/dma/test_pdma.py
+++ b/tests/ciris_engine/dma/test_pdma.py
@@ -27,7 +27,9 @@ async def test_pdma_init_and_evaluate(monkeypatch):
         thought_type="test",
         content="test",
     )
-    result = await evaluator.evaluate(item)
+    from ciris_engine.schemas.context_schemas_v1 import ThoughtContext, SystemSnapshot
+    ctx = ThoughtContext(system_snapshot=SystemSnapshot(system_counts={}))
+    result = await evaluator.evaluate(item, ctx)
     assert isinstance(result, EthicalDMAResult)
     assert result.alignment_check == {"SPEAK": "ok"}
     assert result.decision == "Allow"

--- a/tests/ciris_engine/schemas/test_context_schemas_v1.py
+++ b/tests/ciris_engine/schemas/test_context_schemas_v1.py
@@ -22,12 +22,12 @@ def test_system_snapshot_full():
         user_profiles={"u1": {"name": "Alice"}},
         extra_field="extra"  # test extra allowed
     )
-    assert snap.current_task_details["task_id"] == "t1"
-    assert snap.current_thought_summary["thought_id"] == "th1"
+    assert snap.current_task_details.task_id == "t1"
+    assert snap.current_thought_summary.thought_id == "th1"
     assert snap.system_counts["total_tasks"] == 5
-    assert snap.top_pending_tasks_summary[0]["task_id"] == "t2"
-    assert snap.recently_completed_tasks_summary[0]["task_id"] == "t3"
-    assert snap.user_profiles["u1"]["name"] == "Alice"
+    assert snap.top_pending_tasks_summary[0].task_id == "t2"
+    assert snap.recently_completed_tasks_summary[0].task_id == "t3"
+    assert snap.user_profiles["u1"].name == "Alice"
     assert snap.extra_field == "extra"
 
 
@@ -47,6 +47,6 @@ def test_thought_context_full():
         task_history=[{"task_id": "t4"}],
         identity_context="Agent identity string"
     )
-    assert ctx.user_profiles["u2"]["name"] == "Bob"
-    assert ctx.task_history[0]["task_id"] == "t4"
+    assert ctx.user_profiles["u2"].name == "Bob"
+    assert ctx.task_history[0].task_id == "t4"
     assert ctx.identity_context == "Agent identity string"


### PR DESCRIPTION
## Summary
- keep parent context when handlers create follow-up thoughts
- update PDMA helper tests for mandatory context
- expect typed values from context schemas
- verify follow-up context propagation for handlers
- add builder test for follow-up channel context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f79430964832b9865d4fb3c9d21d2