### PR TITLE
Fix context snapshot conversion

### DIFF
--- a/tests/ciris_engine/context/test_builder.py
+++ b/tests/ciris_engine/context/test_builder.py
@@ -100,3 +100,14 @@ async def test_followup_thought_channel_context():
     task = make_task()
     ctx = await builder.build_thought_context(child, task)
     assert ctx.system_snapshot.channel_id == "chan-123"
+
+
+@pytest.mark.asyncio
+async def test_current_task_details_is_summary():
+    builder = ContextBuilder()
+    thought = make_thought()
+    task = make_task()
+    ctx = await builder.build_thought_context(thought, task)
+    assert ctx.system_snapshot.current_task_details.task_id == task.task_id
+    from ciris_engine.schemas.context_schemas_v1 import TaskSummary
+    assert isinstance(ctx.system_snapshot.current_task_details, TaskSummary)

--- a/tests/ciris_engine/dma/test_action_selection_pdma.py
+++ b/tests/ciris_engine/dma/test_action_selection_pdma.py
@@ -48,7 +48,10 @@ async def test_forced_ponder(monkeypatch):
     assert result.selected_action == HandlerActionType.PONDER
     assert "Forced" in result.rationale
     # Schema-driven assertion
-    ponder_params = PonderParams(**result.action_parameters)
+    if isinstance(result.action_parameters, PonderParams):
+        ponder_params = result.action_parameters
+    else:
+        ponder_params = PonderParams(**result.action_parameters)
     assert isinstance(ponder_params.questions, list)
     assert any("Forced" in q for q in ponder_params.questions)
 
@@ -129,7 +132,10 @@ async def test_instructor_retry(monkeypatch):
     assert result.selected_action == HandlerActionType.PONDER
     assert "InstructorRetryException" in result.rationale or "Fallback" in result.rationale
     # Schema-driven assertion
-    ponder_params = PonderParams(**result.action_parameters)
+    if isinstance(result.action_parameters, PonderParams):
+        ponder_params = result.action_parameters
+    else:
+        ponder_params = PonderParams(**result.action_parameters)
     assert any("System error" in q or "err" in q for q in ponder_params.questions)
 
 @pytest.mark.asyncio
@@ -158,7 +164,10 @@ async def test_general_exception(monkeypatch):
     assert result.selected_action == HandlerActionType.PONDER
     assert "General Exception" in result.rationale or "Fallback" in result.rationale
     # Schema-driven assertion
-    ponder_params = PonderParams(**result.action_parameters)
+    if isinstance(result.action_parameters, PonderParams):
+        ponder_params = result.action_parameters
+    else:
+        ponder_params = PonderParams(**result.action_parameters)
     assert any("System error" in q or "fail" in q for q in ponder_params.questions)
 
 # Optionally, add a negative test to ensure invalid action_parameters raise ValidationError

--- a/tests/ciris_engine/schemas/test_agent_core_schemas_v1.py
+++ b/tests/ciris_engine/schemas/test_agent_core_schemas_v1.py
@@ -19,7 +19,7 @@ def test_task_minimal():
     )
     assert t.status == fs.TaskStatus.PENDING
     assert t.priority == 0
-    assert t.context == {}
+    assert t.context is None
     assert t.outcome == {}
     assert t.parent_task_id is None
 
@@ -40,7 +40,7 @@ def test_thought_minimal():
     )
     assert th.status == fs.ThoughtStatus.PENDING
     assert th.thought_type == "standard"
-    assert th.context == {}
+    assert th.context is None
     assert th.ponder_count == 0
     assert th.ponder_notes is None
     assert th.parent_thought_id is None


### PR DESCRIPTION
## Summary
- ensure current_task_details is always a TaskSummary in ContextBuilder
- support dict contexts when resolving channel IDs
- test new TaskSummary logic
- adapt schema tests for new `None` context defaults
- handle PonderParams objects in action selection tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f836254e4832b9f13bd3174a1312c