### PR TITLE
Refactor context types

### DIFF
--- a/ciris_engine/action_handlers/base_handler.py
+++ b/ciris_engine/action_handlers/base_handler.py
@@ -172,7 +172,7 @@ class BaseActionHandler(ABC):
         """Get channel ID from dispatch or thought context."""
         channel_id = dispatch_context.get("channel_id")
         if not channel_id and getattr(thought, "context", None):
-            channel_id = thought.context.get("channel_id")
+            channel_id = getattr(thought.context.system_snapshot, "channel_id", None)
         if not channel_id:
             # No fallback needed since observer functionality is at adapter level
             pass

--- a/ciris_engine/action_handlers/forget_handler.py
+++ b/ciris_engine/action_handlers/forget_handler.py
@@ -33,10 +33,8 @@ class ForgetHandler(BaseActionHandler):
                     "is_follow_up": True,
                     "error": str(e)
                 }
-                if isinstance(follow_up.context, dict):
-                    follow_up.context.update(ctx)
-                else:
-                    follow_up.context = ctx
+                for k, v in ctx.items():
+                    setattr(follow_up.context, k, v)
                 self.dependencies.persistence.add_thought(follow_up)
                 await self._audit_log(HandlerActionType.FORGET, {**dispatch_context, "thought_id": thought_id}, outcome="failed")
                 return
@@ -52,10 +50,8 @@ class ForgetHandler(BaseActionHandler):
                 "is_follow_up": True,
                 "error": f"Invalid params type: {type(raw_params)}"
             }
-            if isinstance(follow_up.context, dict):
-                follow_up.context.update(ctx)
-            else:
-                follow_up.context = ctx
+            for k, v in ctx.items():
+                setattr(follow_up.context, k, v)
             self.dependencies.persistence.add_thought(follow_up)
             await self._audit_log(HandlerActionType.FORGET, {**dispatch_context, "thought_id": thought_id}, outcome="failed")
             return
@@ -71,10 +67,8 @@ class ForgetHandler(BaseActionHandler):
                 "is_follow_up": True,
                 "error": "Permission denied or WA required"
             }
-            if isinstance(follow_up.context, dict):
-                follow_up.context.update(ctx)
-            else:
-                follow_up.context = ctx
+            for k, v in ctx.items():
+                setattr(follow_up.context, k, v)
             self.dependencies.persistence.add_thought(follow_up)
             return
         memory_service: Optional[MemoryService] = await self.get_memory_service()
@@ -106,10 +100,8 @@ class ForgetHandler(BaseActionHandler):
                 "is_follow_up": True,
                 "error": "wa_denied",
             }
-            if isinstance(follow_up.context, dict):
-                follow_up.context.update(ctx)
-            else:
-                follow_up.context = ctx
+            for k, v in ctx.items():
+                setattr(follow_up.context, k, v)
             self.dependencies.persistence.add_thought(follow_up)
             await self._audit_log(
                 HandlerActionType.FORGET,
@@ -149,10 +141,8 @@ class ForgetHandler(BaseActionHandler):
             "forget_scope": node.scope.value,
             "forget_status": str(getattr(forget_result, "status", forget_result))
         }
-        if isinstance(follow_up.context, dict):
-            follow_up.context.update(ctx_final)
-        else:
-            follow_up.context = ctx_final
+        for k, v in ctx_final.items():
+            setattr(follow_up.context, k, v)
         self.dependencies.persistence.add_thought(follow_up)
         await self._audit_log(
             HandlerActionType.FORGET,

--- a/ciris_engine/action_handlers/memorize_handler.py
+++ b/ciris_engine/action_handlers/memorize_handler.py
@@ -142,13 +142,10 @@ class MemorizeHandler(BaseActionHandler):
             if final_thought_status != ThoughtStatus.COMPLETED:
                 context_for_follow_up["error_details"] = follow_up_content_key_info
 
-            # Pass action parameters directly - persistence will handle serialization
             context_for_follow_up["action_params"] = result.action_parameters
 
-            if isinstance(new_follow_up.context, dict):
-                new_follow_up.context.update(context_for_follow_up)  # v1 uses 'context'
-            else:
-                new_follow_up.context = context_for_follow_up
+            for k, v in context_for_follow_up.items():
+                setattr(new_follow_up.context, k, v)
             persistence.add_thought(new_follow_up)
             self.logger.info(
                 f"Created follow-up thought {new_follow_up.thought_id} for original thought {thought_id} after MEMORIZE action."

--- a/ciris_engine/action_handlers/ponder_handler.py
+++ b/ciris_engine/action_handlers/ponder_handler.py
@@ -165,10 +165,8 @@ class PonderHandler(BaseActionHandler):
                 "is_follow_up": True,
                 "ponder_notes": questions_list,
             }
-            if isinstance(follow_up.context, dict):
-                follow_up.context.update(ctx)
-            else:
-                follow_up.context = ctx
+            for k, v in ctx.items():
+                setattr(follow_up.context, k, v)
             persistence.add_thought(follow_up)
             # Note: The thought is already set to PENDING status, so it will be automatically
             # picked up in the next processing round when the queue is populated from the database
@@ -209,9 +207,7 @@ class PonderHandler(BaseActionHandler):
                 "ponder_notes": questions_list,
                 "error": "Failed to update for re-processing"
             }
-            if isinstance(follow_up.context, dict):
-                follow_up.context.update(ctx2)
-            else:
-                follow_up.context = ctx2
+            for k, v in ctx2.items():
+                setattr(follow_up.context, k, v)
             persistence.add_thought(follow_up)
             return None

--- a/ciris_engine/action_handlers/recall_handler.py
+++ b/ciris_engine/action_handlers/recall_handler.py
@@ -69,17 +69,17 @@ class RecallHandler(BaseActionHandler):
             parent=thought,
             content=follow_up_content,
         )
-        # Always set action_performed and is_follow_up in context
-        follow_up_context = follow_up.context if isinstance(follow_up.context, dict) else {}
-        follow_up_context["action_performed"] = HandlerActionType.RECALL.name
-        follow_up_context["is_follow_up"] = True
-        # Optionally add error or memory details if available
+        follow_up_context = {
+            "action_performed": HandlerActionType.RECALL.name,
+            "is_follow_up": True,
+        }
         if not success:
             if isinstance(memory_result, MemoryOpResult):
                 follow_up_context["error_details"] = str(memory_result.status)
             else:
                 follow_up_context["error_details"] = "recall_failed"
-        follow_up.context = follow_up_context
+        for k, v in follow_up_context.items():
+            setattr(follow_up.context, k, v)
         self.dependencies.persistence.add_thought(follow_up)
         await self._audit_log(
             HandlerActionType.RECALL,

--- a/ciris_engine/context/builder.py
+++ b/ciris_engine/context/builder.py
@@ -1,6 +1,6 @@
 from typing import Optional, Dict, Any
 from ciris_engine.schemas.agent_core_schemas_v1 import Thought, Task
-from ciris_engine.schemas.context_schemas_v1 import ThoughtContext, SystemSnapshot
+from ciris_engine.schemas.context_schemas_v1 import ThoughtContext, TaskContext, SystemSnapshot
 from ciris_engine.adapters.local_graph_memory import LocalGraphMemoryService
 from ciris_engine.schemas.graph_schemas_v1 import GraphScope, GraphNode, NodeType # Corrected import for GraphScope
 from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus  # Add TaskStatus import
@@ -69,8 +69,12 @@ class ContextBuilder:
             identity_context_str = channel_context_str
         # Extract initial_task_context from task if available
         initial_task_context = None
-        if task and hasattr(task, 'context') and isinstance(task.context, BaseModel):
-            initial_task_context = task.context
+        if task and hasattr(task, 'context'):
+            ctx = task.context
+            if isinstance(ctx, ThoughtContext):
+                initial_task_context = ctx.initial_task_context
+            elif isinstance(ctx, TaskContext):
+                initial_task_context = ctx
         
         # Create SystemSnapshot object from the data
         system_snapshot = system_snapshot_data

--- a/ciris_engine/persistence/utils.py
+++ b/ciris_engine/persistence/utils.py
@@ -1,5 +1,6 @@
 import json
 from ciris_engine.schemas.agent_core_schemas_v1 import Task, Thought
+from ciris_engine.schemas.context_schemas_v1 import ThoughtContext, SystemSnapshot
 from ciris_engine.schemas.foundational_schemas_v1 import TaskStatus, ThoughtStatus
 import logging
 
@@ -10,12 +11,17 @@ def map_row_to_task(row):
     # Map DB columns to Task fields as per v1 schema
     if row_dict.get("context_json"):
         try:
-            row_dict["context"] = json.loads(row_dict["context_json"])
+            ctx_data = json.loads(row_dict["context_json"])
+            if isinstance(ctx_data, dict):
+                ctx_data.setdefault("system_snapshot", {})
+                row_dict["context"] = ThoughtContext.model_validate(ctx_data)
+            else:
+                row_dict["context"] = ThoughtContext(system_snapshot=SystemSnapshot())
         except Exception:
             logger.warning(f"Failed to decode context_json for task {row_dict.get('task_id')}")
-            row_dict["context"] = {}
+            row_dict["context"] = ThoughtContext(system_snapshot=SystemSnapshot())
     else:
-        row_dict["context"] = {}
+        row_dict["context"] = ThoughtContext(system_snapshot=SystemSnapshot())
     if row_dict.get("outcome_json"):
         try:
             row_dict["outcome"] = json.loads(row_dict["outcome_json"])
@@ -42,12 +48,17 @@ def map_row_to_thought(row):
     # Map DB columns to Thought fields as per v1 schema
     if row_dict.get("context_json"):
         try:
-            row_dict["context"] = json.loads(row_dict["context_json"])
+            ctx_data = json.loads(row_dict["context_json"])
+            if isinstance(ctx_data, dict):
+                ctx_data.setdefault("system_snapshot", {})
+                row_dict["context"] = ThoughtContext.model_validate(ctx_data)
+            else:
+                row_dict["context"] = ThoughtContext(system_snapshot=SystemSnapshot())
         except Exception:
             logger.warning(f"Failed to decode context_json for thought {row_dict.get('thought_id')}")
-            row_dict["context"] = {}
+            row_dict["context"] = ThoughtContext(system_snapshot=SystemSnapshot())
     else:
-        row_dict["context"] = {}
+        row_dict["context"] = ThoughtContext(system_snapshot=SystemSnapshot())
     if row_dict.get("ponder_notes_json"):
         try:
             row_dict["ponder_notes"] = json.loads(row_dict["ponder_notes_json"])

--- a/ciris_engine/processor/processing_queue.py
+++ b/ciris_engine/processor/processing_queue.py
@@ -1,11 +1,14 @@
 import collections
 from pydantic import BaseModel, Field
-from typing import Union, List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional
+
+from ciris_engine.schemas.context_schemas_v1 import ThoughtContext
 import logging
 
 logger = logging.getLogger(__name__)
 
 from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.context_schemas_v1 import ThoughtContext
 
 
 class ThoughtContent(BaseModel):
@@ -21,19 +24,15 @@ class ProcessingQueueItem(BaseModel):
     thought_id: str
     source_task_id: str
     thought_type: str # Corresponds to Thought.thought_type (string)
-    content: Union[str, ThoughtContent, Dict[str, Any]]
+    content: ThoughtContent
     raw_input_string: Optional[str] = Field(default=None, description="The original input string that generated this thought, if applicable.")
-    initial_context: Optional[Dict[str, Any]] = Field(default_factory=dict, description="Initial context when the thought was first received/generated for processing.")
+    initial_context: Optional[Dict[str, Any] | ThoughtContext] = Field(default=None, description="Initial context when the thought was first received/generated for processing.")
     ponder_notes: Optional[List[str]] = Field(default=None, description="Key questions from a previous Ponder action if this item is being re-queued.")
 
     @property
     def content_text(self) -> str:
         """Return a best-effort text representation of the content."""
-        if isinstance(self.content, ThoughtContent):
-            return self.content.text
-        if isinstance(self.content, dict):
-            return self.content.get("text") or self.content.get("description", "")
-        return str(self.content)
+        return self.content.text
 
     @classmethod
     def from_thought(
@@ -41,7 +40,7 @@ class ProcessingQueueItem(BaseModel):
         thought_instance: Thought,
         raw_input: Optional[str] = None,
         initial_ctx: Optional[Dict[str, Any]] = None,
-        queue_item_content: Optional[Union[str, ThoughtContent, Dict[str, Any]]] = None
+        queue_item_content: Optional[ThoughtContent | str | Dict[str, Any]] = None
     ) -> "ProcessingQueueItem":
         """
         Creates a ProcessingQueueItem from a Thought instance.
@@ -51,16 +50,24 @@ class ProcessingQueueItem(BaseModel):
         if hasattr(raw_initial_ctx, 'model_dump') or isinstance(raw_initial_ctx, dict):
             final_initial_ctx = raw_initial_ctx
         else:
-            final_initial_ctx = {} # Default to empty dict if unexpected type
+            final_initial_ctx = None
 
-        resolved_content = queue_item_content if queue_item_content is not None else thought_instance.content
+        raw_content = queue_item_content if queue_item_content is not None else thought_instance.content
+        if isinstance(raw_content, ThoughtContent):
+            resolved_content = raw_content
+        elif isinstance(raw_content, str):
+            resolved_content = ThoughtContent(text=raw_content)
+        elif isinstance(raw_content, dict):
+            resolved_content = ThoughtContent(**raw_content)
+        else:
+            resolved_content = ThoughtContent(text=str(raw_content))
         return cls(
             thought_id=thought_instance.thought_id,
             source_task_id=thought_instance.source_task_id,
             thought_type=thought_instance.thought_type,
             content=resolved_content,
             raw_input_string=raw_input if raw_input is not None else str(thought_instance.content),
-            initial_context=final_initial_ctx if final_initial_ctx is not None else {},
+            initial_context=final_initial_ctx,
             ponder_notes=thought_instance.ponder_notes
         )
 

--- a/ciris_engine/schemas/agent_core_schemas_v1.py
+++ b/ciris_engine/schemas/agent_core_schemas_v1.py
@@ -15,6 +15,7 @@ from .action_params_v1 import (
     ForgetParams,
 )
 from .dma_results_v1 import ActionSelectionResult
+from .context_schemas_v1 import ThoughtContext
 
 class Task(BaseModel):
     """Core task object - minimal v1"""
@@ -25,7 +26,7 @@ class Task(BaseModel):
     created_at: str  # ISO8601
     updated_at: str  # ISO8601
     parent_task_id: Optional[str] = None
-    context: Optional[Any] = Field(default=None, description="Context object, can be a ThoughtContext or dict for legacy support.")
+    context: Optional[ThoughtContext] = Field(default=None, description="Context object")
     outcome: Dict[str, Any] = Field(default_factory=dict)
 
 class Thought(BaseModel):
@@ -38,7 +39,7 @@ class Thought(BaseModel):
     updated_at: str
     round_number: int = 0
     content: str
-    context: Optional[Any] = Field(default=None, description="Context object, can be a ThoughtContext or dict for legacy support.")
+    context: Optional[ThoughtContext] = Field(default=None, description="Context object")
     ponder_count: int = 0
     ponder_notes: Optional[List[str]] = None
     parent_thought_id: Optional[str] = None

--- a/ciris_engine/schemas/context_schemas_v1.py
+++ b/ciris_engine/schemas/context_schemas_v1.py
@@ -43,20 +43,28 @@ class TaskContext(BaseModel):
     author_id: Optional[str] = None
     channel_id: Optional[str] = None
     origin_service: Optional[str] = None
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
+
+    def __contains__(self, key: str) -> bool:
+        return hasattr(self, key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return getattr(self, key, default)
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
 
 class ThoughtContext(BaseModel):
-    system_snapshot: SystemSnapshot
+    system_snapshot: SystemSnapshot = Field(default_factory=SystemSnapshot)
     user_profiles: Dict[str, UserProfile] = Field(default_factory=dict)
     task_history: List[TaskSummary] = Field(default_factory=list)
     identity_context: Optional[str] = None
     initial_task_context: Optional[TaskContext] = None
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
 
     def get(self, key: str, default: Any = None) -> Any:
         """Dictionary-style access for backward compatibility."""
-        if hasattr(self, key):
-            return getattr(self, key)
-        return default
+        return getattr(self, key, default)
 
     def __getitem__(self, key: str) -> Any:
         return getattr(self, key)

--- a/ciris_engine/schemas/dma_results_v1.py
+++ b/ciris_engine/schemas/dma_results_v1.py
@@ -47,7 +47,6 @@ class ActionSelectionResult(BaseModel):
         RecallParams,
         ForgetParams,
         Dict[str, Any],
-        Any,
     ]:
         """Return action_parameters cast to the appropriate params model."""
         if isinstance(self.action_parameters, BaseModel):

--- a/tests/ciris_engine/dma/test_csdma.py
+++ b/tests/ciris_engine/dma/test_csdma.py
@@ -24,11 +24,12 @@ async def test_csdma_evaluate_thought(monkeypatch):
     mock_result = CSDMAResult(plausibility_score=0.8, flags=["f1"], reasoning="r")
     monkeypatch.setattr("instructor.patch", lambda c, mode: c)
     dummy_client.client.chat.completions.create = AsyncMock(return_value=mock_result)
+    from ciris_engine.processor.processing_queue import ThoughtContent
     item = ProcessingQueueItem(
         thought_id="t1",
         source_task_id="s1",
         thought_type="test",
-        content="test",
+        content=ThoughtContent(text="test"),
     )
     result = await evaluator.evaluate_thought(item)
     assert isinstance(result, CSDMAResult)

--- a/tests/ciris_engine/dma/test_dma_executor.py
+++ b/tests/ciris_engine/dma/test_dma_executor.py
@@ -83,11 +83,12 @@ async def test_run_pdma_queue_item_context_fallback():
 async def test_run_pdma_invalid_context_raises():
     evaluator = MagicMock()
     evaluator.evaluate = AsyncMock(return_value="ok")
+    from ciris_engine.processor.processing_queue import ThoughtContent
     item = ProcessingQueueItem(
         thought_id="t3",
         source_task_id="task3",
         thought_type="test",
-        content="c",
+        content=ThoughtContent(text="c"),
     )
     with pytest.raises(DMAFailure):
         await run_pdma(evaluator, item)

--- a/tests/ciris_engine/dma/test_pdma.py
+++ b/tests/ciris_engine/dma/test_pdma.py
@@ -21,11 +21,12 @@ async def test_pdma_init_and_evaluate(monkeypatch):
     )
     dummy_client.instruct_client.chat.completions.create = AsyncMock(return_value=mock_result)
     dummy_client.instruct_client.chat.completions.create = AsyncMock(return_value=mock_result)
+    from ciris_engine.processor.processing_queue import ThoughtContent
     item = ProcessingQueueItem(
         thought_id="t1",
         source_task_id="s1",
         thought_type="test",
-        content="test",
+        content=ThoughtContent(text="test"),
     )
     from ciris_engine.schemas.context_schemas_v1 import ThoughtContext, SystemSnapshot
     ctx = ThoughtContext(system_snapshot=SystemSnapshot(system_counts={}))

--- a/tests/ciris_engine/processor/test_base_processor.py
+++ b/tests/ciris_engine/processor/test_base_processor.py
@@ -66,11 +66,12 @@ async def test_process_thought_item_updates_metrics():
     tp = AsyncMock()
     proc = DummyProcessor(AppConfig(), tp, ad, {})
 
+    from ciris_engine.processor.processing_queue import ThoughtContent
     item = ProcessingQueueItem(
         thought_id="th1",
         source_task_id="t1",
         thought_type="test",
-        content="hello",
+        content=ThoughtContent(text="hello"),
     )
 
     tp.process_thought = AsyncMock(return_value="r")
@@ -87,11 +88,12 @@ async def test_process_thought_item_error(monkeypatch):
     tp.process_thought = AsyncMock(side_effect=Exception("err"))
     proc = DummyProcessor(AppConfig(), tp, ad, {})
 
+    from ciris_engine.processor.processing_queue import ThoughtContent
     item = ProcessingQueueItem(
         thought_id="th1",
         source_task_id="t1",
         thought_type="test",
-        content="hello",
+        content=ThoughtContent(text="hello"),
     )
 
     with pytest.raises(Exception):
@@ -115,11 +117,12 @@ async def test_process_thought_item_dma_failure_fallback(monkeypatch):
     # Simulate DMA failure
     tp.process_thought = AsyncMock(side_effect=DMAFailure("dma fail"))
 
+    from ciris_engine.processor.processing_queue import ThoughtContent
     item = ProcessingQueueItem(
         thought_id="th1",
         source_task_id="t1",
         thought_type="test",
-        content="hello",
+        content=ThoughtContent(text="hello"),
     )
 
     # Should call force_ponder and return its result

--- a/tests/ciris_engine/processor/test_processing_queue.py
+++ b/tests/ciris_engine/processor/test_processing_queue.py
@@ -33,7 +33,7 @@ def test_from_thought_with_overrides():
     assert item.thought_id == t.thought_id
     assert item.raw_input_string == "raw"
     assert item.initial_context == {"x": 1}
-    assert item.content == "override"
+    assert item.content.text == "override"
     assert item.ponder_notes is None
 
 
@@ -42,4 +42,4 @@ def test_from_thought_defaults():
     item = ProcessingQueueItem.from_thought(t)
     assert item.raw_input_string == str(t.content)
     assert item.initial_context == t.context
-    assert item.content == t.content
+    assert item.content.text == t.content


### PR DESCRIPTION
## Summary
- enforce `ThoughtContext` for Task and Thought schemas
- add dictionary-like helpers to `TaskContext`
- introduce typed `ThoughtContent` and update `ProcessingQueueItem`
- update helpers and handlers to work with typed context
- adjust context builder for `ThoughtContext`
- revise tests for new types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd3a4ce90832bb9e1fbb1c3de5474