### PR TITLE
Improve DMA context handling

### DIFF
--- a/tests/ciris_engine/dma/test_dma_executor.py
+++ b/tests/ciris_engine/dma/test_dma_executor.py
@@ -9,6 +9,7 @@ from ciris_engine.dma.dma_executor import (
     run_action_selection_pdma,
     DMAFailure,
 )
+from ciris_engine.processor.processing_queue import ProcessingQueueItem
 
 @pytest.mark.asyncio
 async def test_run_dma_with_retries_success():
@@ -36,20 +37,60 @@ async def test_run_dma_with_retries_timeout():
 async def test_run_pdma():
     evaluator = MagicMock()
     evaluator.evaluate = AsyncMock(return_value="ok")
-    from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+    from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ThoughtStatus
+    from ciris_engine.schemas.context_schemas_v1 import ThoughtContext, SystemSnapshot
+    ctx = ThoughtContext(system_snapshot=SystemSnapshot())
     item = Thought(
         thought_id="t1",
         source_task_id="task1",
         thought_type="test",
-        status="pending",
+        status=ThoughtStatus.PENDING,
         created_at="now",
         updated_at="now",
         round_number=1,
         content="c",
-        context={},
+        context=ctx,
     )
     result = await run_pdma(evaluator, item)
     assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_run_pdma_queue_item_context_fallback():
+    evaluator = MagicMock()
+    evaluator.evaluate = AsyncMock(return_value="ok")
+    from ciris_engine.schemas.agent_core_schemas_v1 import Thought, ThoughtStatus
+    from ciris_engine.schemas.context_schemas_v1 import ThoughtContext, SystemSnapshot
+    ctx = ThoughtContext(system_snapshot=SystemSnapshot())
+    thought = Thought(
+        thought_id="t2",
+        source_task_id="task2",
+        thought_type="test",
+        status=ThoughtStatus.PENDING,
+        created_at="now",
+        updated_at="now",
+        round_number=1,
+        content="c",
+        context=None,
+    )
+    item = ProcessingQueueItem.from_thought(thought, initial_ctx=ctx.model_dump())
+    result = await run_pdma(evaluator, item)
+    evaluator.evaluate.assert_awaited_with(item, context=ctx)
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_run_pdma_invalid_context_raises():
+    evaluator = MagicMock()
+    evaluator.evaluate = AsyncMock(return_value="ok")
+    item = ProcessingQueueItem(
+        thought_id="t3",
+        source_task_id="task3",
+        thought_type="test",
+        content="c",
+    )
+    with pytest.raises(DMAFailure):
+        await run_pdma(evaluator, item)
 
 @pytest.mark.asyncio
 async def test_run_csdma():


### PR DESCRIPTION
## Summary
- fix `run_pdma` to validate context and handle `ProcessingQueueItem`
- extend DMA executor tests for new context logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f911a7bdc832baf4c0ff494ee91de