### PR TITLE
Fix timezone naive datetimes

### DIFF
--- a/ciris_engine/adapters/api/api_adapter.py
+++ b/ciris_engine/adapters/api/api_adapter.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List
 
 from ciris_engine.schemas.foundational_schemas_v1 import FetchedMessage
@@ -36,7 +36,7 @@ class APIAdapter(CommunicationService, WiseAuthorityService, ToolService, Memory
 
     async def send_message(self, channel_id: str, content: str) -> bool:
         response_id = str(uuid.uuid4())
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(timezone.utc).isoformat()
         
         response_data = {
             "channel_id": channel_id,
@@ -86,8 +86,8 @@ class APIAdapter(CommunicationService, WiseAuthorityService, ToolService, Memory
                 action_type="fetch_guidance",
                 request_data=context,
                 status=ServiceCorrelationStatus.COMPLETED,
-                created_at=datetime.utcnow().isoformat(),
-                updated_at=datetime.utcnow().isoformat(),
+                created_at=datetime.now(timezone.utc).isoformat(),
+                updated_at=datetime.now(timezone.utc).isoformat(),
             )
         )
         return None
@@ -97,7 +97,7 @@ class APIAdapter(CommunicationService, WiseAuthorityService, ToolService, Memory
             "type": "deferral",
             "thought_id": thought_id,
             "reason": reason,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         if context:
             deferral_data["context"] = context

--- a/ciris_engine/adapters/cli/cli_tools.py
+++ b/ciris_engine/adapters/cli/cli_tools.py
@@ -1,7 +1,7 @@
 import os
 import asyncio
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 
 from ciris_engine.schemas.correlation_schemas_v1 import (
@@ -34,8 +34,8 @@ class CLIToolService(ToolService):
             action_type=tool_name,
             request_data=parameters,
             status=ServiceCorrelationStatus.PENDING,
-            created_at=datetime.utcnow().isoformat(),
-            updated_at=datetime.utcnow().isoformat(),
+            created_at=datetime.now(timezone.utc).isoformat(),
+            updated_at=datetime.now(timezone.utc).isoformat(),
         )
         persistence.add_correlation(corr)
 

--- a/ciris_engine/adapters/cli/cli_wa_service.py
+++ b/ciris_engine/adapters/cli/cli_wa_service.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List
 
 from ciris_engine.protocols.services import WiseAuthorityService
@@ -50,7 +50,7 @@ class CLIWiseAuthorityService(WiseAuthorityService):
         print("[CIRIS DEFERRAL REPORT]")
         print(f"Thought ID: {thought_id}")
         print(f"Reason: {reason}")
-        print(f"Timestamp: {datetime.utcnow().isoformat()}Z")
+        print(f"Timestamp: {datetime.now(timezone.utc).isoformat()}Z")
         
         if context:
             if "task_id" in context:
@@ -76,8 +76,8 @@ class CLIWiseAuthorityService(WiseAuthorityService):
             request_data={"thought_id": thought_id, "reason": reason, "context": context},
             response_data={"status": "logged"},
             status=ServiceCorrelationStatus.COMPLETED,
-            created_at=datetime.utcnow().isoformat(),
-            updated_at=datetime.utcnow().isoformat(),
+            created_at=datetime.now(timezone.utc).isoformat(),
+            updated_at=datetime.now(timezone.utc).isoformat(),
         )
         persistence.add_correlation(corr)
         return True

--- a/ciris_engine/adapters/discord/discord_adapter.py
+++ b/ciris_engine/adapters/discord/discord_adapter.py
@@ -3,7 +3,7 @@ from discord.errors import Forbidden, NotFound, InvalidData, HTTPException, Conn
 import logging
 import asyncio
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, Awaitable, Optional, List, Dict, Any
 from ciris_engine.schemas.foundational_schemas_v1 import DiscordMessage, FetchedMessage
 from ciris_engine.protocols.services import CommunicationService, WiseAuthorityService, ToolService
@@ -65,8 +65,8 @@ class DiscordAdapter(Service, CommunicationService, WiseAuthorityService, ToolSe
                     request_data={"channel_id": channel_id, "content": content},
                     response_data={"sent": True},
                     status=ServiceCorrelationStatus.COMPLETED,
-                    created_at=datetime.utcnow().isoformat(),
-                    updated_at=datetime.utcnow().isoformat(),
+                    created_at=datetime.now(timezone.utc).isoformat(),
+                    updated_at=datetime.now(timezone.utc).isoformat(),
                 )
             )
             return True
@@ -139,8 +139,8 @@ class DiscordAdapter(Service, CommunicationService, WiseAuthorityService, ToolSe
                     request_data=context,
                     response_data=guidance,
                     status=ServiceCorrelationStatus.COMPLETED,
-                    created_at=datetime.utcnow().isoformat(),
-                    updated_at=datetime.utcnow().isoformat(),
+                    created_at=datetime.now(timezone.utc).isoformat(),
+                    updated_at=datetime.now(timezone.utc).isoformat(),
                 )
             )
             return guidance
@@ -227,8 +227,8 @@ class DiscordAdapter(Service, CommunicationService, WiseAuthorityService, ToolSe
                     request_data={"thought_id": thought_id, "reason": reason},
                     response_data={"status": "sent"},
                     status=ServiceCorrelationStatus.COMPLETED,
-                    created_at=datetime.utcnow().isoformat(),
-                    updated_at=datetime.utcnow().isoformat(),
+                    created_at=datetime.now(timezone.utc).isoformat(),
+                    updated_at=datetime.now(timezone.utc).isoformat(),
                 )
             )
             return True
@@ -250,7 +250,7 @@ class DiscordAdapter(Service, CommunicationService, WiseAuthorityService, ToolSe
             "**[CIRIS Deferral Report]**",
             f"**Thought ID:** `{thought_id}`",
             f"**Reason:** {reason}",
-            f"**Timestamp:** {datetime.utcnow().isoformat()}Z"
+            f"**Timestamp:** {datetime.now(timezone.utc).isoformat()}Z"
         ]
         
         if context:
@@ -330,8 +330,8 @@ class DiscordAdapter(Service, CommunicationService, WiseAuthorityService, ToolSe
                 action_type=tool_name,
                 request_data=tool_args,
                 status=ServiceCorrelationStatus.PENDING,
-                created_at=datetime.utcnow().isoformat(),
-                updated_at=datetime.utcnow().isoformat(),
+                created_at=datetime.now(timezone.utc).isoformat(),
+                updated_at=datetime.now(timezone.utc).isoformat(),
             )
         )
         result = await handler({**tool_args, "bot": self.client})

--- a/ciris_engine/schemas/filter_schemas_v1.py
+++ b/ciris_engine/schemas/filter_schemas_v1.py
@@ -7,7 +7,7 @@ with graph memory persistence and self-configuration support.
 
 from pydantic import BaseModel, Field
 from typing import List, Dict, Optional, Any, Pattern
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 import re
 
@@ -47,7 +47,7 @@ class FilterTrigger(BaseModel):
     true_positive_count: int = 0
     false_positive_count: int = 0
     last_triggered: Optional[datetime] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     created_by: str = Field(default="system")
     
     # For learned patterns
@@ -108,7 +108,7 @@ class FilterResult(BaseModel):
 
 class AdaptiveFilterConfig(BaseModel):
     """Complete filter configuration stored in graph memory"""
-    config_id: str = Field(default_factory=lambda: f"filter_config_{datetime.utcnow().timestamp()}")
+    config_id: str = Field(default_factory=lambda: f"filter_config_{datetime.now(timezone.utc).timestamp()}")
     version: int = 1
     
     # Core attention triggers (agent always sees these)
@@ -147,7 +147,7 @@ class FilterStats(BaseModel):
     by_trigger_type: Dict[TriggerType, int] = Field(default_factory=dict)
     false_positive_reports: int = 0
     true_positive_confirmations: int = 0
-    last_reset: datetime = Field(default_factory=datetime.utcnow)
+    last_reset: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class FilterHealth(BaseModel):
@@ -157,4 +157,4 @@ class FilterHealth(BaseModel):
     errors: List[str] = Field(default_factory=list)
     stats: FilterStats = Field(default_factory=FilterStats)
     config_version: int = 1
-    last_updated: datetime = Field(default_factory=datetime.utcnow)
+    last_updated: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/ciris_engine/telemetry/collectors.py
+++ b/ciris_engine/telemetry/collectors.py
@@ -7,7 +7,7 @@ to balance observability with performance and security constraints.
 import asyncio
 import logging
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, Callable, List
 from dataclasses import dataclass
 
@@ -40,7 +40,7 @@ class BaseCollector(ABC):
         self._running = False
         self._task: Optional[asyncio.Task] = None
         self._metrics_collected = 0
-        self._last_collection = datetime.utcnow()
+        self._last_collection = datetime.now(timezone.utc)
         
     async def start(self) -> None:
         """Start the collector."""
@@ -101,7 +101,7 @@ class BaseCollector(ABC):
             if filtered_metrics:
                 await self.process_metrics(filtered_metrics)
                 self._metrics_collected += len(filtered_metrics)
-                self._last_collection = datetime.utcnow()
+                self._last_collection = datetime.now(timezone.utc)
                 
         except Exception as e:
             logger.error(f"Error collecting metrics in {self.__class__.__name__}: {e}")
@@ -145,7 +145,7 @@ class InstantCollector(BaseCollector):
     async def collect_raw_metrics(self) -> List[MetricData]:
         """Collect critical instant metrics."""
         metrics = []
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         
         # Circuit breaker states
         if self.circuit_breaker_registry:
@@ -188,7 +188,7 @@ class FastCollector(BaseCollector):
     async def collect_raw_metrics(self) -> List[MetricData]:
         """Collect fast metrics."""
         metrics = []
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         
         # Active thoughts count
         if self.thought_manager:
@@ -230,7 +230,7 @@ class NormalCollector(BaseCollector):
     async def collect_raw_metrics(self) -> List[MetricData]:
         """Collect normal interval metrics."""
         metrics = []
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         
         # Resource usage
         if self.resource_monitor:
@@ -282,7 +282,7 @@ class SlowCollector(BaseCollector):
     async def collect_raw_metrics(self) -> List[MetricData]:
         """Collect slow interval metrics."""
         metrics = []
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         
         # Memory service stats
         if self.memory_service:
@@ -329,7 +329,7 @@ class AggregateCollector(BaseCollector):
     async def collect_raw_metrics(self) -> List[MetricData]:
         """Collect aggregate metrics."""
         metrics = []
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         
         # System health rollups
         if self.telemetry_service:
@@ -362,7 +362,7 @@ class AggregateCollector(BaseCollector):
             # Audit aggregate metric collection
             await self.audit_service.log_action(
                 "telemetry_aggregation",
-                {"metrics_count": len(metrics), "timestamp": datetime.utcnow().isoformat()},
+                {"metrics_count": len(metrics), "timestamp": datetime.now(timezone.utc).isoformat()},
                 "success"
             )
             

--- a/ciris_engine/telemetry/core.py
+++ b/ciris_engine/telemetry/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import defaultdict, deque
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Deque, Dict, Tuple, Any
 
 from ciris_engine.adapters.base import Service
@@ -24,7 +24,7 @@ class TelemetryService(Service):
             lambda: deque(maxlen=self.buffer_size)
         )
         self._filter = security_filter or SecurityFilter()
-        self.start_time = datetime.utcnow()
+        self.start_time = datetime.now(timezone.utc)
 
     async def start(self) -> None:
         await super().start()
@@ -40,11 +40,11 @@ class TelemetryService(Service):
             logger.debug("Metric discarded by security filter: %s", metric_name)
             return
         name, val = sanitized
-        self._history[name].append((datetime.utcnow(), float(val)))
+        self._history[name].append((datetime.now(timezone.utc), float(val)))
 
     async def update_system_snapshot(self, snapshot: SystemSnapshot) -> None:
         """Update SystemSnapshot.telemetry with recent metrics."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         cutoff = now - timedelta(hours=24)
         telemetry = CompactTelemetry()
         for name, records in self._history.items():

--- a/tests/ciris_engine/action_handlers/test_defer_handler.py
+++ b/tests/ciris_engine/action_handlers/test_defer_handler.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
-from datetime import datetime
+from datetime import datetime, timezone
 
 from ciris_engine.action_handlers.defer_handler import DeferHandler
 from ciris_engine.schemas.action_params_v1 import DeferParams, MemorizeParams
@@ -10,7 +10,7 @@ from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, Thou
 from ciris_engine.action_handlers.base_handler import ActionHandlerDependencies
 from ciris_engine.schemas.graph_schemas_v1 import GraphNode, NodeType, GraphScope
 
-now = datetime.utcnow()
+now = datetime.now(timezone.utc)
 
 @pytest.mark.asyncio
 async def test_defer_handler_schema_driven(monkeypatch):

--- a/tests/ciris_engine/action_handlers/test_followup_helpers.py
+++ b/tests/ciris_engine/action_handlers/test_followup_helpers.py
@@ -1,12 +1,12 @@
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 from ciris_engine.action_handlers.helpers import create_follow_up_thought
 from ciris_engine.schemas.agent_core_schemas_v1 import Thought
 from ciris_engine.schemas.foundational_schemas_v1 import ThoughtStatus, ThoughtType
 
 
 def make_parent():
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     # Set channel_id and foo in context for propagation
     context = {"channel_id": "chan", "foo": "bar"}
     return Thought(


### PR DESCRIPTION
## Summary
- replace `datetime.utcnow()` usage with `datetime.now(timezone.utc)`
- update default factories to generate timezone-aware datetimes
- adjust tests accordingly

## Testing
- `pytest -q` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_6845bb9732e0832b85b64d3ce8aa0d33