### PR TITLE
Improve tests for guardrails and sinks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,3 +361,12 @@ When working through this task list:
 6. **Integration testing** - Ensure new features don't break existing functionality
 
 Remember: This is mission-critical software. Quality and security are more important than speed.
+
+## ADDITIONAL GUIDELINES
+
+- All implementation details can be found in the top-level `README.md` and each module's `README.md`. Refer to those documents for background, usage, and architectural notes.
+- The development environment has full internet access. Use online resources if needed.
+- When running or testing the system, **always** use the mock LLM service (`--mock-llm`). Extend the mock implementation when debugging issues rather than calling external APIs.
+- Every code change must be mission critical and completely typed. No legacy accommodation or backward compatibility should be introduced.
+- Guardrails and sinks currently have less than 40% test coverage. Prioritize tests to bring these modules to acceptable levels.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ python-multipart
 # Testing
 pytest
 pytest-asyncio
+pytest-cov
 click
 streamlit-shadcn-ui
 mypy

--- a/tests/ciris_engine/guardrails/test_orchestrator.py
+++ b/tests/ciris_engine/guardrails/test_orchestrator.py
@@ -1,0 +1,70 @@
+import pytest
+from ciris_engine.guardrails.orchestrator import GuardrailOrchestrator
+from ciris_engine.guardrails.registry import GuardrailRegistry
+from ciris_engine.schemas.guardrails_schemas_v1 import GuardrailCheckResult, GuardrailStatus
+from ciris_engine.schemas.processing_schemas_v1 import GuardrailResult
+from ciris_engine.schemas.agent_core_schemas_v1 import Thought
+from ciris_engine.schemas.action_params_v1 import SpeakParams, PonderParams
+from ciris_engine.schemas.dma_results_v1 import ActionSelectionResult
+from ciris_engine.schemas.foundational_schemas_v1 import HandlerActionType, ThoughtStatus, ThoughtType
+
+DEFAULT_THOUGHT_KWARGS = dict(
+    thought_id="t1",
+    source_task_id="task1",
+    thought_type=ThoughtType.STANDARD,
+    status=ThoughtStatus.PENDING,
+    created_at="now",
+    updated_at="now",
+    round_number=1,
+    content="content",
+    context={},
+    ponder_count=0,
+    ponder_notes=None,
+    parent_thought_id=None,
+    final_action={},
+)
+
+class PassingGuardrail:
+    async def check(self, action, context):
+        return GuardrailCheckResult(status=GuardrailStatus.PASSED, passed=True, check_timestamp="0")
+
+class FailingGuardrail:
+    async def check(self, action, context):
+        return GuardrailCheckResult(status=GuardrailStatus.FAILED, passed=False, reason="bad", check_timestamp="0")
+
+@pytest.mark.asyncio
+async def test_orchestrator_no_override_when_passes():
+    registry = GuardrailRegistry()
+    registry.register_guardrail("pass", PassingGuardrail())
+    orchestrator = GuardrailOrchestrator(registry)
+
+    action = ActionSelectionResult.model_construct(
+        selected_action=HandlerActionType.SPEAK,
+        action_parameters=SpeakParams(content="hi"),
+        rationale="r",
+    )
+    thought = Thought(**DEFAULT_THOUGHT_KWARGS)
+
+    result = await orchestrator.apply_guardrails(action, thought, {})
+    assert not result.overridden
+    assert result.final_action == action
+
+@pytest.mark.asyncio
+async def test_orchestrator_overrides_on_failure():
+    registry = GuardrailRegistry()
+    registry.register_guardrail("fail", FailingGuardrail())
+    orchestrator = GuardrailOrchestrator(registry)
+
+    action = ActionSelectionResult.model_construct(
+        selected_action=HandlerActionType.SPEAK,
+        action_parameters=SpeakParams(content="hi"),
+        rationale="r",
+    )
+    thought = Thought(**DEFAULT_THOUGHT_KWARGS)
+
+    result = await orchestrator.apply_guardrails(action, thought, {})
+    assert result.overridden
+    assert result.final_action.selected_action == HandlerActionType.PONDER
+    assert result.override_reason == "bad"
+    assert "fail" in result.epistemic_data
+

--- a/tests/ciris_engine/guardrails/test_registry.py
+++ b/tests/ciris_engine/guardrails/test_registry.py
@@ -1,0 +1,23 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from ciris_engine.guardrails.registry import GuardrailRegistry, GuardrailInterface
+
+class DummyGuardrail:
+    async def check(self, action, context):
+        return None
+
+def test_registry_orders_by_priority_and_enable():
+    registry = GuardrailRegistry()
+    g1 = DummyGuardrail()
+    g2 = DummyGuardrail()
+    registry.register_guardrail("g1", g1, priority=10)
+    registry.register_guardrail("g2", g2, priority=5)
+
+    names = [e.name for e in registry.get_guardrails()]
+    assert names == ["g2", "g1"]
+
+    registry.set_enabled("g2", False)
+    names_after = [e.name for e in registry.get_guardrails()]
+    assert names_after == ["g1"]
+

--- a/tests/ciris_engine/sinks/test_base_sink.py
+++ b/tests/ciris_engine/sinks/test_base_sink.py
@@ -1,0 +1,38 @@
+import pytest
+from unittest.mock import AsyncMock
+from ciris_engine.sinks.multi_service_sink import MultiServiceActionSink
+from ciris_engine.schemas.service_actions_v1 import (
+    ActionMessage,
+    ActionType,
+    SendMessageAction,
+    SendDeferralAction,
+)
+
+class DummySink(MultiServiceActionSink):
+    async def _get_service(self, service_type: str, action: ActionMessage):
+        return None
+
+@pytest.mark.asyncio
+async def test_enqueue_action_queue_full():
+    sink = DummySink(max_queue_size=1)
+    msg = ActionMessage(ActionType.SEND_MESSAGE, "handler", {})
+    assert await sink.enqueue_action(msg) is True
+    assert await sink.enqueue_action(msg) is False
+
+@pytest.mark.asyncio
+async def test_process_action_calls_fallback(monkeypatch):
+    sink = DummySink()
+    fallback = AsyncMock()
+    monkeypatch.setattr(sink, "_handle_fallback", fallback)
+    msg = SendMessageAction("h", {}, channel_id="c", content="hi")
+    await sink._process_action(msg)
+    fallback.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_validate_action_rules():
+    sink = DummySink()
+    msg = SendMessageAction("h", {}, channel_id="", content="")
+    assert await sink._validate_action(msg) is False
+    def_msg = SendDeferralAction("h", {}, thought_id="", reason="")
+    assert await sink._validate_action(def_msg) is False
+


### PR DESCRIPTION
## Summary
- add `pytest-cov` to requirements
- unit tests for guardrail registry and orchestrator
- basic tests for multi-service action sink queueing and validation

## Testing
- `pip install -r requirements.txt` *(fails: Could not find pytest-cov)*
- `pytest -q` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_6845c6623cd4832b96b0a75d15ba67d3