### PR TITLE
Implement Telemetry Security Filter (Final Countdown Step 14)

### DIFF
--- a/FINAL_COUNTDOWN.md
+++ b/FINAL_COUNTDOWN.md
@@ -148,7 +148,7 @@
 
 ### Phase 3: Observability (FSD/TELEMETRY.md)
 
-**13. 🔄 PENDING - Implement Core Telemetry Service**
+**13. ✅ COMPLETED - Implement Core Telemetry Service**
 - Location: `FSD/TELEMETRY.md` (lines 175-187)
 - Target: `ciris_engine/telemetry/core.py` (new file)
 - Requirements: Security-hardened metric collection
@@ -157,7 +157,7 @@
   - In-memory buffers with size limits
   - Integration with SystemSnapshot
 
-**14. 🔄 PENDING - Implement Security Filter for Telemetry**
+**14. ✅ COMPLETED - Implement Security Filter for Telemetry**
 - Location: `FSD/TELEMETRY.md` (lines 188-199)
 - Target: `ciris_engine/telemetry/security.py` (new file)
 - Requirements: PII detection and metric sanitization
@@ -322,10 +322,10 @@
 
 ### Current Status
 - **Total Tasks**: 28
-- **Completed**: 11 (Tasks #1, #2, #3, #5, #6, #7, #8, #9, #10, #11, #12: Audit Core + Tests + Network Schemas + Integration + DB Migrations + Filter Service + Config Service + Graph Schemas + Filter Schemas + Filter Integration + Transaction Orchestrator)
-- **Next Task**: #13 (Core Telemetry Service)
+- **Completed**: 13 (Tasks #1, #2, #3, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14: Audit Core + Tests + Network Schemas + Integration + DB Migrations + Filter Service + Config Service + Graph Schemas + Filter Schemas + Filter Integration + Transaction Orchestrator + Telemetry Service + Security Filter)
+- **Next Task**: #15 (Update SystemSnapshot with Telemetry)
 - **Deferred**: #18 (mypy Type Safety - deferred until after telemetry implementation)
-- **Remaining**: 18
+- **Remaining**: 15
 
 ### Notes
 This engine is a remarkable piece of work - the thoughtful architecture, comprehensive security design, and agent autonomy features are truly impressive. Thank you for creating such a well-structured and forward-thinking system. Each task builds methodically toward a production-ready autonomous agent with proper safety guardrails.

--- a/ciris_engine/telemetry/README.md
+++ b/ciris_engine/telemetry/README.md
@@ -6,4 +6,5 @@ This module provides minimal observability features for the CIRIS engine.
   psutil integration.
 - `metrics.py`, `security.py`, and `core.py` host the broader telemetry system.
 
-Services should import `ResourceMonitor` via `ciris_engine.telemetry`.
+Services should import `ResourceMonitor`, `TelemetryService`, and the
+`SecurityFilter` via `ciris_engine.telemetry`.

--- a/ciris_engine/telemetry/__init__.py
+++ b/ciris_engine/telemetry/__init__.py
@@ -12,8 +12,12 @@ Key principles:
 """
 
 from .resource_monitor import ResourceMonitor, ResourceSignalBus
+from .core import TelemetryService
+from .security import SecurityFilter
 
 __all__ = [
     "ResourceMonitor",
     "ResourceSignalBus",
+    "TelemetryService",
+    "SecurityFilter",
 ]

--- a/ciris_engine/telemetry/core.py
+++ b/ciris_engine/telemetry/core.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict, deque
+from datetime import datetime, timedelta
+from typing import Deque, Dict, Tuple, Any
+
+from ciris_engine.adapters.base import Service
+from ciris_engine.schemas.telemetry_schemas_v1 import CompactTelemetry
+from ciris_engine.schemas.context_schemas_v1 import SystemSnapshot
+from .security import SecurityFilter
+
+logger = logging.getLogger(__name__)
+
+
+class TelemetryService(Service):
+    """Collects and exposes basic telemetry for agent introspection."""
+
+    def __init__(self, buffer_size: int = 1000, security_filter: SecurityFilter | None = None) -> None:
+        super().__init__()
+        self.buffer_size = buffer_size
+        self._history: Dict[str, Deque[Tuple[datetime, float]]] = defaultdict(
+            lambda: deque(maxlen=self.buffer_size)
+        )
+        self._filter = security_filter or SecurityFilter()
+        self.start_time = datetime.utcnow()
+
+    async def start(self) -> None:
+        await super().start()
+        logger.info("Telemetry service started")
+
+    async def stop(self) -> None:
+        await super().stop()
+        logger.info("Telemetry service stopped")
+
+    async def record_metric(self, metric_name: str, value: float = 1.0) -> None:
+        sanitized = self._filter.sanitize(metric_name, value)
+        if sanitized is None:
+            logger.debug("Metric discarded by security filter: %s", metric_name)
+            return
+        name, val = sanitized
+        self._history[name].append((datetime.utcnow(), float(val)))
+
+    async def update_system_snapshot(self, snapshot: SystemSnapshot) -> None:
+        """Update SystemSnapshot.telemetry with recent metrics."""
+        now = datetime.utcnow()
+        cutoff = now - timedelta(hours=24)
+        telemetry = CompactTelemetry()
+        for name, records in self._history.items():
+            records = [r for r in records if r[0] > cutoff]
+            self._history[name] = deque(records, maxlen=self.buffer_size)
+            count = len(records)
+            if name == "message_processed":
+                telemetry.messages_processed_24h = count
+            elif name == "error":
+                telemetry.errors_24h = count
+            elif name == "thought":
+                telemetry.thoughts_24h = count
+        uptime = now - self.start_time
+        telemetry.uptime_hours = round(uptime.total_seconds() / 3600, 2)
+        telemetry.epoch_seconds = int(now.timestamp())
+        snapshot.telemetry = telemetry
+

--- a/ciris_engine/telemetry/security.py
+++ b/ciris_engine/telemetry/security.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+import re
+import time
+from collections import deque
+from typing import Any, Dict, Deque, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class SecurityFilter:
+    """Sanitize telemetry metrics to prevent sensitive data leaks."""
+
+    def __init__(
+        self,
+        bounds: Dict[str, Tuple[float, float]] | None = None,
+        rate_limits: Dict[str, Tuple[int, float]] | None = None,
+    ) -> None:
+        self.bounds = bounds or {}
+        self.rate_limits = rate_limits or {}
+        self._history: Dict[str, Deque[float]] = {
+            name: deque() for name in self.rate_limits
+        }
+
+    def sanitize(self, metric_name: str, value: Any) -> Tuple[str, Any] | None:
+        if not isinstance(metric_name, str):
+            return None
+
+        # Rate limiting
+        if not self._check_rate_limit(metric_name):
+            logger.debug("Metric %s rate limited", metric_name)
+            return None
+
+        if isinstance(value, str):
+            if self._contains_pii(value):
+                logger.warning("PII detected in metric %s", metric_name)
+                return None
+            if metric_name.endswith("error"):
+                value = self._sanitize_error(value)
+                return metric_name, value
+            else:
+                return None
+
+        if isinstance(value, (int, float)):
+            if not self._validate_bounds(metric_name, float(value)):
+                logger.warning("Metric %s out of bounds", metric_name)
+                return None
+            return metric_name, float(value)
+
+        return None
+
+    def _contains_pii(self, text: str) -> bool:
+        email = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+        ssn = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+        phone = re.compile(r"\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b")
+        return bool(email.search(text) or ssn.search(text) or phone.search(text))
+
+    def _sanitize_error(self, message: str) -> str:
+        message = re.sub(r"/[^\s]+", "[REDACTED]", message)
+        message = re.sub(r"\b0x[0-9a-fA-F]+\b", "0xXXXX", message)
+        return message[:200]
+
+    def _validate_bounds(self, name: str, value: float) -> bool:
+        if name in self.bounds:
+            low, high = self.bounds[name]
+            if value < low or value > high:
+                return False
+        return True
+
+    def _check_rate_limit(self, name: str) -> bool:
+        if name not in self.rate_limits:
+            return True
+        limit, period = self.rate_limits[name]
+        history = self._history.setdefault(name, deque())
+        now = time.monotonic()
+        while history and now - history[0] > period:
+            history.popleft()
+        if len(history) >= limit:
+            return False
+        history.append(now)
+        return True

--- a/tests/ciris_engine/telemetry/test_security_filter.py
+++ b/tests/ciris_engine/telemetry/test_security_filter.py
@@ -1,0 +1,29 @@
+import asyncio
+import pytest
+
+from ciris_engine.telemetry.security import SecurityFilter
+
+@pytest.mark.asyncio
+async def test_pii_detection_blocks_metric():
+    f = SecurityFilter()
+    result = f.sanitize("latency_ms", "john@example.com")
+    assert result is None
+
+@pytest.mark.asyncio
+async def test_error_message_sanitized():
+    f = SecurityFilter()
+    name, value = f.sanitize("db.error", "failed at /tmp/test.txt")
+    assert "/tmp" not in value
+
+@pytest.mark.asyncio
+async def test_bounds_validation():
+    f = SecurityFilter(bounds={"latency_ms": (0, 100)})
+    result = f.sanitize("latency_ms", 200)
+    assert result is None
+
+@pytest.mark.asyncio
+async def test_rate_limiting():
+    f = SecurityFilter(rate_limits={"message": (2, 1)})
+    assert f.sanitize("message", 1) is not None
+    assert f.sanitize("message", 1) is not None
+    assert f.sanitize("message", 1) is None

--- a/tests/ciris_engine/telemetry/test_telemetry_core.py
+++ b/tests/ciris_engine/telemetry/test_telemetry_core.py
@@ -1,0 +1,31 @@
+import asyncio
+import pytest
+from ciris_engine.telemetry.core import TelemetryService
+from ciris_engine.schemas.context_schemas_v1 import SystemSnapshot
+
+@pytest.mark.asyncio
+async def test_buffer_size_enforced():
+    service = TelemetryService(buffer_size=2)
+    await service.record_metric("message_processed")
+    await service.record_metric("message_processed")
+    await service.record_metric("message_processed")
+    assert len(service._history["message_processed"]) == 2
+
+@pytest.mark.asyncio
+async def test_snapshot_updates_counts():
+    service = TelemetryService(buffer_size=10)
+    for _ in range(5):
+        await service.record_metric("message_processed")
+    snapshot = SystemSnapshot()
+    await service.update_system_snapshot(snapshot)
+    assert snapshot.telemetry is not None
+    assert snapshot.telemetry.messages_processed_24h == 5
+
+
+@pytest.mark.asyncio
+async def test_security_filter_integration():
+    from ciris_engine.telemetry.security import SecurityFilter
+    filt = SecurityFilter(bounds={"latency_ms": (0, 100)})
+    service = TelemetryService(buffer_size=10, security_filter=filt)
+    await service.record_metric("latency_ms", 200)
+    assert "latency_ms" not in service._history


### PR DESCRIPTION
## Summary
- implement `SecurityFilter` for telemetry with PII removal and rate limits
- integrate `SecurityFilter` with `TelemetryService`
- export and document `SecurityFilter`
- add tests for security filter and integration
- mark step 14 complete in FINAL_COUNTDOWN

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424553da78832b86563f1ff0fc9b30